### PR TITLE
feat: add requests for collecting  filters values from Airtable

### DIFF
--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -191,6 +191,93 @@ describe('AirtableService', () => {
     });
   });
 
+  it('should be able to get all teams filter values and available teams filter values from teams table', async () => {
+    (teamsTableMock.select as jest.Mock)
+      .mockReset()
+      .mockReturnValueOnce({
+        all: jest.fn().mockReturnValue([
+          {
+            fields: {
+              Industry: ['Industry 01', 'Industry 02'],
+              'Funding Stage': 'Funding Stage 01',
+              'Funding Vehicle': ['Funding Vehicle 01', 'Funding Vehicle 02'],
+            },
+          },
+          {
+            fields: {
+              Industry: ['Industry 01', 'Industry 02', 'Industry 03'],
+              'Funding Stage': 'Funding Stage 02',
+              'Funding Vehicle': ['Funding Vehicle 02', 'Funding Vehicle 03'],
+            },
+          },
+          {
+            fields: {
+              Industry: ['Industry 04', 'Industry 05'],
+              'Funding Stage': 'Funding Stage 03',
+              'Funding Vehicle': ['Funding Vehicle 04'],
+            },
+          },
+          {
+            fields: {},
+          },
+        ]),
+      })
+      .mockReturnValueOnce({
+        all: jest.fn().mockReturnValue([
+          {
+            fields: {
+              Industry: ['Industry 01', 'Industry 02'],
+              'Funding Stage': 'Funding Stage 01',
+              'Funding Vehicle': ['Funding Vehicle 01', 'Funding Vehicle 02'],
+            },
+          },
+          {
+            fields: {
+              Industry: ['Industry 01', 'Industry 02', 'Industry 03'],
+              'Funding Stage': 'Funding Stage 02',
+              'Funding Vehicle': ['Funding Vehicle 02', 'Funding Vehicle 03'],
+            },
+          },
+        ]),
+      });
+
+    const filtersValues = await airtableService.getTeamsFiltersValues({
+      sort: [{ field: 'Name', direction: 'asc' }],
+    });
+
+    expect(filtersValues).toEqual({
+      valuesByFilter: {
+        industry: [
+          'Industry 01',
+          'Industry 02',
+          'Industry 03',
+          'Industry 04',
+          'Industry 05',
+        ],
+        fundingStage: [
+          'Funding Stage 01',
+          'Funding Stage 02',
+          'Funding Stage 03',
+        ],
+        fundingVehicle: [
+          'Funding Vehicle 01',
+          'Funding Vehicle 02',
+          'Funding Vehicle 03',
+          'Funding Vehicle 04',
+        ],
+      },
+      availableValuesByFilter: {
+        industry: ['Industry 01', 'Industry 02', 'Industry 03'],
+        fundingStage: ['Funding Stage 01', 'Funding Stage 02'],
+        fundingVehicle: [
+          'Funding Vehicle 01',
+          'Funding Vehicle 02',
+          'Funding Vehicle 03',
+        ],
+      },
+    });
+  });
+
   it('should be able to select and retrieve all labbers from labbers table', async () => {
     const labbers = await airtableService.getLabbers();
 

--- a/libs/airtable/src/models/team.ts
+++ b/libs/airtable/src/models/team.ts
@@ -44,3 +44,9 @@ export interface IAirtableTeamLogo {
     full?: IAirtableImage;
   };
 }
+
+export interface IAirtableTeamsFiltersValues {
+  industry: string[];
+  fundingStage: string[];
+  fundingVehicle: string[];
+}


### PR DESCRIPTION
## Description

Add the ability to get all filter values from Airtable.

For that, we're making two requests:
- the first one gets all values for each filter and reduces them into a list of string values per filter;
- the second one gets the available values for each filter (by selecting only the results that correspond to the currently active filters, from the Airtable teams' table), and reduces them into a list of string values per filter.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-16

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
