### PR TITLE
refactor: convert sort option from list utils into an array for Airtable usage readiness

### DIFF
--- a/apps/web-app/tests/utils/list.utils.spec.ts
+++ b/apps/web-app/tests/utils/list.utils.spec.ts
@@ -3,19 +3,19 @@ import { getListRequestOptionsFromQuery } from '../../utils/api/list.utils';
 describe('#getListRequestOptionsFromQuery', () => {
   it('should return valid options when sort is provided and is valid', () => {
     expect(getListRequestOptionsFromQuery({ sort: 'Name,desc' })).toEqual({
-      sort: { field: 'Name', direction: 'desc' },
+      sort: [{ field: 'Name', direction: 'desc' }],
     });
   });
 
   it('should return valid options when sort is provided and is invalid', () => {
     expect(getListRequestOptionsFromQuery({ sort: 'invalid' })).toEqual({
-      sort: { field: 'Name', direction: 'asc' },
+      sort: [{ field: 'Name', direction: 'asc' }],
     });
   });
 
   it('should return valid options when sort is not provided', () => {
     expect(getListRequestOptionsFromQuery({})).toEqual({
-      sort: { field: 'Name', direction: 'asc' },
+      sort: [{ field: 'Name', direction: 'asc' }],
     });
   });
 });

--- a/apps/web-app/utils/api/list.utils.ts
+++ b/apps/web-app/utils/api/list.utils.ts
@@ -12,7 +12,7 @@ export function getListRequestOptionsFromQuery(queryParams: ParsedUrlQuery) {
   const { sort } = queryParams;
 
   return {
-    sort: getSortFromQuery(sort?.toString()),
+    sort: [getSortFromQuery(sort?.toString())],
   };
 }
 

--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -127,7 +127,7 @@ describe('AirtableService', () => {
 
   it('should be able to select and retrieve all teams from teams table', async () => {
     const teams = await airtableService.getTeams({
-      sort: { field: 'Name', direction: 'asc' },
+      sort: [{ field: 'Name', direction: 'asc' }],
     });
 
     expect(teamsTableMock.select).toHaveBeenCalledTimes(1);

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -27,9 +27,7 @@ class AirtableService {
    */
   public async getTeams(options: IListOptions) {
     const teams: IAirtableTeam[] = (await this._teamsTable
-      .select({
-        sort: [options.sort],
-      })
+      .select(options)
       .all()) as unknown as IAirtableTeam[];
 
     return this._parseTeams(teams);

--- a/libs/api/src/list.ts
+++ b/libs/api/src/list.ts
@@ -1,5 +1,5 @@
 export interface IListOptions {
-  sort: IListSort;
+  sort: IListSort[];
 }
 
 interface IListSort {


### PR DESCRIPTION
## Description

Refactor current Airtable list request options getter to return a properly formatted object, according to the Airtable API model.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-16

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
