### PR TITLE
feat: add reusable directory filters components

### DIFF
--- a/apps/web-app/components/directory/directory-filters/directory-filter/directory-filter.tsx
+++ b/apps/web-app/components/directory/directory-filters/directory-filter/directory-filter.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+interface DirectoryFilterProps {
+  title: string;
+  children: ReactNode;
+}
+
+export function DirectoryFilter({ title, children }: DirectoryFilterProps) {
+  return (
+    <>
+      <div className="text-sm font-semibold leading-5 mb-4">{title}</div>
+      <div>{children}</div>
+    </>
+  );
+}
+
+export default DirectoryFilter;

--- a/apps/web-app/components/directory/directory-filters/directory-filters.spec.tsx
+++ b/apps/web-app/components/directory/directory-filters/directory-filters.spec.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+import { createMockRouter } from '../../../utils/test/createMockRouter';
+import DirectoryFilters from './directory-filters';
+
+describe('DirectoryFilters', () => {
+  it('should clear the filter related query parameters when user clicks to clear filters', () => {
+    const push = jest.fn();
+
+    render(
+      <RouterContext.Provider
+        value={createMockRouter({
+          query: {
+            industry: 'industry_01',
+            fundingVehicle: 'funding_vehicle_01',
+            sort: 'Name,desc',
+          },
+          push,
+        })}
+      >
+        <DirectoryFilters filterProperties={['industry', 'fundingVehicle']}>
+          <div></div>
+        </DirectoryFilters>
+      </RouterContext.Provider>
+    );
+
+    const clearFiltersBtn = screen.getByRole('button', {
+      name: /clear all/i,
+    });
+    fireEvent.click(clearFiltersBtn);
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/',
+      query: { sort: 'Name,desc' },
+    });
+  });
+});

--- a/apps/web-app/components/directory/directory-filters/directory-filters.tsx
+++ b/apps/web-app/components/directory/directory-filters/directory-filters.tsx
@@ -1,0 +1,38 @@
+import { useRouter } from 'next/router';
+
+interface DirectoryFiltersProps {
+  children: React.ReactNode;
+  filterProperties: string[];
+}
+
+export function DirectoryFilters({
+  children,
+  filterProperties,
+}: DirectoryFiltersProps) {
+  const { push, pathname, query } = useRouter();
+
+  function clearFilters() {
+    const cleanQuery = { ...query };
+
+    filterProperties.forEach((property) => delete cleanQuery[property]);
+
+    push({ pathname, query: cleanQuery });
+  }
+
+  return (
+    <>
+      <div className="flex justify-between p-5 border-b border-b-slate-200">
+        <span className="text-lg font-semibold leading-7">Filters</span>
+        <button
+          className="text-xs text-sky-600 hover:text-sky-500 transition-colors"
+          onClick={clearFilters}
+        >
+          Clear all
+        </button>
+      </div>
+      <div className="p-5">{children}</div>
+    </>
+  );
+}
+
+export default DirectoryFilters;


### PR DESCRIPTION
## Description

Add reusable directory filters and directory filter components.

- **Directory filters** component will be reused as the filters sidebar for the teams and members directories.
- **Directory filter** component contains the base styling and structure for each individual filter in each directory (e.g., industry filter, funding stage filter).

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-16

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
