### PR TITLE
chore: add prettier plugin for automatically sorting tailwindcss classes

### DIFF
--- a/apps/web-app/components/directory/directory-card/directory-card.tsx
+++ b/apps/web-app/components/directory/directory-card/directory-card.tsx
@@ -8,7 +8,7 @@ export type DirectoryCardProps = { isGrid: boolean } & Pick<
 export function DirectoryCard({ isGrid, children }: DirectoryCardProps) {
   return (
     <div
-      className={`bg-white border rounded-lg shadow-md text-sm flex  ${
+      className={`flex rounded-lg border bg-white text-sm shadow-md  ${
         isGrid ? 'w-[260px] flex-col' : 'w-full flex-row flex-wrap'
       }`}
     >

--- a/apps/web-app/components/directory/directory-filters/directory-filter/directory-filter.tsx
+++ b/apps/web-app/components/directory/directory-filters/directory-filter/directory-filter.tsx
@@ -8,7 +8,7 @@ interface DirectoryFilterProps {
 function DirectoryFilter({ title, children }: DirectoryFilterProps) {
   return (
     <>
-      <div className="text-sm font-semibold leading-5 mb-4">{title}</div>
+      <div className="mb-4 text-sm font-semibold leading-5">{title}</div>
       <div>{children}</div>
     </>
   );

--- a/apps/web-app/components/directory/directory-filters/directory-filters.tsx
+++ b/apps/web-app/components/directory/directory-filters/directory-filters.tsx
@@ -21,10 +21,10 @@ function DirectoryFilters({
 
   return (
     <>
-      <div className="flex justify-between p-5 border-b border-b-slate-200">
+      <div className="flex justify-between border-b border-b-slate-200 p-5">
         <span className="text-lg font-semibold leading-7">Filters</span>
         <button
-          className="text-xs text-sky-600 hover:text-sky-500 transition-colors"
+          className="text-xs text-sky-600 transition-colors hover:text-sky-500"
           onClick={clearFilters}
         >
           Clear all

--- a/apps/web-app/components/directory/directory-filters/directory-tags-filter/directory-tags-filter.tsx
+++ b/apps/web-app/components/directory/directory-filters/directory-tags-filter/directory-tags-filter.tsx
@@ -39,13 +39,13 @@ function DirectoryTagsFilter({
                 />
               ))}
             </Collapsible.Content>
-            <Collapsible.Trigger className="flex items-center mt-2">
-              <span className="text-xs font-semibold leading-4 mr-1">
+            <Collapsible.Trigger className="mt-2 flex items-center">
+              <span className="mr-1 text-xs font-semibold leading-4">
                 Show {open ? 'less' : 'more'}
               </span>
               {open ? null : <Badge text={`${collapsibleTags.length}`} />}
               <ChevronDownIcon
-                className={`h-5 ml-2 ${open ? 'rotate-180' : ''}`}
+                className={`ml-2 h-5 ${open ? 'rotate-180' : ''}`}
               />
             </Collapsible.Trigger>
           </>

--- a/apps/web-app/components/directory/directory-sort/directory-sort-button-content.tsx
+++ b/apps/web-app/components/directory/directory-sort/directory-sort-button-content.tsx
@@ -12,7 +12,7 @@ export function DirectorySortButtonContent({
 
   return (
     <>
-      <SortIcon className="h-4 mr-1 top-px relative pointer-events-none" />
+      <SortIcon className="pointer-events-none relative top-px mr-1 h-4" />
       <div className="leading-6">Sorted: {selectedOption.label}</div>
     </>
   );

--- a/apps/web-app/components/directory/directory-view-type/directory-view-type.tsx
+++ b/apps/web-app/components/directory/directory-view-type/directory-view-type.tsx
@@ -26,11 +26,11 @@ export function DirectoryViewType() {
 
     return (
       <button
-        className={`group relative w-10 h-10 border first:rounded-l-lg last:rounded-r-lg ml-[-1px] first:ml-0 focus:outline-none focus:ring focus:ring-sky-300/30 focus:border-sky-300 focus:z-20
+        className={`group relative ml-[-1px] h-10 w-10 border first:ml-0 first:rounded-l-lg last:rounded-r-lg focus:z-20 focus:border-sky-300 focus:outline-none focus:ring focus:ring-sky-300/30
         ${
           isActive
-            ? 'bg-sky-100 border-sky-600 z-10'
-            : 'bg-white border-slate-300'
+            ? 'z-10 border-sky-600 bg-sky-100'
+            : 'border-slate-300 bg-white'
         }
         `}
         onClick={() => changeView(viewType)}
@@ -38,7 +38,7 @@ export function DirectoryViewType() {
       >
         <span className="sr-only">{label}</span>
         <ViewTypeIcon
-          className={`h-6 w-6 m-auto ${
+          className={`m-auto h-6 w-6 ${
             isActive
               ? 'stroke-sky-600'
               : 'stroke-slate-600 group-hover:stroke-sky-600'

--- a/apps/web-app/components/layout/navbar/join-network-menu/join-network-menu.tsx
+++ b/apps/web-app/components/layout/navbar/join-network-menu/join-network-menu.tsx
@@ -28,9 +28,9 @@ const JOIN_NETWORK_MENU_OPTIONS: IMenuOption[] = [
 export function JoinNetworkMenu() {
   return (
     <Menu as="div" className="relative">
-      <Menu.Button className="inline-flex w-full justify-center rounded-full px-6 py-2 leading-6 text-[15px] font-semibold text-white bg-gradient-to-r from-[#427DFF] to-[#44D5BB] hover:from-[#1A61FF] hover:to-[#2CC3A8] shadow-special-button-default hover:shadow-special-button-hover focus:shadow-special-button-focus outline-none">
+      <Menu.Button className="shadow-special-button-default hover:shadow-special-button-hover focus:shadow-special-button-focus inline-flex w-full justify-center rounded-full bg-gradient-to-r from-[#427DFF] to-[#44D5BB] px-6 py-2 text-[15px] font-semibold leading-6 text-white outline-none hover:from-[#1A61FF] hover:to-[#2CC3A8]">
         Join the Network
-        <div className="ml-3.5 my-auto">
+        <div className="my-auto ml-3.5">
           <ArrowIcon />
         </div>
       </Menu.Button>
@@ -44,14 +44,14 @@ export function JoinNetworkMenu() {
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
       >
-        <Menu.Items className="absolute right-0 mt-2 p-2 w-full rounded-lg bg-white shadow-md focus:outline-none">
+        <Menu.Items className="absolute right-0 mt-2 w-full rounded-lg bg-white p-2 shadow-md focus:outline-none">
           {JOIN_NETWORK_MENU_OPTIONS.map((option) => {
             const OptionIcon = option.icon;
             return (
               <Menu.Item key={option.label}>
                 {({ active }) => (
                   <OptionLink href={option.url} active={active}>
-                    <OptionIcon className="mr-2 w-5 h-5" />
+                    <OptionIcon className="mr-2 h-5 w-5" />
                     {option.label}
                   </OptionLink>
                 )}

--- a/apps/web-app/components/layout/navbar/menu/menu.tsx
+++ b/apps/web-app/components/layout/navbar/menu/menu.tsx
@@ -27,7 +27,7 @@ export function Menu() {
   const router = useRouter();
 
   return (
-    <ul className="text-sm text-gray-700 flex">
+    <ul className="flex text-sm text-gray-700">
       {MENU_ITEMS.map((item) => {
         const Icon = item.icon;
 
@@ -41,7 +41,7 @@ export function Menu() {
               >
                 <Icon
                   data-testid={`${item.name}-icon`}
-                  className="mr-2 w-5 h-5"
+                  className="mr-2 h-5 w-5"
                 />
                 {item.name}
               </a>

--- a/apps/web-app/components/layout/navbar/navbar.tsx
+++ b/apps/web-app/components/layout/navbar/navbar.tsx
@@ -5,7 +5,7 @@ import { ReactComponent as ProtocolLabsLogo } from '/public/assets/images/protoc
 
 export function Navbar() {
   return (
-    <nav className="w-full bg-white/95 py-3 px-8 border-b border-slate-200 flex items-center justify-between">
+    <nav className="flex w-full items-center justify-between border-b border-slate-200 bg-white/95 py-3 px-8">
       <div className="flex items-center space-x-5">
         <Link href="/">
           <a>

--- a/apps/web-app/components/members/member-card/member-card.tsx
+++ b/apps/web-app/components/members/member-card/member-card.tsx
@@ -22,7 +22,7 @@ export default function MemberCard({
     <div className="card w-[295px] space-y-4">
       <div className="flex gap-3">
         <div
-          className={`w-20 h-20 rounded-full ${image ? '' : 'bg-slate-200'}`}
+          className={`h-20 w-20 rounded-full ${image ? '' : 'bg-slate-200'}`}
         >
           {image ? (
             <Image

--- a/apps/web-app/components/shared/social-links/social-link.tsx
+++ b/apps/web-app/components/shared/social-links/social-link.tsx
@@ -28,7 +28,7 @@ export function SocialLink({ linkObj, linkIcon, type }: SocialLinkProps) {
   return (
     <AnchorLink {...linkProps}>
       <Icon
-        className={`w-5 h-5 ${
+        className={`h-5 w-5 ${
           isActive ? 'text-slate-500 hover:text-slate-600' : 'text-slate-300'
         }`}
       />

--- a/apps/web-app/components/teams/team-card/team-card.tsx
+++ b/apps/web-app/components/teams/team-card/team-card.tsx
@@ -17,17 +17,17 @@ export function TeamCard({ team, isGrid }: TeamCardProps) {
         >
           <div
             className={`h-24 rounded-lg ${
-              team.logo ? 'bg-no-repeat bg-center bg-contain' : 'bg-slate-200'
-            } ${isGrid ? 'w-full mb-5' : 'w-56 mr-6'}`}
+              team.logo ? 'bg-contain bg-center bg-no-repeat' : 'bg-slate-200'
+            } ${isGrid ? 'mb-5 w-full' : 'mr-6 w-56'}`}
             style={{
               ...(team.logo && { backgroundImage: `url(${team.logo})` }),
             }}
           />
           <div className="w-52 grow-0">
-            <h3 className="text-base text-slate-900 font-semibold">
+            <h3 className="text-base font-semibold text-slate-900">
               {team.name}
             </h3>
-            <p className="mt-0.5 h-16 line-clamp-3">{team.shortDescription}</p>
+            <p className="line-clamp-3 mt-0.5 h-16">{team.shortDescription}</p>
           </div>
         </div>
       </AnchorLink>
@@ -35,12 +35,12 @@ export function TeamCard({ team, isGrid }: TeamCardProps) {
       <div
         className={`${
           !isGrid &&
-          'sm:w-full lg:w-6/12 lg:ml-auto lg:justify-end flex flex-row'
+          'flex flex-row sm:w-full lg:ml-auto lg:w-6/12 lg:justify-end'
         }`}
       >
         <div
-          className={`h-[50px] flex ${
-            isGrid ? 'px-6 pt-3' : 'ml-6 self-center items-center sm:w-6/12'
+          className={`flex h-[50px] ${
+            isGrid ? 'px-6 pt-3' : 'ml-6 items-center self-center sm:w-6/12'
           }`}
         >
           {team.industry && team.industry.length ? (
@@ -52,10 +52,10 @@ export function TeamCard({ team, isGrid }: TeamCardProps) {
           )}
         </div>
         <div
-          className={`flex px-6 py-4 space-x-2 ${
+          className={`flex space-x-2 px-6 py-4 ${
             isGrid
               ? 'border-t border-slate-200'
-              : 'ml-6 justify-center items-center border-l border-slate-200 sm:flex-auto sm:w-6/1'
+              : 'sm:w-6/1 ml-6 items-center justify-center border-l border-slate-200 sm:flex-auto'
           }`}
         >
           <SocialLinks

--- a/apps/web-app/components/teams/team-profile/team-profile-details/team-profile-details.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-details/team-profile-details.tsx
@@ -14,10 +14,10 @@ export default function TeamProfileDetails({
   members,
 }: TeamProfileDetailsProps) {
   return (
-    <div className="w-full mx-14">
-      <div className="max-w-[1225px] flex flex-col gap-y-6">
+    <div className="mx-14 w-full">
+      <div className="flex max-w-[1225px] flex-col gap-y-6">
         <div className="card">
-          <h1 className="text-3xl font-bold mb-4">
+          <h1 className="mb-4 text-3xl font-bold">
             {team.name || 'Not provided'}
           </h1>
 

--- a/apps/web-app/components/teams/team-profile/team-profile-funding-stage/team-profile-funding-stage.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-funding-stage/team-profile-funding-stage.tsx
@@ -10,8 +10,8 @@ export default function TeamProfileFundingStage({
   const hasFundingStage = fundingStage && fundingStage.length;
 
   return (
-    <div className="w-1/2 card">
-      <h3 className="text-sm font-semibold mb-3">Funding Stage</h3>
+    <div className="card w-1/2">
+      <h3 className="mb-3 text-sm font-semibold">Funding Stage</h3>
       <div>
         {hasFundingStage ? <Tags items={[fundingStage]} /> : 'Not provided'}
       </div>

--- a/apps/web-app/components/teams/team-profile/team-profile-funding-vehicle/team-profile-funding-vehicle.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-funding-vehicle/team-profile-funding-vehicle.tsx
@@ -10,8 +10,8 @@ export default function TeamProfileFundingVehicle({
   const hasFundingVehicles = fundingVehicle && fundingVehicle.length;
 
   return (
-    <div className="w-1/2 card">
-      <h3 className="text-sm font-semibold mb-3">Funding Vehicle</h3>
+    <div className="card w-1/2">
+      <h3 className="mb-3 text-sm font-semibold">Funding Vehicle</h3>
       <div>
         {hasFundingVehicles ? <Tags items={fundingVehicle} /> : 'Not provided'}
       </div>

--- a/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
@@ -10,13 +10,13 @@ export default function TeamProfileMembers({
 }: TeamProfileMembersProps) {
   return (
     <>
-      <h3 className="text-slate-500 font-medium mb-4">Members</h3>
+      <h3 className="mb-4 font-medium text-slate-500">Members</h3>
       <div className="flex flex-wrap gap-4">
         {members.map((member) => (
           <MemberCard key={member.id} {...member} />
         ))}
       </div>
-      <div className="text-sm text-slate-500 mt-8 mb-20">
+      <div className="mt-8 mb-20 text-sm text-slate-500">
         Showing <b>{members.length}</b> results
       </div>
     </>

--- a/apps/web-app/components/teams/team-profile/team-profile-sidebar/team-profile-sidebar.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-sidebar/team-profile-sidebar.tsx
@@ -9,9 +9,9 @@ interface TeamProfileSidebarProps {
 
 export default function TeamProfileSidebar({ team }: TeamProfileSidebarProps) {
   return (
-    <div className="w-80 shrink-0 self-start card space-y-4 ml-10">
+    <div className="card ml-10 w-80 shrink-0 space-y-4 self-start">
       <div className="flex gap-3">
-        <div className={`w-20 h-20 rounded ${team.logo ? '' : 'bg-slate-200'}`}>
+        <div className={`h-20 w-20 rounded ${team.logo ? '' : 'bg-slate-200'}`}>
           {team.logo ? (
             <Image
               className="rounded"

--- a/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.tsx
+++ b/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.tsx
@@ -20,11 +20,11 @@ function TeamsDirectoryFilters({ filtersValues }: TeamsDirectoryFiltersProps) {
       ]}
     >
       <IndustryFilter industryTags={filtersValues.industry} />
-      <div className="h-px bg-slate-200 my-5" />
+      <div className="my-5 h-px bg-slate-200" />
       <FundingVehicleFilter fundingVehicleTags={filtersValues.fundingVehicle} />
-      <div className="h-px bg-slate-200 my-5" />
+      <div className="my-5 h-px bg-slate-200" />
       <FundingStageFilter fundingStageTags={filtersValues.fundingStage} />
-      <div className="h-px bg-slate-200 my-5" />
+      <div className="my-5 h-px bg-slate-200" />
       <TechnologyFilter technologyTags={filtersValues.technology} />
     </DirectoryFilters>
   );

--- a/apps/web-app/pages/styles.css
+++ b/apps/web-app/pages/styles.css
@@ -8,6 +8,6 @@ body {
 
 @layer components {
   .card {
-    @apply bg-white shadow-slate-200 px-5 pt-5 pb-6 border rounded-xl shadow-md text-sm;
+    @apply rounded-xl border bg-white px-5 pt-5 pb-6 text-sm shadow-md shadow-slate-200;
   }
 }

--- a/apps/web-app/pages/teams/[id].tsx
+++ b/apps/web-app/pages/teams/[id].tsx
@@ -17,7 +17,7 @@ export default function Team({ team, members }: TeamProps) {
         <title>Team {team.name}</title>
       </Head>
 
-      <div className="pt-10 flex">
+      <div className="flex pt-10">
         <TeamProfileSidebar team={team} />
         <TeamProfileDetails team={team} members={members} />
       </div>

--- a/apps/web-app/pages/teams/index.tsx
+++ b/apps/web-app/pages/teams/index.tsx
@@ -28,16 +28,16 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
       </Head>
 
       <section className="flex">
-        <div className="w-[291px] flex-shrink-0 bg-white border-r border-r-slate-200">
+        <div className="w-[291px] flex-shrink-0 border-r border-r-slate-200 bg-white">
           <TeamsDirectoryFilters filtersValues={filtersValues} />
         </div>
 
-        <div className="p-8 w-[1164px] flex-shrink-0 mx-auto">
-          <div className="flex justify-between items-center mb-10">
+        <div className="mx-auto w-[1164px] flex-shrink-0 p-8">
+          <div className="mb-10 flex items-center justify-between">
             <h1 className="text-3xl font-bold">Teams</h1>
-            <div className="flex space-x-4 items-center">
+            <div className="flex items-center space-x-4">
               <DirectorySearch />
-              <span className="w-px h-6 bg-slate-300" />
+              <span className="h-6 w-px bg-slate-300" />
               <DirectorySort />
               <DirectoryViewType />
             </div>

--- a/libs/ui/src/lib/badge/badge.tsx
+++ b/libs/ui/src/lib/badge/badge.tsx
@@ -4,7 +4,7 @@ export interface BadgeProps {
 
 export function Badge({ text }: BadgeProps) {
   return (
-    <div className="text-xs font-medium leading-4 text-slate-600 py-0.5 px-2 bg-slate-100 rounded-3xl">
+    <div className="rounded-3xl bg-slate-100 py-0.5 px-2 text-xs font-medium leading-4 text-slate-600">
       {text}
     </div>
   );

--- a/libs/ui/src/lib/dropdown/dropdown.tsx
+++ b/libs/ui/src/lib/dropdown/dropdown.tsx
@@ -43,7 +43,7 @@ export function Dropdown({
     >
       <div className="relative">
         <Listbox.Button
-          className={`flex items-center rounded-lg border bg-white px-3 h-10 border-slate-300 focus:outline-none focus:ring focus:ring-sky-300/30 focus:border-sky-300 transition ease-in-out duration-150 `}
+          className={`flex h-10 items-center rounded-lg border border-slate-300 bg-white px-3 transition duration-150 ease-in-out focus:border-sky-300 focus:outline-none focus:ring focus:ring-sky-300/30 `}
           data-testid="dropdown__button"
         >
           {buttonContent ? (
@@ -51,12 +51,12 @@ export function Dropdown({
           ) : (
             <div className="leading-6">{selectedOption.label}</div>
           )}
-          <ChevronDownIcon className="h-4 ml-5 pointer-events-none" />
+          <ChevronDownIcon className="pointer-events-none ml-5 h-4" />
         </Listbox.Button>
 
         <Listbox.Options
           as="div"
-          className="absolute w-full rounded-lg bg-white border border-slate-300 mt-1 leading-6 shadow-md focus:outline-none"
+          className="absolute mt-1 w-full rounded-lg border border-slate-300 bg-white leading-6 shadow-md focus:outline-none"
         >
           {options.map((option) => (
             <Listbox.Option
@@ -69,13 +69,13 @@ export function Dropdown({
                   className={`${
                     active ? 'bg-sky-500 text-white' : 'bg-white'
                   } ${selected && 'font-semibold'}
-                    select-none relative py-1 pl-8 pr-4 first:rounded-t-lg last:rounded-b-lg overflow-hidden cursor-pointer`}
+                    relative cursor-pointer select-none overflow-hidden py-1 pl-8 pr-4 first:rounded-t-lg last:rounded-b-lg`}
                 >
                   {selected && (
                     <CheckIcon
                       className={`${
                         active ? 'text-white' : 'text-sky-600'
-                      } h-4 absolute inset-y-0 left-2 my-auto pointer-events-none`}
+                      } pointer-events-none absolute inset-y-0 left-2 my-auto h-4`}
                     />
                   )}
                   {option.label}

--- a/libs/ui/src/lib/input-field/input-field.tsx
+++ b/libs/ui/src/lib/input-field/input-field.tsx
@@ -35,13 +35,13 @@ export function InputField({
     <label className="relative block">
       <span className="sr-only">{label}</span>
       {InputIcon ? (
-        <InputIcon className="absolute left-2 inset-y-0 my-auto w-4 h-4 fill-slate-600" />
+        <InputIcon className="absolute inset-y-0 left-2 my-auto h-4 w-4 fill-slate-600" />
       ) : null}
       <input
         {...props}
-        className={`text-sm text-slate-600 leading-6 placeholder:text-sm placeholder:text-slate-600 block bg-white border border-slate-300 w-full rounded-lg 
-        ${icon ? 'pl-8' : 'pl-3'} pr-2 h-10 leading-10
-        shadow-sm shadow-slate-900/16 focus:outline-none focus:ring focus:ring-sky-300/30 focus:border-sky-300 ${
+        className={`block w-full rounded-lg border border-slate-300 bg-white text-sm leading-6 text-slate-600 placeholder:text-sm placeholder:text-slate-600 
+        ${icon ? 'pl-8' : 'pl-3'} shadow-slate-900/16 h-10 pr-2
+        leading-10 shadow-sm focus:border-sky-300 focus:outline-none focus:ring focus:ring-sky-300/30 ${
           props.className || ''
         }`}
         onChange={composeEventHandlers(props.onChange, handleUserInput)}
@@ -54,7 +54,7 @@ export function InputField({
           }`}
           onClick={handleClear}
         >
-          <XIcon className="w-3 h-3 fill-slate-600" />
+          <XIcon className="h-3 w-3 fill-slate-600" />
         </button>
       ) : null}
     </label>

--- a/libs/ui/src/lib/tag/tag.tsx
+++ b/libs/ui/src/lib/tag/tag.tsx
@@ -8,11 +8,11 @@ export interface TagProps {
 export function Tag({ disabled, onClick, selected, value }: TagProps) {
   return (
     <button
-      className={`text-xs px-3 py-1 mr-2 mb-2 last:mr-0 border rounded-full hover:text-sky-700 focus:outline-none focus:ring focus:ring-sky-300/30 focus:border-sky-300 ${
+      className={`mr-2 mb-2 rounded-full border px-3 py-1 text-xs last:mr-0 hover:text-sky-700 focus:border-sky-300 focus:outline-none focus:ring focus:ring-sky-300/30 ${
         selected
-          ? 'border-sky-700 text-sky-700 bg-sky-100'
+          ? 'border-sky-700 bg-sky-100 text-sky-700'
           : disabled
-          ? 'border-slate-200 text-slate-400 pointer-events-none'
+          ? 'pointer-events-none border-slate-200 text-slate-400'
           : 'border-slate-300'
       }`}
       onClick={() => onClick && onClick()}

--- a/libs/ui/src/lib/tags/tags.tsx
+++ b/libs/ui/src/lib/tags/tags.tsx
@@ -11,7 +11,7 @@ function HiddenTagsTooltip({ items }: TagsProps) {
     <Tooltip.Provider delayDuration={0}>
       <Tooltip.Root>
         <Tooltip.Trigger>
-          <span className="flex items-center justify-center w-[26px] h-[26px] text-xs font-medium text-slate-600 rounded-full bg-slate-100 group">
+          <span className="group flex h-[26px] w-[26px] items-center justify-center rounded-full bg-slate-100 text-xs font-medium text-slate-600">
             +{items.length}
           </span>
         </Tooltip.Trigger>
@@ -19,7 +19,7 @@ function HiddenTagsTooltip({ items }: TagsProps) {
           side="top"
           align="center"
           sideOffset={8}
-          className="flex-shrink-0 bg-slate-900 rounded py-1 px-2 text-white text-xs font-medium min-w-[50px]"
+          className="min-w-[50px] flex-shrink-0 rounded bg-slate-900 py-1 px-2 text-xs font-medium text-white"
         >
           {items.toString()}
         </Tooltip.Content>
@@ -60,7 +60,7 @@ export function Tags({ items, isInline = true }: TagsProps) {
 
   return (
     <div
-      className={`flex items-start w-full ${
+      className={`flex w-full items-start ${
         isInline ? 'overflow-hidden' : 'flex-wrap'
       }`}
       ref={containerRef}
@@ -68,7 +68,7 @@ export function Tags({ items, isInline = true }: TagsProps) {
       {items.map((item, i) => (
         <span
           key={i}
-          className={`h-[26px] px-3 py-1.5 mr-2 text-xs font-medium text-slate-600 rounded-3xl bg-slate-100 whitespace-nowrap ${
+          className={`mr-2 h-[26px] whitespace-nowrap rounded-3xl bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-600 ${
             isInline && i >= hiddenStartIndex ? 'invisible' : 'visible mb-2'
           }`}
           style={{ order: i >= hiddenStartIndex ? i + 1 : i }}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "jest": "27.2.3",
     "nx": "13.9.7",
     "prettier": "^2.5.1",
+    "prettier-plugin-tailwindcss": "^0.1.11",
     "react-test-renderer": "17.0.2",
     "sass": "1.43.2",
     "semantic-release": "^19.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14749,6 +14749,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier-plugin-tailwindcss@^0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.11.tgz#6112da68d9d022b7f896d35c070464931c99c35f"
+  integrity sha512-a28+1jvpIZQdZ/W97wOXb6VqI762MKE/TxMMuibMEHhyYsSxQA8Ek30KObd5kJI2HF1ldtSYprFayXJXi3pz8Q==
+
 "prettier@>=2.2.1 <=2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"


### PR DESCRIPTION
## Description

🛠️  Add a Prettier plugin for automatically sorting TailwindCSS classes

More info on the plugin can be found [here](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier).

> **Warning**
> Every developer must run `yarn install` after fetching these changes for the plugin to take effect.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-65

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
