### PR TITLE
refactor(pl-132): freeze teams filters sidebar

### DIFF
--- a/apps/web-app/components/directory/directory-filters/directory-filters.tsx
+++ b/apps/web-app/components/directory/directory-filters/directory-filters.tsx
@@ -21,7 +21,7 @@ export function DirectoryFilters({
 
   return (
     <>
-      <div className="flex justify-between border-b border-b-slate-200 p-5">
+      <div className="relative flex justify-between bg-white p-5 before:absolute before:left-0 before:bottom-[-0.2rem] before:h-1 before:w-full before:border-t after:absolute after:bottom-[-2.25rem] after:left-0 after:h-9 after:w-[calc(100%_-_1.23rem)] after:bg-gradient-to-b after:from-white">
         <span className="text-lg font-semibold leading-7">Filters</span>
         <button
           className="text-xs text-sky-600 transition-colors hover:text-sky-500"
@@ -30,7 +30,10 @@ export function DirectoryFilters({
           Clear all
         </button>
       </div>
-      <div className="p-5">{children}</div>
+
+      <div className="h-[calc(100vh_-_159px)] overflow-y-auto p-5">
+        {children}
+      </div>
     </>
   );
 }

--- a/apps/web-app/pages/teams/index.tsx
+++ b/apps/web-app/pages/teams/index.tsx
@@ -26,11 +26,11 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
       </Head>
 
       <section className="flex">
-        <div className="w-[291px] flex-shrink-0 border-r border-r-slate-200 bg-white">
+        <div className="fixed w-[291px] flex-shrink-0 border-r border-r-slate-200 bg-white">
           <TeamsDirectoryFilters filtersValues={filtersValues} />
         </div>
 
-        <div className="mx-auto p-8">
+        <div className="mx-auto p-8 pl-[291px]">
           <div className="w-[917px] space-y-10">
             <DirectoryHeader
               title="Teams"


### PR DESCRIPTION
## Description

♺ Updates teams filters sidebar to freeze on the left of the page;

**note:** This PR should be merged only after [PR-85]( https://github.com/Pixelmatters/protocol-labs-network/pull/85)

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-132

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
