### PR TITLE
feat(pl-7): add requests to collect the members of a provided team 

### DIFF
--- a/apps/web-app/components/team-profile/team-profile-details/team-profile-details.tsx
+++ b/apps/web-app/components/team-profile/team-profile-details/team-profile-details.tsx
@@ -1,20 +1,29 @@
-import { ITeam } from '@protocol-labs-network/api';
+import { ILabber, ITeam } from '@protocol-labs-network/api';
 import TeamProfileDescription from '../team-profile-description/team-profile-description';
 import TeamProfileFundingStage from '../team-profile-funding-stage/team-profile-funding-stage';
 import TeamProfileFundingVehicle from '../team-profile-funding-vehicle/team-profile-funding-vehicle';
 
 interface TeamProfileDetailsProps {
   team: ITeam;
+  members: ILabber[];
+  membersTeamsNames: { [teamId: string]: string };
 }
 
-export default function TeamProfileDetails({ team }: TeamProfileDetailsProps) {
+export default function TeamProfileDetails({
+  team,
+  members,
+  membersTeamsNames,
+}: TeamProfileDetailsProps) {
   return (
-    <div className="w-full">
-      <div className="w-full card ml-9">
+    <div className="w-full flex flex-col gap-y-6">
+      <div className="w-full card">
         <h1 className="text-3xl font-bold mb-4">{team.name}</h1>
-        <TeamProfileDescription description={team.longDescription} />
+
+        <TeamProfileDescription
+          description={team.longDescription || 'Not provided'}
+        />
       </div>
-      <div className="flex w-full mt-6 ml-9 gap-x-6">
+      <div className="flex w-full gap-x-6">
         <TeamProfileFundingStage fundingStage={team.fundingStage} />
         <TeamProfileFundingVehicle fundingVehicle={team.fundingVehicle} />
       </div>

--- a/apps/web-app/components/team-profile/team-profile-funding-stage/team-profile-funding-stage.tsx
+++ b/apps/web-app/components/team-profile/team-profile-funding-stage/team-profile-funding-stage.tsx
@@ -11,7 +11,9 @@ export default function TeamProfileFundingStage({
 
   return (
     <div className="w-1/2 card">
-      <h3 className="text-base mb-3">Funding Stage</h3>
+      <h3 className="text-base text-slate-500 font-medium mb-3">
+        Funding Stage
+      </h3>
       <div>
         {hasFundingStage ? <Tags items={[fundingStage]} /> : 'Not provided'}
       </div>

--- a/apps/web-app/components/team-profile/team-profile-funding-vehicle/team-profile-funding-vehicle.tsx
+++ b/apps/web-app/components/team-profile/team-profile-funding-vehicle/team-profile-funding-vehicle.tsx
@@ -11,7 +11,9 @@ export default function TeamProfileFundingVehicle({
 
   return (
     <div className="w-1/2 card">
-      <h3 className="text-base mb-4">Funding Vehicle</h3>
+      <h3 className="text-base text-slate-500 font-medium mb-4">
+        Funding Vehicle
+      </h3>
       <div>
         {hasFundingVehicles ? <Tags items={fundingVehicle} /> : 'Not provided'}
       </div>

--- a/apps/web-app/pages/styles.css
+++ b/apps/web-app/pages/styles.css
@@ -8,6 +8,6 @@ body {
 
 @layer components {
   .card {
-    @apply bg-white shadow-slate-200 px-6 py-9 border rounded-lg shadow-md text-sm cursor-default;
+    @apply bg-white shadow-slate-200 px-4 py-6 border rounded-lg shadow-md text-sm cursor-default;
   }
 }

--- a/apps/web-app/pages/teams/[id].tsx
+++ b/apps/web-app/pages/teams/[id].tsx
@@ -1,5 +1,5 @@
 import airtableService from '@protocol-labs-network/airtable';
-import { ITeam } from '@protocol-labs-network/api';
+import { ILabber, ITeam } from '@protocol-labs-network/api';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import TeamProfileDetails from '../../components/team-profile/team-profile-details/team-profile-details';
@@ -7,18 +7,24 @@ import TeamProfileSidebar from '../../components/team-profile/team-profile-sideb
 
 interface TeamProps {
   team: ITeam;
+  members: ILabber[];
+  membersTeamsNames: { [teamId: string]: string };
 }
 
-export default function Team({ team }: TeamProps) {
+export default function Team({ team, members, membersTeamsNames }: TeamProps) {
   return (
-    <section className="p-8 min-w-[768px] max-w-[1164px] mx-auto">
+    <section className="p-8 mx-36">
       <Head>
         <title>Team {team.name}</title>
       </Head>
 
-      <div className="flex items-stretch">
+      <div className="flex items-stretch gap-x-6">
         <TeamProfileSidebar team={team} />
-        <TeamProfileDetails team={team} />
+        <TeamProfileDetails
+          team={team}
+          members={members}
+          membersTeamsNames={membersTeamsNames}
+        />
       </div>
     </section>
   );
@@ -29,8 +35,10 @@ export const getServerSideProps: GetServerSideProps<TeamProps> = async (
 ) => {
   const { id } = context.query as { id: string };
   const team = await airtableService.getTeam(id);
+  const members = await airtableService.getTeamMembers(team.name);
+  const membersTeamsNames = await airtableService.getMembersTeamsNames(members);
 
   return {
-    props: { team },
+    props: { team, members, membersTeamsNames },
   };
 };

--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -295,6 +295,7 @@ describe('AirtableService', () => {
         image: labberMock.fields['Profile picture']?.[0].url,
         name: labberMock.fields.Name,
         role: labberMock.fields.Role,
+        teams: labberMock.fields.Teams,
         twitter: labberMock.fields.Twitter,
       },
       {
@@ -305,6 +306,7 @@ describe('AirtableService', () => {
         image: null,
         name: null,
         role: null,
+        teams: [],
         twitter: null,
       },
     ]);
@@ -323,6 +325,7 @@ describe('AirtableService', () => {
       image: labberMock.fields['Profile picture']?.[0].url,
       name: labberMock.fields.Name,
       role: labberMock.fields.Role,
+      teams: labberMock.fields.Teams,
       twitter: labberMock.fields.Twitter,
     });
   });

--- a/libs/api/src/labbers.ts
+++ b/libs/api/src/labbers.ts
@@ -7,4 +7,5 @@ export interface ILabber {
   name: string | null;
   role: string | null;
   twitter: string | null;
+  teams: string[];
 }

--- a/libs/api/src/list.ts
+++ b/libs/api/src/list.ts
@@ -1,6 +1,7 @@
 export interface IListOptions {
-  sort: IListSort[];
-  filterByFormula: string;
+  sort?: IListSort[];
+  filterByFormula?: string;
+  fields?: string[];
 }
 
 interface IListSort {


### PR DESCRIPTION
## Description

1. Add the ability to filter labbers from Airtable with a list of options:

- filterByFormula: in this case we want labbers from a certain team;
- fields: we want just some of the information regarding members;
- sort: by asc;

2. In addition, it adds a function to receive the names of the teams to which each member belongs

3. Makes some tweaks to the layout of the team details page

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-7

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
