### PR TITLE
feat: add airtable utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Environment Files
+.env

--- a/libs/airtable/.babelrc
+++ b/libs/airtable/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/airtable/.eslintrc.json
+++ b/libs/airtable/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/airtable/README.md
+++ b/libs/airtable/README.md
@@ -1,0 +1,9 @@
+# airtable
+
+Utils for getting data from Protocol Labs Network's Airtable instance.
+
+## Running unit tests
+
+Run `nx test airtable` to execute the unit tests via [Jest](https://jestjs.io).
+
+_This library was generated with [Nx](https://nx.dev)._

--- a/libs/airtable/jest.config.js
+++ b/libs/airtable/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'airtable',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/airtable',
+};

--- a/libs/airtable/project.json
+++ b/libs/airtable/project.json
@@ -1,0 +1,23 @@
+{
+  "root": "libs/airtable",
+  "sourceRoot": "libs/airtable/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/airtable/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/airtable"],
+      "options": {
+        "jestConfig": "libs/airtable/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/airtable/src/index.ts
+++ b/libs/airtable/src/index.ts
@@ -1,0 +1,4 @@
+import airtableService from './lib/airtable';
+
+export default airtableService;
+export * from './models';

--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -1,0 +1,131 @@
+const teamMock = { id: 'team_01' } as IAirtableTeam;
+const teamsMock = [teamMock];
+const teamsTableMock: Airtable.Table<object> = {
+  select: jest.fn().mockReturnValue({
+    all: jest.fn().mockReturnValue(teamsMock),
+  }),
+  find: jest.fn().mockReturnValue(teamMock),
+};
+
+const labberMock = { id: 'labber_01' } as IAirtableLabber;
+const labbersMock = [labberMock];
+const labbersTableMock: Airtable.Table<object> = {
+  select: jest.fn().mockReturnValue({
+    all: jest.fn().mockReturnValue(labbersMock),
+  }),
+  find: jest.fn().mockReturnValue(labberMock),
+};
+
+const baseFunctionMock = jest.fn().mockImplementation((tableId: string) => {
+  return tableId === process.env.AIRTABLE_TEAMS_TABLE_ID
+    ? teamsTableMock
+    : labbersTableMock;
+});
+const baseMock = jest.fn().mockImplementation(() => baseFunctionMock);
+const airtableMock = jest.fn().mockImplementation(() => {
+  return {
+    base: baseMock,
+  };
+});
+
+jest.mock('airtable', () => {
+  return airtableMock;
+});
+
+import Airtable = require('airtable');
+import { IAirtableLabber, IAirtableTeam } from '../models';
+import airtableService from './airtable';
+
+describe('AirtableService', () => {
+  describe('when initialized', () => {
+    it('should create a new Airtable instance', () => {
+      expect(airtableMock).toHaveBeenCalledTimes(1);
+      expect(airtableMock).toHaveBeenCalledWith({
+        apiKey: process.env.AIRTABLE_API_KEY,
+      });
+    });
+
+    it('should get the Airtable base', () => {
+      expect(baseMock).toHaveBeenCalledTimes(1);
+      expect(baseMock).toHaveBeenCalledWith(process.env.AIRTABLE_BASE_ID);
+    });
+
+    it('should get the Airtable tables', () => {
+      expect(baseFunctionMock).toHaveBeenCalledTimes(2);
+      expect(baseFunctionMock).toHaveBeenCalledWith(
+        process.env.AIRTABLE_TEAMS_TABLE_ID
+      );
+      expect(baseFunctionMock).toHaveBeenCalledWith(
+        process.env.AIRTABLE_LABBERS_TABLE_ID
+      );
+    });
+  });
+
+  describe('#getAllTeams', () => {
+    let teams: IAirtableTeam[];
+
+    beforeEach(async () => {
+      teams = await airtableService.getAllTeams();
+    });
+
+    it('should select all teams from teams table', () => {
+      expect(teamsTableMock.select).toHaveBeenCalledTimes(1);
+      expect(teamsTableMock.select().all).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retrieve all teams', () => {
+      expect(teams).toEqual(teamsMock);
+    });
+  });
+
+  describe('#getTeam', () => {
+    let team: IAirtableTeam;
+
+    beforeEach(async () => {
+      team = await airtableService.getTeam(teamMock.id);
+    });
+
+    it('should find the team with the provided id on teams table', () => {
+      expect(teamsTableMock.find).toHaveBeenCalledTimes(1);
+      expect(teamsTableMock.find).toHaveBeenCalledWith(teamMock.id);
+    });
+
+    it('should retrieve the team with the provided id', () => {
+      expect(team).toEqual(teamMock);
+    });
+  });
+
+  describe('#getAllLabbers', () => {
+    let labbers: IAirtableLabber[];
+
+    beforeEach(async () => {
+      labbers = await airtableService.getAllLabbers();
+    });
+
+    it('should select all labbers from labbers table', () => {
+      expect(labbersTableMock.select).toHaveBeenCalledTimes(1);
+      expect(labbersTableMock.select().all).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retrieve all labbers', () => {
+      expect(labbers).toEqual(labbersMock);
+    });
+  });
+
+  describe('#getLabber', () => {
+    let labber: IAirtableLabber;
+
+    beforeEach(async () => {
+      labber = await airtableService.getLabber(labberMock.id);
+    });
+
+    it('should find the labber with the provided id on labbers table', () => {
+      expect(labbersTableMock.find).toHaveBeenCalledTimes(1);
+      expect(labbersTableMock.find).toHaveBeenCalledWith(labberMock.id);
+    });
+
+    it('should retrieve the labber with the provided id', () => {
+      expect(labber).toEqual(labberMock);
+    });
+  });
+});

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -1,0 +1,92 @@
+import * as Airtable from 'airtable';
+import { IAirtableLabber, IAirtableTeam } from '../models';
+
+/**
+ * Service to collect data from Airtable.
+ *
+ * @class AirtableService
+ */
+class AirtableService {
+  private static _instance: AirtableService;
+
+  private _teamsTable: Airtable.Table<Airtable.FieldSet>;
+  private _labbersTable: Airtable.Table<Airtable.FieldSet>;
+
+  constructor() {
+    if (!AirtableService._instance) {
+      this._init();
+      AirtableService._instance = this;
+    }
+
+    return AirtableService._instance;
+  }
+
+  /**
+   * Get all teams from Airtable.
+   *
+   * @return {*}  {Promise<IAirtableTeam[]>}
+   * @memberof AirtableService
+   */
+  public async getAllTeams(): Promise<IAirtableTeam[]> {
+    const teams = await this._teamsTable.select().all();
+
+    return JSON.parse(JSON.stringify(teams)) as IAirtableTeam[];
+  }
+
+  /**
+   * Get a specific team from Airtable.
+   *
+   * @param {string} id
+   * @return {*}  {Promise<IAirtableTeam>}
+   * @memberof AirtableService
+   */
+  public async getTeam(id: string): Promise<IAirtableTeam> {
+    const team = await this._teamsTable.find(id);
+
+    return JSON.parse(JSON.stringify(team)) as IAirtableTeam;
+  }
+
+  /**
+   * Get all labbers from Airtable.
+   *
+   * @return {*}  {Promise<IAirtableLabber[]>}
+   * @memberof AirtableService
+   */
+  public async getAllLabbers(): Promise<IAirtableLabber[]> {
+    const labbers = await this._labbersTable.select().all();
+
+    return JSON.parse(JSON.stringify(labbers)) as IAirtableLabber[];
+  }
+
+  /**
+   * Get a specific labber from Airtable.
+   *
+   * @param {string} id
+   * @return {*}  {Promise<IAirtableLabber>}
+   * @memberof AirtableService
+   */
+  public async getLabber(id: string): Promise<IAirtableLabber> {
+    const labber = await this._labbersTable.find(id);
+
+    return JSON.parse(JSON.stringify(labber)) as IAirtableLabber;
+  }
+
+  /**
+   * Service initialization.
+   *
+   * @private
+   * @memberof AirtableService
+   */
+  private _init() {
+    const base = new Airtable({
+      apiKey: `${process.env.AIRTABLE_API_KEY}`,
+    }).base(`${process.env.AIRTABLE_BASE_ID}`);
+
+    this._teamsTable = base(`${process.env.AIRTABLE_TEAMS_TABLE_ID}`);
+    this._labbersTable = base(`${process.env.AIRTABLE_LABBERS_TABLE_ID}`);
+  }
+}
+
+const airtableService = new AirtableService();
+Object.freeze(airtableService);
+export default airtableService;

--- a/libs/airtable/src/models/common.ts
+++ b/libs/airtable/src/models/common.ts
@@ -1,0 +1,5 @@
+export interface IAirtableImage {
+  url: string;
+  width: number;
+  height: number;
+}

--- a/libs/airtable/src/models/index.ts
+++ b/libs/airtable/src/models/index.ts
@@ -1,0 +1,3 @@
+export * from './common';
+export * from './labber';
+export * from './team';

--- a/libs/airtable/src/models/labber.ts
+++ b/libs/airtable/src/models/labber.ts
@@ -1,0 +1,42 @@
+import { IAirtableImage } from './common';
+
+export interface IAirtableLabber {
+  id: string;
+  fields: IAirtableLabberFields;
+}
+
+export interface IAirtableLabberFields {
+  Name: string;
+  'Display Name': string;
+  'PLN Start Date': Date;
+  'PLN End Date': Date;
+  'Profile picture': IAirtableLabberPicture[];
+  Skills: string[];
+  'Github Handle': string;
+  'Office hours link': string;
+  'Team lead': boolean;
+  Teams: string[];
+  Role: string;
+  Location: string;
+  Email: string;
+  Twitter: string;
+  'Discord Handle': string;
+  Notes: string;
+  'Date contacted': Date;
+  'Location (text)': string;
+  'Team Name': string;
+}
+
+export interface IAirtableLabberPicture {
+  id: string;
+  width: number;
+  height: number;
+  url: string;
+  filename: string;
+  size: number;
+  type: string;
+  thumbnails: {
+    small: IAirtableImage;
+    large: IAirtableImage;
+  };
+}

--- a/libs/airtable/src/models/team.ts
+++ b/libs/airtable/src/models/team.ts
@@ -1,0 +1,39 @@
+import { IAirtableImage } from './common';
+
+export interface IAirtableTeam {
+  id: string;
+  fields: IAirtableTeamFields;
+}
+
+export interface IAirtableTeamFields {
+  Name: string;
+  'Short description': string;
+  'Long description': string;
+  Website: string;
+  Twitter: string;
+  'Funding Vehicle': string[];
+  Labbers: string[];
+  Logo: IAirtableTeamLogo[];
+  Industry: string[];
+  'Last Audited': Date;
+  Notes: string;
+  'Last Modified': Date;
+  'Eligible for marketplace credits': boolean;
+  'Grants program': boolean;
+  Blog: string;
+}
+
+export interface IAirtableTeamLogo {
+  id: string;
+  width: number;
+  height: number;
+  url: string;
+  filename: string;
+  size: number;
+  type: string;
+  thumbnails: {
+    small: IAirtableImage;
+    large: IAirtableImage;
+    full: IAirtableImage;
+  };
+}

--- a/libs/airtable/tsconfig.json
+++ b/libs/airtable/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/libs/airtable/tsconfig.lib.json
+++ b/libs/airtable/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.spec.ts"]
+}

--- a/libs/airtable/tsconfig.spec.json
+++ b/libs/airtable/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@heroicons/react": "^1.0.6",
     "@nrwl/next": "13.9.7",
     "@sentry/nextjs": "^6.19.6",
+    "airtable": "^0.11.3",
     "autoprefixer": "^10.4.4",
     "core-js": "^3.6.5",
     "next": "12.1.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@protocol-labs-network/airtable": ["libs/airtable/src/index.ts"],
       "@protocol-labs-network/ui": ["libs/ui/src/index.ts"]
     }
   },

