### PR TITLE
refactor: update team and labber parsers and interfaces

### DIFF
--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -25,7 +25,8 @@ const teamMock: IAirtableTeam = {
     'Friend of PLN': true,
   },
 };
-const teamsMock = [teamMock];
+const emptyTeamMock: IAirtableTeam = { id: 'team_id_02', fields: {} };
+const teamsMock = [teamMock, emptyTeamMock];
 const teamsTableMock: Airtable.Table<Record<string, string>> = {
   select: jest.fn().mockReturnValue({
     all: jest.fn().mockReturnValue(teamsMock),
@@ -73,7 +74,8 @@ const labberMock: IAirtableLabber = {
     'Friend of PLN': true,
   },
 };
-const labbersMock = [labberMock];
+const emptyLabberMock: IAirtableLabber = { id: 'labber_id_02', fields: {} };
+const labbersMock = [labberMock, emptyLabberMock];
 const labbersTableMock: Airtable.Table<Record<string, string>> = {
   select: jest.fn().mockReturnValue({
     all: jest.fn().mockReturnValue(labbersMock),
@@ -155,6 +157,21 @@ describe('AirtableService', () => {
           twitter: teamMock.fields.Twitter,
           website: teamMock.fields.Website,
         },
+        {
+          filecoinUser: false,
+          fundingStage: null,
+          fundingVehicle: [],
+          id: emptyTeamMock.id,
+          industry: [],
+          ipfsUser: false,
+          labbers: [],
+          logo: null,
+          longDescription: null,
+          name: null,
+          shortDescription: null,
+          twitter: null,
+          website: null,
+        },
       ]);
     });
   });
@@ -213,6 +230,16 @@ describe('AirtableService', () => {
           name: labberMock.fields.Name,
           role: labberMock.fields.Role,
           twitter: labberMock.fields.Twitter,
+        },
+        {
+          discordHandle: null,
+          displayName: null,
+          email: null,
+          id: emptyLabberMock.id,
+          image: null,
+          name: null,
+          role: null,
+          twitter: null,
         },
       ]);
     });

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -86,19 +86,19 @@ class AirtableService {
    */
   private _parseTeam(team: IAirtableTeam): ITeam {
     return {
-      filecoinUser: team.fields['Filecoin User'],
-      fundingStage: team.fields['Funding Stage'],
-      fundingVehicle: team.fields['Funding Vehicle'],
+      filecoinUser: !!team.fields['Filecoin User'],
+      fundingStage: team.fields['Funding Stage'] || null,
+      fundingVehicle: team.fields['Funding Vehicle'] || [],
       id: team.id,
-      industry: team.fields.Industry,
-      ipfsUser: team.fields['IPFS User'],
-      labbers: team.fields['Network members'],
-      logo: team.fields.Logo && team.fields.Logo[0]?.url,
-      longDescription: team.fields['Long description'],
-      name: team.fields.Name,
-      shortDescription: team.fields['Short description'],
-      twitter: team.fields.Twitter,
-      website: team.fields.Website,
+      industry: team.fields.Industry || [],
+      ipfsUser: !!team.fields['IPFS User'],
+      labbers: team.fields['Network members'] || [],
+      logo: (team.fields.Logo && team.fields.Logo[0]?.url) || null,
+      longDescription: team.fields['Long description'] || null,
+      name: team.fields.Name || null,
+      shortDescription: team.fields['Short description'] || null,
+      twitter: team.fields.Twitter || null,
+      website: team.fields.Website || null,
     };
   }
 
@@ -114,16 +114,17 @@ class AirtableService {
    */
   private _parseLabber(labber: IAirtableLabber): ILabber {
     return {
-      discordHandle: labber.fields['Discord Handle'],
-      displayName: labber.fields['Display Name'],
-      email: labber.fields.Email,
+      discordHandle: labber.fields['Discord Handle'] || null,
+      displayName: labber.fields['Display Name'] || null,
+      email: labber.fields.Email || null,
       id: labber.id,
       image:
-        labber.fields['Profile picture'] &&
-        labber.fields['Profile picture'][0].url,
-      name: labber.fields.Name,
-      role: labber.fields.Role,
-      twitter: labber.fields.Twitter,
+        (labber.fields['Profile picture'] &&
+          labber.fields['Profile picture'][0]?.url) ||
+        null,
+      name: labber.fields.Name || null,
+      role: labber.fields.Role || null,
+      twitter: labber.fields.Twitter || null,
     };
   }
 }

--- a/libs/api/src/labbers.ts
+++ b/libs/api/src/labbers.ts
@@ -1,10 +1,10 @@
 export interface ILabber {
-  discordHandle?: string;
-  displayName?: string;
-  email?: string;
-  id: string;
-  image?: string;
-  name?: string;
-  role?: string;
-  twitter?: string;
+  discordHandle: string | null;
+  displayName: string | null;
+  email: string | null;
+  id: string | null;
+  image: string | null;
+  name: string | null;
+  role: string | null;
+  twitter: string | null;
 }

--- a/libs/api/src/teams.ts
+++ b/libs/api/src/teams.ts
@@ -1,15 +1,15 @@
 export interface ITeam {
-  filecoinUser?: boolean;
-  fundingStage?: string;
-  fundingVehicle?: string[];
+  filecoinUser: boolean;
+  fundingStage: string | null;
+  fundingVehicle: string[];
   id: string;
-  industry?: string[];
-  ipfsUser?: boolean;
-  labbers?: string[];
-  logo?: string;
-  longDescription?: string;
-  name?: string;
-  shortDescription?: string;
-  twitter?: string;
-  website?: string;
+  industry: string[];
+  ipfsUser: boolean;
+  labbers: string[];
+  logo: string | null;
+  longDescription: string | null;
+  name: string | null;
+  shortDescription: string | null;
+  twitter: string | null;
+  website: string | null;
 }


### PR DESCRIPTION
## Description

Update parser for teams and labbers responses from Airtable's data source to comply with Next.js way of work.

This solves an issue we were facing, where [based on the fact that empty teams' and labbers' properties are not included in the response objects,] Next.js was complaining that some properties were missing on the listed teams. This way, we ensure that all the properties are there, while they can still be empty (e.g., `null` or `[]`).

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-15

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
