### PR TITLE
refactor: move directories headers into a reusable component

### DIFF
--- a/apps/web-app/components/directory/directory-header/directory-header.tsx
+++ b/apps/web-app/components/directory/directory-header/directory-header.tsx
@@ -1,0 +1,25 @@
+import { DirectorySearch } from '../../../components/directory/directory-search/directory-search';
+import { DirectorySort } from '../../../components/directory/directory-sort/directory-sort';
+import { DirectoryView } from '../../../components/directory/directory-view/directory-view';
+
+type DirectoryHeaderProps = {
+  searchPlaceholder: string;
+  title: string;
+};
+
+export function DirectoryHeader({
+  searchPlaceholder,
+  title,
+}: DirectoryHeaderProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <h1 className="text-3xl font-bold">{title}</h1>
+      <div className="flex items-center space-x-4">
+        <DirectorySearch placeholder={searchPlaceholder} />
+        <span className="h-6 w-px bg-slate-300" />
+        <DirectorySort />
+        <DirectoryView />
+      </div>
+    </div>
+  );
+}

--- a/apps/web-app/pages/members/index.tsx
+++ b/apps/web-app/pages/members/index.tsx
@@ -2,9 +2,7 @@ import airtableService from '@protocol-labs-network/airtable';
 import { IMember } from '@protocol-labs-network/api';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { DirectorySearch } from '../../components/directory/directory-search/directory-search';
-import { DirectorySort } from '../../components/directory/directory-sort/directory-sort';
-import { DirectoryView } from '../../components/directory/directory-view/directory-view';
+import { DirectoryHeader } from '../../components/directory/directory-header/directory-header';
 import { useViewType } from '../../components/directory/directory-view/use-directory-view-type.hook';
 import { MembersDirectoryFilters } from '../../components/members/members-directory/members-directory-filters/members-directory-filters';
 import { IMembersFiltersValues } from '../../components/members/members-directory/members-directory-filters/members-directory-filters.types';
@@ -33,16 +31,11 @@ export default function Members({ members, filtersValues }: MembersProps) {
         </div>
 
         <div className="mx-auto p-8">
-          <div className="w-[917px] flex-shrink-0">
-            <div className="mb-10 flex items-center justify-between">
-              <h1 className="text-3xl font-bold">Members</h1>
-              <div className="flex items-center space-x-4">
-                <DirectorySearch placeholder="Search for a member" />
-                <span className="h-6 w-px bg-slate-300" />
-                <DirectorySort />
-                <DirectoryView />
-              </div>
-            </div>
+          <div className="w-[917px] space-y-10">
+            <DirectoryHeader
+              title="Members"
+              searchPlaceholder="Search for a member"
+            />
 
             <div className="flex flex-wrap gap-4">
               {members.map((member) => (
@@ -58,7 +51,7 @@ export default function Members({ members, filtersValues }: MembersProps) {
               ))}
             </div>
 
-            <div className="mt-8 text-sm text-slate-500">
+            <div className="text-sm text-slate-500">
               Showing <b>{members.length}</b> results
             </div>
           </div>

--- a/apps/web-app/pages/teams/index.tsx
+++ b/apps/web-app/pages/teams/index.tsx
@@ -2,9 +2,7 @@ import airtableService from '@protocol-labs-network/airtable';
 import { ITeam } from '@protocol-labs-network/api';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { DirectorySearch } from '../../components/directory/directory-search/directory-search';
-import { DirectorySort } from '../../components/directory/directory-sort/directory-sort';
-import { DirectoryView } from '../../components/directory/directory-view/directory-view';
+import { DirectoryHeader } from '../../components/directory/directory-header/directory-header';
 import { useViewType } from '../../components/directory/directory-view/use-directory-view-type.hook';
 import { TeamCard } from '../../components/shared/teams/team-card/team-card';
 import { TeamsDirectoryFilters } from '../../components/teams/teams-directory/teams-directory-filters/teams-directory-filters';
@@ -33,16 +31,11 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
         </div>
 
         <div className="mx-auto p-8">
-          <div className="w-[917px] flex-shrink-0">
-            <div className="mb-10 flex items-center justify-between">
-              <h1 className="text-3xl font-bold">Teams</h1>
-              <div className="flex items-center space-x-4">
-                <DirectorySearch placeholder="Search for a team" />
-                <span className="h-6 w-px bg-slate-300" />
-                <DirectorySort />
-                <DirectoryView />
-              </div>
-            </div>
+          <div className="w-[917px] space-y-10">
+            <DirectoryHeader
+              title="Teams"
+              searchPlaceholder="Search for a team"
+            />
 
             <div className="flex flex-wrap gap-4">
               {teams.map((team) => {
@@ -57,7 +50,7 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
               })}
             </div>
 
-            <div className="mt-8 text-sm text-slate-500">
+            <div className="text-sm text-slate-500">
               Showing <b>{teams.length}</b> results
             </div>
           </div>


### PR DESCRIPTION
## Description

♺ Move directories headers into their own reusable component

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-114

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
