### PR TITLE
ci: add build task runner without NxCloud

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -20,6 +20,12 @@
         "cacheableOperations": ["build", "lint", "test", "e2e"],
         "accessToken": "MjgwMzk0ZWQtNDBmZi00YmM1LTgwNTUtMTdkZWZlZjllM2RifHJlYWQtd3JpdGU="
       }
+    },
+    "no-cloud": {
+      "runner": "@nrwl/workspace/src/tasks-runner/default-tasks-runner",
+      "options": {
+        "cacheableOperations": ["build", "lint", "test", "e2e"]
+      }
     }
   },
   "targetDependencies": {


### PR DESCRIPTION
## Description

Add build task runner that does not use NxCloud.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-37

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