--- a/workspace.json
+++ b/workspace.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "projects": {
+    "airtable": "libs/airtable",
     "ui": "libs/ui",
     "web-app": "apps/web-app",
     "web-app-e2e": "apps/web-app-e2e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3913,6 +3913,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
   integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
 
+"@types/node@>=8.0.0 <15":
+  version "14.18.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.13.tgz#6ad4d9db59e6b3faf98dcfe4ca9d2aec84443277"
+  integrity sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==
+
 "@types/node@^14.0.10", "@types/node@^14.14.31":
   version "14.18.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.12.tgz#0d4557fd3b94497d793efd4e7d92df2f83b4ef24"
@@ -4619,6 +4624,18 @@ abab@^2.0.3, abab@^2.0.5:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
+abortcontroller-polyfill@^1.4.0:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz#1b5b487bd6436b5b764fd52a612509702c3144b5"
+  integrity sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -4716,6 +4733,17 @@ airbnb-js-shims@^2.2.1:
     string.prototype.padend "^3.0.0"
     string.prototype.padstart "^3.0.0"
     symbol.prototype.description "^1.0.0"
+
+airtable@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/airtable/-/airtable-0.11.3.tgz#bed8f81454ec46ce4ce39cb53dc2ef61030b546b"
+  integrity sha512-fPT0SdipmJU1eQNe+sJshvnb87HcZ2rPS7gJuryDAF9xDbfbxB8AmYQSuC1f0PIbLyPPpSWBuEewf4UJ9i3rJw==
+  dependencies:
+    "@types/node" ">=8.0.0 <15"
+    abort-controller "^3.0.0"
+    abortcontroller-polyfill "^1.4.0"
+    lodash "^4.17.21"
+    node-fetch "^2.6.7"
 
 ajv-errors@^1.0.0:
   version "1.0.1"
@@ -7831,6 +7859,11 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter2@^6.4.3:
   version "6.4.5"


### PR DESCRIPTION
## Description

Add Airtable library containing utilities for getting data from Protocol Labs Network instance.

**Developers will need to create a local `.env` file with their own API keys for Airtable.**

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-39
- https://pixelmatters.atlassian.net/browse/PL-36

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
