### PR TITLE
feat:(pl-95): adds a redirect on the initial page to teams

### DIFF
--- a/apps/web-app/pages/index.tsx
+++ b/apps/web-app/pages/index.tsx
@@ -1,16 +1,12 @@
-export function Index() {
-  /*
-   * Replace the elements below with your own.
-   *
-   * Note: The corresponding styles are in the ./index.scss file.
-   */
-  return (
-    <div>
-      <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">
-        Protocol Labs Network
-      </h1>
-    </div>
-  );
+export default function Index() {
+  return <div></div>;
 }
 
-export default Index;
+export const getServerSideProps = async () => {
+  return {
+    redirect: {
+      permanent: false,
+      destination: '/teams',
+    },
+  };
+};


### PR DESCRIPTION
## Description
Uses `getServerSideProps` to reinforce redirection from main page to teams directory

```
sources for this ticket:
https://stackoverflow.com/questions/69076301/next-js-getserversideprops-redirect-with-props
https://stackoverflow.com/questions/58173809/next-js-redirect-from-to-another-page
```

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-95

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
