### PR TITLE
feat(pl-136): replace skills on members cards by teams

### DIFF
--- a/apps/web-app/components/members/member-profile/member-profile-header.tsx
+++ b/apps/web-app/components/members/member-profile/member-profile-header.tsx
@@ -4,7 +4,6 @@ import { IMember } from '@protocol-labs-network/api';
 import Image from 'next/image';
 import { SocialLinks } from '../../shared/social-links/social-links';
 import { TagsGroup } from '../../shared/tags-group/tags-group';
-import { parseStringsIntoTagsGroupItems } from '../../shared/tags-group/tags-group.utils';
 
 interface MemberProfileHeaderProps {
   member: IMember;
@@ -46,7 +45,7 @@ export function MemberProfileHeader({ member }: MemberProfileHeaderProps) {
       <div className="px-7 py-6">
         <h3 className="mb-2 text-sm font-medium text-slate-400">Skills</h3>
         {member.skills.length ? (
-          <TagsGroup items={parseStringsIntoTagsGroupItems(member.skills)} />
+          <TagsGroup items={member.skills} />
         ) : (
           <div className="text-xs leading-7">-</div>
         )}

--- a/apps/web-app/components/shared/members/member-card/member-card.tsx
+++ b/apps/web-app/components/shared/members/member-card/member-card.tsx
@@ -6,18 +6,13 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { DirectoryCard } from '../../../../components/directory/directory-card/directory-card';
 import { SocialLinks } from '../../../../components/shared/social-links/social-links';
-import { TagsGroup } from '../../../shared/tags-group/tags-group';
-import { parseStringsIntoTagsGroupItems } from '../../../shared/tags-group/tags-group.utils';
-import { ITagsGroupItem } from '../../tags-group/tags-group';
+import { TagsGroup } from '../../tags-group/tags-group';
 
 interface MemberCardProps {
   isClickable?: boolean;
   isGrid?: boolean;
   member: IMember;
   showLocation?: boolean;
-  showSkills?: boolean;
-  showTeams?: boolean;
-  teamId?: string;
 }
 
 export function MemberCard({
@@ -25,9 +20,6 @@ export function MemberCard({
   isGrid = true,
   member,
   showLocation = false,
-  showSkills = false,
-  showTeams = true,
-  teamId,
 }: MemberCardProps) {
   const router = useRouter();
   const backLink = encodeURIComponent(router.asPath);
@@ -36,15 +28,7 @@ export function MemberCard({
       ? { href: `/members/${member.id}?backLink=${backLink}` }
       : {}),
   };
-  let memberTeamsTags: ITagsGroupItem[];
-
-  if (showTeams) {
-    memberTeamsTags = member.teams.map((team) => ({
-      url: `/teams/${team.id}`,
-      label: team.name,
-      disabled: teamId === team.id,
-    }));
-  }
+  const teamsNames = member.teams.map(({ name }) => name);
 
   return (
     <DirectoryCard isGrid={isGrid}>
@@ -85,30 +69,10 @@ export function MemberCard({
         </div>
       </AnchorLink>
 
-      {showTeams ? (
-        <div className={`${isGrid ? 'my-4' : 'mx-4 w-[348px] self-center'}`}>
-          <h4 className="mb-2 text-sm font-medium text-slate-500">Teams</h4>
-          <TagsGroup items={memberTeamsTags} isSingleLine={true} />
-        </div>
-      ) : null}
-
-      {showSkills ? (
-        <div
-          className={`text-slate-500 ${
-            isGrid ? 'mt-4 mb-2' : 'mx-4 w-[348px] self-center'
-          }`}
-        >
-          <h4 className="mb-2 text-sm font-medium">Skills</h4>
-          {member.skills.length ? (
-            <TagsGroup
-              items={parseStringsIntoTagsGroupItems(member.skills)}
-              isSingleLine={true}
-            />
-          ) : (
-            <div className="leading-7">-</div>
-          )}
-        </div>
-      ) : null}
+      <div className={`${isGrid ? 'my-4' : 'mx-4 w-[348px] self-center'}`}>
+        <h4 className="mb-2 text-sm font-medium text-slate-500">Teams</h4>
+        <TagsGroup items={teamsNames} isSingleLine={true} />
+      </div>
 
       <div
         className={`border-slate-200 ${

--- a/apps/web-app/components/shared/tags-group/hidden-tags-tooltip.tsx
+++ b/apps/web-app/components/shared/tags-group/hidden-tags-tooltip.tsx
@@ -1,9 +1,7 @@
 import { Tooltip } from '@protocol-labs-network/ui';
-import Link from 'next/link';
-import { ITagsGroupItem } from './tags-group';
 
 export interface HiddenTagsTooltipProps {
-  items: ITagsGroupItem[];
+  items: string[];
 }
 
 export function HiddenTagsTooltip({ items }: HiddenTagsTooltipProps) {
@@ -15,29 +13,14 @@ export function HiddenTagsTooltip({ items }: HiddenTagsTooltipProps) {
 
   return (
     <Tooltip Trigger={hiddenTagsTrigger}>
-      {items.map((item, i) =>
-        item?.url ? (
-          <Link key={i} href={item.url}>
-            <a
-              className={`${
-                item.disabled
-                  ? 'pointer-events-none'
-                  : 'hover:text-sky-700 focus:text-sky-700'
-              } block whitespace-nowrap
-                border-b border-slate-200 p-1 last:border-b-0`}
-            >
-              {item.label}
-            </a>
-          </Link>
-        ) : (
-          <span
-            key={i}
-            className="after:mr-1 after:content-[',']  last:after:content-['']"
-          >
-            {item.label}
-          </span>
-        )
-      )}
+      {items.map((item, i) => (
+        <span
+          key={i}
+          className="after:mr-1 after:content-[',']  last:after:content-['']"
+        >
+          {item}
+        </span>
+      ))}
     </Tooltip>
   );
 }

--- a/apps/web-app/components/shared/tags-group/tags-group.tsx
+++ b/apps/web-app/components/shared/tags-group/tags-group.tsx
@@ -1,20 +1,13 @@
-import Link from 'next/link';
 import { HiddenTagsTooltip } from './hidden-tags-tooltip';
 
-export interface ITagsGroupItem {
-  disabled?: boolean;
-  label: string;
-  url?: string;
-}
-
 export interface TagsGroupProps {
-  items: ITagsGroupItem[];
+  items: string[];
   isSingleLine?: boolean;
 }
 
 export function TagsGroup({ items, isSingleLine = false }: TagsGroupProps) {
-  let visibleTags: ITagsGroupItem[];
-  let hiddenTags: ITagsGroupItem[];
+  let visibleTags: string[];
+  let hiddenTags: string[];
 
   if (isSingleLine && items.length > 1) {
     visibleTags = [items[0]];
@@ -26,31 +19,14 @@ export function TagsGroup({ items, isSingleLine = false }: TagsGroupProps) {
       className={`flex w-full items-start ${!isSingleLine ? 'flex-wrap' : ''}`}
     >
       {(visibleTags || items).map((item, i) => {
-        if (item.url) {
-          return (
-            <Link key={i} href={item.url}>
-              <a
-                className={`tag ${!isSingleLine ? 'mb-2' : 'truncate'}
-                ${
-                  item.disabled
-                    ? 'pointer-events-none'
-                    : 'tag--clickable border border-slate-200 bg-white'
-                } `}
-              >
-                {item.label}
-              </a>
-            </Link>
-          );
-        } else {
-          return (
-            <span
-              key={i}
-              className={`tag ${!isSingleLine ? 'mb-2' : 'truncate'}`}
-            >
-              {item.label}
-            </span>
-          );
-        }
+        return (
+          <span
+            key={i}
+            className={`tag ${!isSingleLine ? 'mb-2' : 'truncate'}`}
+          >
+            {item}
+          </span>
+        );
       })}
 
       {hiddenTags ? <HiddenTagsTooltip items={hiddenTags} /> : null}

--- a/apps/web-app/components/shared/tags-group/tags-group.utils.ts
+++ b/apps/web-app/components/shared/tags-group/tags-group.utils.ts
@@ -1,3 +1,0 @@
-export function parseStringsIntoTagsGroupItems(arr: string[]) {
-  return arr.map((item) => ({ label: item }));
-}

--- a/apps/web-app/components/shared/teams/team-card/team-card.tsx
+++ b/apps/web-app/components/shared/teams/team-card/team-card.tsx
@@ -6,7 +6,6 @@ import { useRouter } from 'next/router';
 import { DirectoryCard } from '../../../directory/directory-card/directory-card';
 import { SocialLinks } from '../../social-links/social-links';
 import { TagsGroup } from '../../tags-group/tags-group';
-import { parseStringsIntoTagsGroupItems } from '../../tags-group/tags-group.utils';
 
 export interface TeamCardProps {
   isClickable?: boolean;
@@ -75,10 +74,7 @@ export function TeamCard({
         className={`h-[28px] ${isGrid ? 'my-4' : 'mx-4 w-[248px] self-center'}`}
       >
         {team.tags && team.tags.length ? (
-          <TagsGroup
-            isSingleLine
-            items={parseStringsIntoTagsGroupItems(team.tags)}
-          />
+          <TagsGroup isSingleLine items={team.tags} />
         ) : (
           <span className="text-xs leading-7 text-slate-400">
             Tags not provided

--- a/apps/web-app/components/teams/team-profile/team-profile-funding-stage/team-profile-funding-stage.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-funding-stage/team-profile-funding-stage.tsx
@@ -1,5 +1,4 @@
 import { TagsGroup } from '../../../shared/tags-group/tags-group';
-import { parseStringsIntoTagsGroupItems } from '../../../shared/tags-group/tags-group.utils';
 interface TeamProfileFundingStageProps {
   fundingStage?: string;
 }
@@ -14,7 +13,7 @@ export default function TeamProfileFundingStage({
       <h3 className="mb-3 text-sm font-semibold">Funding Stage</h3>
       <div>
         {hasFundingStage ? (
-          <TagsGroup items={parseStringsIntoTagsGroupItems([fundingStage])} />
+          <TagsGroup items={[fundingStage]} />
         ) : (
           'Not provided'
         )}

--- a/apps/web-app/components/teams/team-profile/team-profile-funding-vehicle/team-profile-funding-vehicle.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-funding-vehicle/team-profile-funding-vehicle.tsx
@@ -1,5 +1,4 @@
 import { TagsGroup } from '../../../shared/tags-group/tags-group';
-import { parseStringsIntoTagsGroupItems } from '../../../shared/tags-group/tags-group.utils';
 
 interface TeamProfileFundingVehicleProps {
   fundingVehicle?: string[];
@@ -15,7 +14,7 @@ export default function TeamProfileFundingVehicle({
       <h3 className="mb-3 text-sm font-semibold">Funding Vehicle</h3>
       <div>
         {hasFundingVehicles ? (
-          <TagsGroup items={parseStringsIntoTagsGroupItems(fundingVehicle)} />
+          <TagsGroup items={fundingVehicle} />
         ) : (
           'Not provided'
         )}

--- a/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
@@ -18,11 +18,7 @@ export default function TeamProfileMembers({
       <h3 className="mb-4 font-medium text-slate-500">Members</h3>
       <div className="flex flex-wrap gap-4">
         {members.map((member) => (
-          <MemberCard
-            key={`${id}.${member.id}`}
-            teamId={id as string}
-            member={member}
-          />
+          <MemberCard key={`${id}.${member.id}`} member={member} />
         ))}
       </div>
       <div className="mt-8 mb-20 text-sm text-slate-500">

--- a/apps/web-app/components/teams/team-profile/team-profile-sidebar/team-profile-sidebar.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-sidebar/team-profile-sidebar.tsx
@@ -3,7 +3,6 @@ import { ITeam } from '@protocol-labs-network/api';
 import Image from 'next/image';
 import { SocialLinks } from '../../../shared/social-links/social-links';
 import { TagsGroup } from '../../../shared/tags-group/tags-group';
-import { parseStringsIntoTagsGroupItems } from '../../../shared/tags-group/tags-group.utils';
 
 interface TeamProfileSidebarProps {
   team: ITeam;
@@ -43,7 +42,7 @@ export default function TeamProfileSidebar({ team }: TeamProfileSidebarProps) {
       <div>{team.shortDescription || 'Not provided'}</div>
       <div>
         {team.tags && team.tags.length ? (
-          <TagsGroup items={parseStringsIntoTagsGroupItems(team.tags)} />
+          <TagsGroup items={team.tags} />
         ) : (
           'Tags not provided'
         )}

--- a/apps/web-app/pages/members/index.tsx
+++ b/apps/web-app/pages/members/index.tsx
@@ -45,8 +45,6 @@ export default function Members({ members, filtersValues }: MembersProps) {
                   isClickable
                   isGrid={isGrid}
                   showLocation
-                  showSkills
-                  showTeams={false}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Description

🚀 All member cards must show tags of the teams they belong to;

> It also removes the no longer needed function like `parseStringsIntoTagsGroupItems` and code used to make tags clickable on cards


## Tickets
- https://pixelmatters.atlassian.net/browse/PL-136

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
