### PR TITLE
feat: add the ability to sort the teams directory

### DIFF
--- a/apps/web-app/pages/api/teams/index.ts
+++ b/apps/web-app/pages/api/teams/index.ts
@@ -1,5 +1,6 @@
 import airtableService from '@protocol-labs-network/airtable';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { getListRequestOptionsFromQuery } from '../../../utils/api/list.utils';
 
 export default async function getTeamsHandler(
   req: NextApiRequest,
@@ -13,7 +14,8 @@ export default async function getTeamsHandler(
   }
 
   try {
-    const teams = await airtableService.getTeams();
+    const options = getListRequestOptionsFromQuery(req.query);
+    const teams = await airtableService.getTeams(options);
     res.status(200).json(teams);
   } catch (error) {
     res.status(500).json({ msg: 'Ups, something went wrong 😕' });

--- a/apps/web-app/pages/teams/index.tsx
+++ b/apps/web-app/pages/teams/index.tsx
@@ -6,6 +6,7 @@ import { DirectorySort } from '../../components/directory-sort/directory-sort';
 import { SelectViewType } from '../../components/select-view-type/select-view-type';
 import { useViewType } from '../../components/select-view-type/use-view-type.hook';
 import { TeamCard } from '../../components/TeamCard/TeamCard';
+import { getListRequestOptionsFromQuery } from '../../utils/api/list.utils';
 
 type TeamsProps = {
   teams: ITeam[];
@@ -42,8 +43,11 @@ export default function Teams({ teams }: TeamsProps) {
   );
 }
 
-export const getServerSideProps: GetServerSideProps<TeamsProps> = async () => {
-  const teams = await airtableService.getTeams();
+export const getServerSideProps: GetServerSideProps<TeamsProps> = async (
+  context
+) => {
+  const options = getListRequestOptionsFromQuery(context.query);
+  const teams = await airtableService.getTeams(options);
 
   return {
     props: { teams },

--- a/apps/web-app/tests/pages/api/teams/index.spec.ts
+++ b/apps/web-app/tests/pages/api/teams/index.spec.ts
@@ -8,6 +8,11 @@ jest.mock('@protocol-labs-network/airtable', () => ({
   getTeams: jest.fn(() => mockTeams),
 }));
 
+const mockOptions = { sort: { field: 'Name', direction: 'desc' } };
+jest.mock('../../../utils/api/list.utils', () => ({
+  getListRequestOptionsFromQuery: jest.fn(() => mockOptions),
+}));
+
 describe('/api/teams', () => {
   const json = jest.fn();
   const end = jest.fn();
@@ -15,6 +20,7 @@ describe('/api/teams', () => {
   const status = jest.fn(() => ({ json, end }));
   const req: NextApiRequest = {
     method: 'GET',
+    query: {},
   } as unknown as NextApiRequest;
   const res: NextApiResponse = {
     status,
@@ -50,7 +56,7 @@ describe('/api/teams', () => {
 
   it('should get the teams from AirtableService', () => {
     expect(airtableService.getTeams).toHaveBeenCalledTimes(1);
-    expect(airtableService.getTeams).toHaveBeenCalledWith();
+    expect(airtableService.getTeams).toHaveBeenCalledWith(mockOptions);
   });
 
   describe('and AirtableService successfully retrieves the teams', () => {

--- a/apps/web-app/tests/utils/list.utils.spec.ts
+++ b/apps/web-app/tests/utils/list.utils.spec.ts
@@ -1,0 +1,21 @@
+import { getListRequestOptionsFromQuery } from '../../utils/api/list.utils';
+
+describe('#getListRequestOptionsFromQuery', () => {
+  it('should return valid options when sort is provided and is valid', () => {
+    expect(getListRequestOptionsFromQuery({ sort: 'Name,desc' })).toEqual({
+      sort: { field: 'Name', direction: 'desc' },
+    });
+  });
+
+  it('should return valid options when sort is provided and is invalid', () => {
+    expect(getListRequestOptionsFromQuery({ sort: 'invalid' })).toEqual({
+      sort: { field: 'Name', direction: 'asc' },
+    });
+  });
+
+  it('should return valid options when sort is not provided', () => {
+    expect(getListRequestOptionsFromQuery({})).toEqual({
+      sort: { field: 'Name', direction: 'asc' },
+    });
+  });
+});

--- a/apps/web-app/utils/api/list.utils.ts
+++ b/apps/web-app/utils/api/list.utils.ts
@@ -1,0 +1,40 @@
+import { ParsedUrlQuery } from 'querystring';
+import {
+  directorySortOptions,
+  TDirectorySortOption,
+} from '../../components/directory-sort/directory-sort.types';
+
+/**
+ * Returns an options for requesting a list of teams or labbers, by parsing
+ * the provided query parameters.
+ */
+export function getListRequestOptionsFromQuery(queryParams: ParsedUrlQuery) {
+  const { sort } = queryParams;
+
+  return {
+    sort: getSortFromQuery(sort?.toString()),
+  };
+}
+
+/**
+ * Gets sort options by parsing the provided sort query parameter.
+ */
+function getSortFromQuery(sortQuery?: string) {
+  const sort = isSortValid(sortQuery) ? sortQuery : 'Name,asc';
+  const sortSettings = sort.split(',');
+
+  return {
+    field: sortSettings[0],
+    direction: sortSettings[1] as 'asc' | 'desc',
+  };
+}
+
+/**
+ * Checks if provided sort query parameter exists and is valid.
+ */
+function isSortValid(sortQuery?: string) {
+  return (
+    sortQuery &&
+    directorySortOptions.includes(sortQuery as TDirectorySortOption)
+  );
+}

--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -98,98 +98,45 @@ jest.mock('airtable', () => ({
   default: airtableMock,
 }));
 
-import { ILabber, ITeam } from '@protocol-labs-network/api';
 import { IAirtableLabber, IAirtableTeam } from '../models';
 import airtableService from './airtable';
 import Airtable = require('airtable');
 
 describe('AirtableService', () => {
-  describe('when initialized', () => {
-    it('should create a new Airtable instance', () => {
-      expect(airtableMock).toHaveBeenCalledTimes(1);
-      expect(airtableMock).toHaveBeenCalledWith({
-        apiKey: 'MOCK_AIRTABLE_API_KEY',
-      });
-    });
-
-    it('should get the Airtable base', () => {
-      expect(baseMock).toHaveBeenCalledTimes(1);
-      expect(baseMock).toHaveBeenCalledWith('MOCK_AIRTABLE_BASE_ID');
-    });
-
-    it('should get the Airtable tables', () => {
-      expect(baseFunctionMock).toHaveBeenCalledTimes(2);
-      expect(baseFunctionMock).toHaveBeenCalledWith(
-        'MOCK_AIRTABLE_TEAMS_TABLE_ID'
-      );
-      expect(baseFunctionMock).toHaveBeenCalledWith(
-        'MOCK_AIRTABLE_LABBERS_TABLE_ID'
-      );
+  it('should create a new Airtable instance', () => {
+    expect(airtableMock).toHaveBeenCalledTimes(1);
+    expect(airtableMock).toHaveBeenCalledWith({
+      apiKey: 'MOCK_AIRTABLE_API_KEY',
     });
   });
 
-  describe('#getTeams', () => {
-    let teams: ITeam[];
-
-    beforeEach(async () => {
-      teams = await airtableService.getTeams();
-    });
-
-    it('should select all teams from teams table', () => {
-      expect(teamsTableMock.select).toHaveBeenCalledTimes(1);
-      expect(teamsTableMock.select().all).toHaveBeenCalledTimes(1);
-    });
-
-    it('should retrieve all teams', () => {
-      expect(teams).toEqual([
-        {
-          filecoinUser: teamMock.fields['Filecoin User'],
-          fundingStage: teamMock.fields['Funding Stage'],
-          fundingVehicle: teamMock.fields['Funding Vehicle'],
-          id: teamMock.id,
-          industry: teamMock.fields.Industry,
-          ipfsUser: teamMock.fields['IPFS User'],
-          labbers: teamMock.fields['Network members'],
-          logo: teamMock.fields.Logo?.[0].url,
-          longDescription: teamMock.fields['Long description'],
-          name: teamMock.fields.Name,
-          shortDescription: teamMock.fields['Short description'],
-          twitter: teamMock.fields.Twitter,
-          website: 'http://team01.com/',
-        },
-        {
-          filecoinUser: false,
-          fundingStage: null,
-          fundingVehicle: [],
-          id: emptyTeamMock.id,
-          industry: [],
-          ipfsUser: false,
-          labbers: [],
-          logo: null,
-          longDescription: null,
-          name: null,
-          shortDescription: null,
-          twitter: null,
-          website: null,
-        },
-      ]);
-    });
+  it('should get the Airtable base', () => {
+    expect(baseMock).toHaveBeenCalledTimes(1);
+    expect(baseMock).toHaveBeenCalledWith('MOCK_AIRTABLE_BASE_ID');
   });
 
-  describe('#getTeam', () => {
-    let team: ITeam;
+  it('should get the Airtable tables', () => {
+    expect(baseFunctionMock).toHaveBeenCalledTimes(2);
+    expect(baseFunctionMock).toHaveBeenCalledWith(
+      'MOCK_AIRTABLE_TEAMS_TABLE_ID'
+    );
+    expect(baseFunctionMock).toHaveBeenCalledWith(
+      'MOCK_AIRTABLE_LABBERS_TABLE_ID'
+    );
+  });
 
-    beforeEach(async () => {
-      team = await airtableService.getTeam(teamMock.id);
+  it('should be able to select and retrieve all teams from teams table', async () => {
+    const teams = await airtableService.getTeams({
+      sort: { field: 'Name', direction: 'asc' },
     });
 
-    it('should find the team with the provided id on teams table', () => {
-      expect(teamsTableMock.find).toHaveBeenCalledTimes(1);
-      expect(teamsTableMock.find).toHaveBeenCalledWith(teamMock.id);
+    expect(teamsTableMock.select).toHaveBeenCalledTimes(1);
+    expect(teamsTableMock.select).toHaveBeenCalledWith({
+      sort: [{ field: 'Name', direction: 'asc' }],
     });
-
-    it('should retrieve the team with the provided id', () => {
-      expect(team).toEqual({
+    expect(teamsTableMock.select().all).toHaveBeenCalledTimes(1);
+    expect(teams).toEqual([
+      {
         filecoinUser: teamMock.fields['Filecoin User'],
         fundingStage: teamMock.fields['Funding Stage'],
         fundingVehicle: teamMock.fields['Funding Vehicle'],
@@ -203,62 +150,54 @@ describe('AirtableService', () => {
         shortDescription: teamMock.fields['Short description'],
         twitter: teamMock.fields.Twitter,
         website: 'http://team01.com/',
-      });
+      },
+      {
+        filecoinUser: false,
+        fundingStage: null,
+        fundingVehicle: [],
+        id: emptyTeamMock.id,
+        industry: [],
+        ipfsUser: false,
+        labbers: [],
+        logo: null,
+        longDescription: null,
+        name: null,
+        shortDescription: null,
+        twitter: null,
+        website: null,
+      },
+    ]);
+  });
+
+  it('should be able to find and retrieve the team with the provided id on teams table', async () => {
+    const team = await airtableService.getTeam(teamMock.id);
+
+    expect(teamsTableMock.find).toHaveBeenCalledTimes(1);
+    expect(teamsTableMock.find).toHaveBeenCalledWith(teamMock.id);
+    expect(team).toEqual({
+      filecoinUser: teamMock.fields['Filecoin User'],
+      fundingStage: teamMock.fields['Funding Stage'],
+      fundingVehicle: teamMock.fields['Funding Vehicle'],
+      id: teamMock.id,
+      industry: teamMock.fields.Industry,
+      ipfsUser: teamMock.fields['IPFS User'],
+      labbers: teamMock.fields['Network members'],
+      logo: teamMock.fields.Logo?.[0].url,
+      longDescription: teamMock.fields['Long description'],
+      name: teamMock.fields.Name,
+      shortDescription: teamMock.fields['Short description'],
+      twitter: teamMock.fields.Twitter,
+      website: 'http://team01.com/',
     });
   });
 
-  describe('#getLabbers', () => {
-    let labbers: ILabber[];
+  it('should be able to select and retrieve all labbers from labbers table', async () => {
+    const labbers = await airtableService.getLabbers();
 
-    beforeEach(async () => {
-      labbers = await airtableService.getLabbers();
-    });
-
-    it('should select all labbers from labbers table', () => {
-      expect(labbersTableMock.select).toHaveBeenCalledTimes(1);
-      expect(labbersTableMock.select().all).toHaveBeenCalledTimes(1);
-    });
-
-    it('should retrieve all labbers', () => {
-      expect(labbers).toEqual([
-        {
-          discordHandle: labberMock.fields['Discord Handle'],
-          displayName: labberMock.fields['Display Name'],
-          email: labberMock.fields.Email,
-          id: labberMock.id,
-          image: labberMock.fields['Profile picture']?.[0].url,
-          name: labberMock.fields.Name,
-          role: labberMock.fields.Role,
-          twitter: labberMock.fields.Twitter,
-        },
-        {
-          discordHandle: null,
-          displayName: null,
-          email: null,
-          id: emptyLabberMock.id,
-          image: null,
-          name: null,
-          role: null,
-          twitter: null,
-        },
-      ]);
-    });
-  });
-
-  describe('#getLabber', () => {
-    let labber: ILabber;
-
-    beforeEach(async () => {
-      labber = await airtableService.getLabber(labberMock.id);
-    });
-
-    it('should find the labber with the provided id on labbers table', () => {
-      expect(labbersTableMock.find).toHaveBeenCalledTimes(1);
-      expect(labbersTableMock.find).toHaveBeenCalledWith(labberMock.id);
-    });
-
-    it('should retrieve the labber with the provided id', () => {
-      expect(labber).toEqual({
+    expect(labbersTableMock.select).toHaveBeenCalledTimes(1);
+    expect(labbersTableMock.select().all).toHaveBeenCalledTimes(1);
+    expect(labbers).toEqual([
+      {
         discordHandle: labberMock.fields['Discord Handle'],
         displayName: labberMock.fields['Display Name'],
         email: labberMock.fields.Email,
@@ -267,7 +206,34 @@ describe('AirtableService', () => {
         name: labberMock.fields.Name,
         role: labberMock.fields.Role,
         twitter: labberMock.fields.Twitter,
-      });
+      },
+      {
+        discordHandle: null,
+        displayName: null,
+        email: null,
+        id: emptyLabberMock.id,
+        image: null,
+        name: null,
+        role: null,
+        twitter: null,
+      },
+    ]);
+  });
+
+  it('should be able to find and retrieve the labber with the provided id on labbers table', async () => {
+    const labber = await airtableService.getLabber(labberMock.id);
+
+    expect(labbersTableMock.find).toHaveBeenCalledTimes(1);
+    expect(labbersTableMock.find).toHaveBeenCalledWith(labberMock.id);
+    expect(labber).toEqual({
+      discordHandle: labberMock.fields['Discord Handle'],
+      displayName: labberMock.fields['Display Name'],
+      email: labberMock.fields.Email,
+      id: labberMock.id,
+      image: labberMock.fields['Profile picture']?.[0].url,
+      name: labberMock.fields.Name,
+      role: labberMock.fields.Role,
+      twitter: labberMock.fields.Twitter,
     });
   });
 });

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -1,4 +1,4 @@
-import { ILabber, ITeam } from '@protocol-labs-network/api';
+import { ILabber, IListOptions, ITeam } from '@protocol-labs-network/api';
 import Airtable from 'airtable';
 import { IAirtableLabber, IAirtableTeam } from '../models';
 
@@ -25,9 +25,11 @@ class AirtableService {
   /**
    * Get teams from Airtable.
    */
-  public async getTeams() {
+  public async getTeams(options: IListOptions) {
     const teams: IAirtableTeam[] = (await this._teamsTable
-      .select()
+      .select({
+        sort: [options.sort],
+      })
       .all()) as unknown as IAirtableTeam[];
 
     return this._parseTeams(teams);

--- a/libs/api/src/index.ts
+++ b/libs/api/src/index.ts
@@ -1,2 +1,3 @@
 export * from './labbers';
+export * from './list';
 export * from './teams';

--- a/libs/api/src/list.ts
+++ b/libs/api/src/list.ts
@@ -1,0 +1,8 @@
+export interface IListOptions {
+  sort: IListSort;
+}
+
+interface IListSort {
+  field: string;
+  direction: 'asc' | 'desc';
+}


### PR DESCRIPTION
## Description

- Adds the ability to sort the teams on the Teams Directory.
- Adds the ability to request a sorted teams list from Airtable.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-15

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
