### PR TITLE
feat: add teams directory filters utils

### DIFF
--- a/apps/web-app/components/teams-directory/teams-directory-filters/teams-directory-filters.types.ts
+++ b/apps/web-app/components/teams-directory/teams-directory-filters/teams-directory-filters.types.ts
@@ -1,0 +1,7 @@
+import { IFilterTag } from '../../../components/directory/directory-filters/directory-tags-filter/directory-tags-filter.types';
+
+export interface ITeamsFiltersValues {
+  fundingStage: IFilterTag[];
+  fundingVehicle: IFilterTag[];
+  industry: IFilterTag[];
+}

--- a/apps/web-app/components/teams-directory/teams-directory-filters/teams-directory-filters.utils.spec.ts
+++ b/apps/web-app/components/teams-directory/teams-directory-filters/teams-directory-filters.utils.spec.ts
@@ -1,0 +1,49 @@
+import { parseTeamsFilters } from './teams-directory-filters.utils';
+
+describe('#parseTeamsFilters', () => {
+  it('should parse teams filter values into each filter component`s consumable format', () => {
+    expect(
+      parseTeamsFilters(
+        {
+          valuesByFilter: {
+            industry: ['Industry 01', 'Industry 02', 'Industry 03'],
+            fundingVehicle: [
+              'Funding Vehicle 01',
+              'Funding Vehicle 02',
+              'Funding Vehicle 03',
+            ],
+            fundingStage: [
+              'Funding Stage 01',
+              'Funding Stage 02',
+              'Funding Stage 03',
+            ],
+          },
+          availableValuesByFilter: {
+            industry: ['Industry 01', 'Industry 03'],
+            fundingVehicle: ['Funding Vehicle 01', 'Funding Vehicle 03'],
+            fundingStage: ['Funding Stage 01', 'Funding Stage 02'],
+          },
+        },
+        {
+          industry: 'Industry 01',
+        }
+      )
+    ).toEqual({
+      industry: [
+        { value: 'Industry 01', selected: true, disabled: false },
+        { value: 'Industry 02', selected: false, disabled: true },
+        { value: 'Industry 03', selected: false, disabled: false },
+      ],
+      fundingVehicle: [
+        { value: 'Funding Vehicle 01', selected: false, disabled: false },
+        { value: 'Funding Vehicle 02', selected: false, disabled: true },
+        { value: 'Funding Vehicle 03', selected: false, disabled: false },
+      ],
+      fundingStage: [
+        { value: 'Funding Stage 01', selected: false, disabled: false },
+        { value: 'Funding Stage 02', selected: false, disabled: false },
+        { value: 'Funding Stage 03', selected: false, disabled: true },
+      ],
+    });
+  });
+});

--- a/apps/web-app/components/teams-directory/teams-directory-filters/teams-directory-filters.utils.ts
+++ b/apps/web-app/components/teams-directory/teams-directory-filters/teams-directory-filters.utils.ts
@@ -1,0 +1,55 @@
+import { IAirtableTeamsFiltersValues } from '@protocol-labs-network/airtable';
+import { ParsedUrlQuery } from 'querystring';
+import { URL_QUERY_VALUE_SEPARATOR } from '../../../constants';
+import { IFilterTag } from '../../directory/directory-filters/directory-tags-filter/directory-tags-filter.types';
+import { ITeamsFiltersValues } from './teams-directory-filters.types';
+
+/**
+ * Parse teams filter values into each filter component's consumable format
+ */
+export function parseTeamsFilters(
+  filtersValues: {
+    valuesByFilter: IAirtableTeamsFiltersValues;
+    availableValuesByFilter: IAirtableTeamsFiltersValues;
+  },
+  query: ParsedUrlQuery
+): ITeamsFiltersValues {
+  return {
+    industry: getTagsFromValues(
+      filtersValues.valuesByFilter.industry,
+      filtersValues.availableValuesByFilter.industry,
+      query.industry
+    ),
+    fundingVehicle: getTagsFromValues(
+      filtersValues.valuesByFilter.fundingVehicle,
+      filtersValues.availableValuesByFilter.fundingVehicle,
+      query.fundingVehicle
+    ),
+    fundingStage: getTagsFromValues(
+      filtersValues.valuesByFilter.fundingStage,
+      filtersValues.availableValuesByFilter.fundingStage,
+      query.fundingStage
+    ),
+  };
+}
+
+/**
+ * Get tags from provided filter values, identifying:
+ * - the selected ones, based on the query parameter value
+ * - the disabled ones, based on either they're available or not to be selected
+ */
+function getTagsFromValues(
+  allValues: string[],
+  availableValues: string[],
+  queryValues: string | string[] = []
+): IFilterTag[] {
+  const queryValuesArr = Array.isArray(queryValues)
+    ? queryValues
+    : queryValues.split(URL_QUERY_VALUE_SEPARATOR);
+
+  return allValues.map((value) => ({
+    value,
+    selected: queryValuesArr.includes(value),
+    disabled: !availableValues.includes(value),
+  }));
+}


### PR DESCRIPTION
## Description

Add filters utils for the teams' directory.

These utils will be used on the Teams Directory page, where we'll be fetching all the values and all the available values (the ones that, if selected, will still have matching results) from Airtable requests and then call these utils with those values, along with the query parameters. Based on these values, we'll return lists of tags with the necessary data to be used on the corresponding filters.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-16

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
