### PR TITLE
refactor(pl-136): update requests to get member teams

### DIFF
--- a/apps/web-app/components/shared/members/member-card/member-card.constants.ts
+++ b/apps/web-app/components/shared/members/member-card/member-card.constants.ts
@@ -3,6 +3,7 @@ export const MEMBER_CARD_FIELDS = [
   'Profile picture',
   'Role',
   'Teams',
+  'Team name',
   'Country',
   'State / Province',
   'City',

--- a/apps/web-app/components/shared/members/member-card/member-card.tsx
+++ b/apps/web-app/components/shared/members/member-card/member-card.tsx
@@ -1,6 +1,6 @@
 import { LocationMarkerIcon } from '@heroicons/react/outline';
 import { UserIcon } from '@heroicons/react/solid';
-import { IMember, IMemberWithTeams } from '@protocol-labs-network/api';
+import { IMember } from '@protocol-labs-network/api';
 import { AnchorLink } from '@protocol-labs-network/ui';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -13,7 +13,7 @@ import { ITagsGroupItem } from '../../tags-group/tags-group';
 interface MemberCardProps {
   isClickable?: boolean;
   isGrid?: boolean;
-  member: IMember | IMemberWithTeams;
+  member: IMember;
   showLocation?: boolean;
   showSkills?: boolean;
   showTeams?: boolean;
@@ -39,10 +39,10 @@ export function MemberCard({
   let memberTeamsTags: ITagsGroupItem[];
 
   if (showTeams) {
-    memberTeamsTags = Object.keys(member.teams).map((memberTeamId) => ({
-      url: `/teams/${memberTeamId}`,
-      label: member.teams[memberTeamId],
-      disabled: teamId === memberTeamId,
+    memberTeamsTags = member.teams.map((team) => ({
+      url: `/teams/${team.id}`,
+      label: team.name,
+      disabled: teamId === team.id,
     }));
   }
 

--- a/apps/web-app/components/teams/team-profile/team-profile-details/team-profile-details.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-details/team-profile-details.tsx
@@ -1,4 +1,4 @@
-import { IMemberWithTeams, ITeam } from '@protocol-labs-network/api';
+import { IMember, ITeam } from '@protocol-labs-network/api';
 import TeamProfileDescription from '../team-profile-description/team-profile-description';
 import TeamProfileFundingStage from '../team-profile-funding-stage/team-profile-funding-stage';
 import TeamProfileFundingVehicle from '../team-profile-funding-vehicle/team-profile-funding-vehicle';
@@ -6,7 +6,7 @@ import TeamProfileMembers from '../team-profile-members/team-profile-members';
 
 interface TeamProfileDetailsProps {
   team: ITeam;
-  members: IMemberWithTeams[];
+  members: IMember[];
 }
 
 export default function TeamProfileDetails({

--- a/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
@@ -1,9 +1,9 @@
-import { IMemberWithTeams } from '@protocol-labs-network/api';
+import { IMember } from '@protocol-labs-network/api';
 import { useRouter } from 'next/router';
 import { MemberCard } from '../../../shared/members/member-card/member-card';
 
 interface TeamProfileMembersProps {
-  members: IMemberWithTeams[];
+  members: IMember[];
 }
 
 export default function TeamProfileMembers({

--- a/apps/web-app/pages/teams/[id].tsx
+++ b/apps/web-app/pages/teams/[id].tsx
@@ -1,5 +1,5 @@
 import airtableService from '@protocol-labs-network/airtable';
-import { IMemberWithTeams, ITeam } from '@protocol-labs-network/api';
+import { IMember, ITeam } from '@protocol-labs-network/api';
 import { Breadcrumb } from '@protocol-labs-network/ui';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
@@ -11,7 +11,7 @@ import { useProfileBreadcrumb } from '../../hooks/profile/use-profile-breadcrumb
 
 interface TeamProps {
   team: ITeam;
-  members: IMemberWithTeams[];
+  members: IMember[];
   backLink: string;
 }
 

--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -52,6 +52,7 @@ const memberMock01: IAirtableMember = {
     'Office hours link': 'https://calendly.com/protoadin',
     'Team lead': true,
     Teams: ['team_id_01'],
+    'Team name': ['team 01'],
     Role: 'CEO',
     Location: 'Seattle, WA',
     Email: 'aarsh.shah@protocol.ai',
@@ -272,7 +273,10 @@ describe('AirtableService', () => {
     });
 
     const teams = await airtableService.getTeamCardsData(
-      ['team_id_01', 'team_id_02'],
+      [
+        { id: 'team_id_01', name: 'team 01' },
+        { id: 'team_id_02', name: 'team 02' },
+      ],
       ['Name']
     );
 
@@ -446,7 +450,12 @@ describe('AirtableService', () => {
         officeHours: memberMock01.fields['Office hours link'],
         role: memberMock01.fields.Role,
         skills: [memberMock01.fields.Skills?.[0]],
-        teams: memberMock01.fields.Teams,
+        teams: [
+          {
+            id: memberMock01.fields.Teams?.[0],
+            name: memberMock01.fields['Team name']?.[0],
+          },
+        ],
         twitter: memberMock01.fields.Twitter,
       },
       {
@@ -531,7 +540,12 @@ describe('AirtableService', () => {
       officeHours: memberMock01.fields['Office hours link'],
       role: memberMock01.fields.Role,
       skills: [memberMock01.fields.Skills?.[0]],
-      teams: memberMock01.fields.Teams,
+      teams: [
+        {
+          id: memberMock01.fields.Teams?.[0],
+          name: memberMock01.fields['Team name']?.[0],
+        },
+      ],
       twitter: memberMock01.fields.Twitter,
     });
   });
@@ -628,6 +642,7 @@ describe('AirtableService', () => {
               },
             ],
             Teams: ['team_id_01', 'team_id_02'],
+            'Team name': ['team 01', 'team 02'],
             Role: 'CEO',
             Email: 'aarsh.shah@protocol.ai',
             Twitter: '@member01',
@@ -648,6 +663,7 @@ describe('AirtableService', () => {
               },
             ],
             Teams: ['team_id_03'],
+            'Team name': ['team 03'],
             Role: 'CEO',
             Email: 'dan.shah@protocol.ai',
             Twitter: '@member01',
@@ -667,6 +683,7 @@ describe('AirtableService', () => {
               },
             ],
             Teams: ['team_id_02', 'team_id_01'],
+            'Team name': ['team 02', 'team 01'],
             Role: 'CEO',
             Email: 'shah@protocol.ai',
             Twitter: '@member03',
@@ -706,20 +723,16 @@ describe('AirtableService', () => {
       ]),
     });
 
-    const members = await airtableService.getTeamMembers('Team 01', ['Name']);
+    const members = await airtableService.getTeamMembers('team_id_01', [
+      'Name',
+    ]);
 
     expect(membersTableMock.select).toHaveBeenCalledTimes(1);
+
     expect(membersTableMock.select).toHaveBeenCalledWith({
-      filterByFormula: 'SEARCH("Team 01",Teams)',
+      filterByFormula: 'SEARCH("team_id_01",Teams)',
       fields: ['Name'],
       sort: [{ field: 'Name', direction: 'asc' }],
-    });
-
-    expect(teamsTableMock.select).toHaveBeenCalledTimes(1);
-    expect(teamsTableMock.select).toHaveBeenCalledWith({
-      filterByFormula:
-        "AND(AND({Name} != \"\", {Short description} != \"\"), OR(RECORD_ID()='team_id_01', RECORD_ID()='team_id_02', RECORD_ID()='team_id_03'))",
-      fields: ['Name'],
     });
 
     expect(members).toStrictEqual([
@@ -736,7 +749,10 @@ describe('AirtableService', () => {
         officeHours: 'https://calendly.com/protoadin',
         role: 'CEO',
         skills: [],
-        teams: { team_id_01: 'Team 01', team_id_02: 'Team 02' },
+        teams: [
+          { id: 'team_id_01', name: 'team 01' },
+          { id: 'team_id_02', name: 'team 02' },
+        ],
         twitter: '@member01',
       },
       {
@@ -751,7 +767,7 @@ describe('AirtableService', () => {
         officeHours: null,
         role: 'CEO',
         skills: [],
-        teams: { team_id_03: 'Team 03' },
+        teams: [{ id: 'team_id_03', name: 'team 03' }],
         twitter: '@member01',
       },
       {
@@ -767,7 +783,10 @@ describe('AirtableService', () => {
         officeHours: null,
         role: 'CEO',
         skills: [],
-        teams: { team_id_01: 'Team 01', team_id_02: 'Team 02' },
+        teams: [
+          { id: 'team_id_02', name: 'team 02' },
+          { id: 'team_id_01', name: 'team 01' },
+        ],
         twitter: '@member03',
       },
     ]);

--- a/libs/airtable/src/models/member.ts
+++ b/libs/airtable/src/models/member.ts
@@ -36,6 +36,7 @@ export interface IAirtableMemberFields {
   'Metro Area'?: string;
   'Location backup'?: string;
   'Friend of PLN'?: boolean;
+  'Team name'?: string[];
 }
 
 export interface IAirtableMemberPicture {

--- a/libs/api/src/members.ts
+++ b/libs/api/src/members.ts
@@ -9,11 +9,12 @@ export interface IMember {
   name: string | null;
   role: string | null;
   skills: string[];
-  teams: string[];
+  teams: IMemberTeam[];
   twitter: string | null;
   officeHours: string | null;
 }
 
-export interface IMemberWithTeams extends Omit<IMember, 'teams'> {
-  teams: { [teamId: string]: string };
+export interface IMemberTeam {
+  id: string;
+  name: string;
 }


### PR DESCRIPTION
## Description
There is a new column on airtable called 'Team Name', in order to remove unnecessary requests from pages where we show members. 
Now each member has a new property teams ```{id: string;name: string;}[]```instead of an id `string[]`
> therefore it removes that extra request to the teams table to get the name referring to id X
## Tickets

- https://pixelmatters.atlassian.net/browse/PL-136

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
