### PR TITLE
feat: cache teams directory and profile pages data

### DIFF
--- a/apps/web-app/pages/teams/[id].tsx
+++ b/apps/web-app/pages/teams/[id].tsx
@@ -30,13 +30,21 @@ export default function Team({ team, members, membersTeamsNames }: TeamProps) {
   );
 }
 
-export const getServerSideProps: GetServerSideProps<TeamProps> = async (
-  context
-) => {
-  const { id } = context.query as { id: string };
+export const getServerSideProps: GetServerSideProps<TeamProps> = async ({
+  query,
+  res,
+}) => {
+  const { id } = query as { id: string };
   const team = await airtableService.getTeam(id);
   const members = await airtableService.getTeamMembers(team.name);
   const membersTeamsNames = await airtableService.getMembersTeamsNames(members);
+
+  // Cache response data in the browser for 1 minute,
+  // and in the CDN for 5 minutes, while keeping it stale for 7 days
+  res.setHeader(
+    'Cache-Control',
+    'public, max-age=60, s-maxage=300, stale-while-revalidate=604800'
+  );
 
   return {
     props: { team, members, membersTeamsNames },


### PR DESCRIPTION
## Description

Cache Teams Directory and Team Profile pages' request data on the server.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-70

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
