### PR TITLE
fix: no router instace found

### DIFF
--- a/apps/web-app/pages/teams/[id].tsx
+++ b/apps/web-app/pages/teams/[id].tsx
@@ -4,6 +4,7 @@ import { Breadcrumb, IBreadcrumbItem } from '@protocol-labs-network/ui';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { AskToEditLink } from '../../components/shared/ask-to-edit-link/ask-to-edit-link';
 import TeamProfileDetails from '../../components/teams/team-profile/team-profile-details/team-profile-details';
 import TeamProfileSidebar from '../../components/teams/team-profile/team-profile-sidebar/team-profile-sidebar';
@@ -21,10 +22,12 @@ export default function Team({ team, members, backLink }: TeamProps) {
     { label: team.name },
   ];
 
-  if (router.query.backLink) {
-    const { backLink, ...query } = router.query;
-    router.replace({ query }, undefined, { shallow: true });
-  }
+  useEffect(() => {
+    if (router.query.backLink) {
+      const { backLink, ...query } = router.query;
+      router.replace({ query }, undefined, { shallow: true });
+    }
+  }, [router]);
 
   return (
     <section className="mx-10 my-3">


### PR DESCRIPTION
## Description

🐛 Fix an error that arises when opening a team in a new tab
> "_Uncaught (in promise) Error: No router instance found. You should only use "next/router" inside the client-side of your app._"

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-84

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
