### PR TITLE
refactor(pl-138): fetch and use tags instead of industry

### DIFF
--- a/apps/web-app/components/directory/directory-filters/directory-filters.spec.tsx
+++ b/apps/web-app/components/directory/directory-filters/directory-filters.spec.tsx
@@ -11,14 +11,14 @@ describe('DirectoryFilters', () => {
       <RouterContext.Provider
         value={createMockRouter({
           query: {
-            industry: 'industry_01',
+            tags: 'tag_01',
             fundingVehicle: 'funding_vehicle_01',
             sort: 'Name,desc',
           },
           push,
         })}
       >
-        <DirectoryFilters filterProperties={['industry', 'fundingVehicle']}>
+        <DirectoryFilters filterProperties={['tags', 'fundingVehicle']}>
           <div></div>
         </DirectoryFilters>
       </RouterContext.Provider>

--- a/apps/web-app/components/directory/directory-sort/directory-sort.spec.tsx
+++ b/apps/web-app/components/directory/directory-sort/directory-sort.spec.tsx
@@ -74,7 +74,7 @@ describe('DirectorySort', () => {
         <RouterContext.Provider
           value={createMockRouter({
             push,
-            query: { sort: 'Name,desc', industry: 'SEO' },
+            query: { sort: 'Name,desc', tags: 'SEO' },
           })}
         >
           <DirectorySort />
@@ -90,7 +90,7 @@ describe('DirectorySort', () => {
       expect(push).toHaveBeenCalledTimes(1);
       expect(push).toHaveBeenCalledWith({
         pathname: '/',
-        query: { industry: 'SEO' },
+        query: { tags: 'SEO' },
       });
     });
   });

--- a/apps/web-app/components/shared/teams/team-card/team-card.constants.ts
+++ b/apps/web-app/components/shared/teams/team-card/team-card.constants.ts
@@ -2,7 +2,7 @@ export const TEAM_CARD_FIELDS = [
   'Name',
   'Logo',
   'Short description',
-  'Industry',
+  'Tags lookup',
   'Website',
   'Twitter',
 ];

--- a/apps/web-app/components/shared/teams/team-card/team-card.tsx
+++ b/apps/web-app/components/shared/teams/team-card/team-card.tsx
@@ -72,14 +72,14 @@ export function TeamCard({
       <div
         className={`h-[28px] ${isGrid ? 'my-4' : 'mx-4 w-[248px] self-center'}`}
       >
-        {team.industry && team.industry.length ? (
+        {team.tags && team.tags.length ? (
           <TagsGroup
             isSingleLine
-            items={parseStringsIntoTagsGroupItems(team.industry)}
+            items={parseStringsIntoTagsGroupItems(team.tags)}
           />
         ) : (
           <span className="text-xs leading-7 text-slate-400">
-            Industry not provided
+            Tags not provided
           </span>
         )}
       </div>

--- a/apps/web-app/components/teams/team-profile/team-profile-sidebar/team-profile-sidebar.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-sidebar/team-profile-sidebar.tsx
@@ -39,10 +39,10 @@ export default function TeamProfileSidebar({ team }: TeamProfileSidebarProps) {
       </div>
       <div>{team.shortDescription || 'Not provided'}</div>
       <div>
-        {team.industry && team.industry.length ? (
-          <TagsGroup items={parseStringsIntoTagsGroupItems(team.industry)} />
+        {team.tags && team.tags.length ? (
+          <TagsGroup items={parseStringsIntoTagsGroupItems(team.tags)} />
         ) : (
-          'Industry not provided'
+          'Tags not provided'
         )}
       </div>
       <div className="border-t border-slate-200 pt-4">

--- a/apps/web-app/components/teams/teams-directory/teams-directory-filters/tags-filter/tags-filter.spec.tsx
+++ b/apps/web-app/components/teams/teams-directory/teams-directory-filters/tags-filter/tags-filter.spec.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 import { createMockRouter } from '../../../../../utils/test/createMockRouter';
 import { IFilterTag } from '../../../../directory/directory-filters/directory-tags-filter/directory-tags-filter.types';
-import { IndustryFilter } from './industry-filter';
+import { TagsFilter } from './tags-filter';
 
 const tags: IFilterTag[] = [
   {
@@ -17,13 +17,13 @@ const tags: IFilterTag[] = [
   },
 ];
 
-describe('IndustryFilter', () => {
+describe('TagsFilter', () => {
   it('should call the router push method with the selected options when a tag gets clicked', () => {
     const push = jest.fn();
 
     render(
       <RouterContext.Provider value={createMockRouter({ push, query: {} })}>
-        <IndustryFilter industryTags={tags} />
+        <TagsFilter tagsTags={tags} />
       </RouterContext.Provider>
     );
 
@@ -33,7 +33,7 @@ describe('IndustryFilter', () => {
     expect(push).toHaveBeenCalledTimes(1);
     expect(push).toHaveBeenCalledWith({
       pathname: '/',
-      query: { industry: 'Tag 01' },
+      query: { tags: 'Tag 01' },
     });
   });
 });

--- a/apps/web-app/components/teams/teams-directory/teams-directory-filters/tags-filter/tags-filter.tsx
+++ b/apps/web-app/components/teams/teams-directory/teams-directory-filters/tags-filter/tags-filter.tsx
@@ -2,14 +2,14 @@ import { DirectoryTagsFilter } from '../../../../directory/directory-filters/dir
 import { IFilterTag } from '../../../../directory/directory-filters/directory-tags-filter/directory-tags-filter.types';
 import { useTagsFilter } from '../../../../directory/directory-filters/directory-tags-filter/use-tags-filter.hook';
 
-export interface IndustryFilterProps {
-  industryTags: IFilterTag[];
+export interface TagsFilterProps {
+  tagsTags: IFilterTag[];
 }
 
-export function IndustryFilter({ industryTags }: IndustryFilterProps) {
-  const [tags, toggleTag] = useTagsFilter('industry', industryTags);
+export function TagsFilter({ tagsTags }: TagsFilterProps) {
+  const [tags, toggleTag] = useTagsFilter('tags', tagsTags);
 
   return (
-    <DirectoryTagsFilter title="Industry" tags={tags} onTagToggle={toggleTag} />
+    <DirectoryTagsFilter title="Tags" tags={tags} onTagToggle={toggleTag} />
   );
 }

--- a/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.tsx
+++ b/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.tsx
@@ -1,7 +1,7 @@
 import { DirectoryFilters } from '../../../directory/directory-filters/directory-filters';
 import { FundingStageFilter } from './funding-stage-filter/funding-stage-filter';
 import { FundingVehicleFilter } from './funding-vehicle-filter/funding-vehicle-filter';
-import { IndustryFilter } from './industry-filter/industry-filter';
+import { TagsFilter } from './tags-filter/tags-filter';
 import { ITeamsFiltersValues } from './teams-directory-filters.types';
 import { TechnologyFilter } from './technology-filter/technology-filter';
 
@@ -15,13 +15,13 @@ export function TeamsDirectoryFilters({
   return (
     <DirectoryFilters
       filterProperties={[
-        'industry',
+        'tags',
         'fundingStage',
         'fundingVehicle',
         'technology',
       ]}
     >
-      <IndustryFilter industryTags={filtersValues.industry} />
+      <TagsFilter tagsTags={filtersValues.tags} />
       <div className="my-5 h-px bg-slate-200" />
       <FundingVehicleFilter fundingVehicleTags={filtersValues.fundingVehicle} />
       <div className="my-5 h-px bg-slate-200" />

--- a/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.types.ts
+++ b/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.types.ts
@@ -3,6 +3,6 @@ import { IFilterTag } from '../../../directory/directory-filters/directory-tags-
 export interface ITeamsFiltersValues {
   fundingStage: IFilterTag[];
   fundingVehicle: IFilterTag[];
-  industry: IFilterTag[];
+  tags: IFilterTag[];
   technology: IFilterTag[];
 }

--- a/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.utils.spec.ts
+++ b/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.utils.spec.ts
@@ -6,7 +6,7 @@ describe('#parseTeamsFilters', () => {
       parseTeamsFilters(
         {
           valuesByFilter: {
-            industry: ['Industry 01', 'Industry 02', 'Industry 03'],
+            tags: ['Tag 01', 'Tag 02', 'Tag 03'],
             fundingVehicle: [
               'Funding Vehicle 01',
               'Funding Vehicle 02',
@@ -20,22 +20,22 @@ describe('#parseTeamsFilters', () => {
             technology: ['Filecoin', 'IPFS'],
           },
           availableValuesByFilter: {
-            industry: ['Industry 01', 'Industry 03'],
+            tags: ['Tag 01', 'Tag 03'],
             fundingVehicle: ['Funding Vehicle 01', 'Funding Vehicle 03'],
             fundingStage: ['Funding Stage 01', 'Funding Stage 02'],
             technology: ['Filecoin'],
           },
         },
         {
-          industry: 'Industry 01',
+          tags: 'Tag 01',
           technology: 'Filecoin',
         }
       )
     ).toEqual({
-      industry: [
-        { value: 'Industry 01', selected: true, disabled: false },
-        { value: 'Industry 02', selected: false, disabled: true },
-        { value: 'Industry 03', selected: false, disabled: false },
+      tags: [
+        { value: 'Tag 01', selected: true, disabled: false },
+        { value: 'Tag 02', selected: false, disabled: true },
+        { value: 'Tag 03', selected: false, disabled: false },
       ],
       fundingVehicle: [
         { value: 'Funding Vehicle 01', selected: false, disabled: false },

--- a/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.utils.ts
+++ b/apps/web-app/components/teams/teams-directory/teams-directory-filters/teams-directory-filters.utils.ts
@@ -14,10 +14,10 @@ export function parseTeamsFilters(
   query: ParsedUrlQuery
 ): ITeamsFiltersValues {
   return {
-    industry: getTagsFromValues(
-      filtersValues.valuesByFilter.industry,
-      filtersValues.availableValuesByFilter.industry,
-      query.industry
+    tags: getTagsFromValues(
+      filtersValues.valuesByFilter.tags,
+      filtersValues.availableValuesByFilter.tags,
+      query.tags
     ),
     fundingVehicle: getTagsFromValues(
       filtersValues.valuesByFilter.fundingVehicle,

--- a/apps/web-app/tests/utils/api/list.utils.spec.ts
+++ b/apps/web-app/tests/utils/api/list.utils.spec.ts
@@ -10,7 +10,7 @@ describe('#getTeamsDirectoryRequestOptionsFromQuery', () => {
     expect(
       getTeamsDirectoryRequestOptionsFromQuery({
         sort: 'Name,desc',
-        industry: 'Analytics',
+        tags: 'Analytics',
         fundingStage: 'Seed',
         fundingVehicle: 'IPFS',
         searchBy: 'void',
@@ -20,7 +20,7 @@ describe('#getTeamsDirectoryRequestOptionsFromQuery', () => {
       fields: TEAM_CARD_FIELDS,
       sort: [{ field: 'Name', direction: 'desc' }],
       filterByFormula:
-        'AND({Name} != "", {Short description} != "", REGEX_MATCH({Name}, "(?i)^(void)"), SEARCH("Analytics", {Industry}), SEARCH("IPFS", {Funding Vehicle}), SEARCH("Seed", {Funding Stage}), {IPFS User} = TRUE())',
+        'AND({Name} != "", {Short description} != "", REGEX_MATCH({Name}, "(?i)^(void)"), SEARCH("Analytics", ARRAYJOIN({Tags lookup})), SEARCH("IPFS", {Funding Vehicle}), SEARCH("Seed", {Funding Stage}), {IPFS User} = TRUE())',
     });
   });
 
@@ -39,7 +39,7 @@ describe('#getTeamsDirectoryRequestOptionsFromQuery', () => {
   it('should return valid options when sort is not provided', () => {
     expect(
       getTeamsDirectoryRequestOptionsFromQuery({
-        industry: 'Analytics',
+        tags: 'Analytics',
         fundingStage: 'Seed',
         fundingVehicle: 'IPFS',
         searchBy: 'void',
@@ -49,7 +49,7 @@ describe('#getTeamsDirectoryRequestOptionsFromQuery', () => {
       fields: TEAM_CARD_FIELDS,
       sort: [{ field: 'Name', direction: 'asc' }],
       filterByFormula:
-        'AND({Name} != "", {Short description} != "", REGEX_MATCH({Name}, "(?i)^(void)"), SEARCH("Analytics", {Industry}), SEARCH("IPFS", {Funding Vehicle}), SEARCH("Seed", {Funding Stage}), {IPFS User} = TRUE(), {Filecoin User} = TRUE())',
+        'AND({Name} != "", {Short description} != "", REGEX_MATCH({Name}, "(?i)^(void)"), SEARCH("Analytics", ARRAYJOIN({Tags lookup})), SEARCH("IPFS", {Funding Vehicle}), SEARCH("Seed", {Funding Stage}), {IPFS User} = TRUE(), {Filecoin User} = TRUE())',
     });
   });
 });

--- a/apps/web-app/utils/api/list.utils.ts
+++ b/apps/web-app/utils/api/list.utils.ts
@@ -15,14 +15,14 @@ import { URL_QUERY_VALUE_SEPARATOR } from '../../constants';
 export function getTeamsDirectoryRequestOptionsFromQuery(
   queryParams: ParsedUrlQuery
 ): IListOptions {
-  const { sort, industry, fundingVehicle, fundingStage, searchBy, technology } =
+  const { sort, tags, fundingVehicle, fundingStage, searchBy, technology } =
     queryParams;
 
   return {
     fields: TEAM_CARD_FIELDS,
     sort: [getSortFromQuery(sort?.toString())],
     filterByFormula: getTeamsDirectoryFormula({
-      industry,
+      tags,
       fundingVehicle,
       fundingStage,
       searchBy,
@@ -79,7 +79,7 @@ function isSortValid(sortQuery?: string) {
  * Get formula for teams directory filtering.
  */
 function getTeamsDirectoryFormula({
-  industry,
+  tags,
   fundingVehicle,
   fundingStage,
   searchBy,
@@ -93,7 +93,7 @@ function getTeamsDirectoryFormula({
       '{Name} != ""',
       '{Short description} != ""',
       ...(searchBy ? [getSearchFormulaFromQuery(searchBy)] : []),
-      ...(industry ? [getFieldFromQuery('Industry', industry)] : []),
+      ...(tags ? [getFieldFromQuery('Tags lookup', tags, true)] : []),
       ...(fundingVehicle
         ? [getFieldFromQuery('Funding Vehicle', fundingVehicle)]
         : []),
@@ -148,13 +148,17 @@ function getSearchFormulaFromQuery(searchQuery: string | string[] = '') {
  */
 function getFieldFromQuery(
   fieldName: string,
-  queryValue: string | string[] = []
+  queryValue: string | string[] = [],
+  isLookupField = false
 ) {
   const values = Array.isArray(queryValue)
     ? queryValue
     : queryValue.split(URL_QUERY_VALUE_SEPARATOR);
+  const whereToSearch = isLookupField
+    ? `ARRAYJOIN({${fieldName}})`
+    : `{${fieldName}}`;
   const valuesFormulas = values.map(
-    (value) => `SEARCH("${value}", {${fieldName}})`
+    (value) => `SEARCH("${value}", ${whereToSearch})`
   );
 
   return valuesFormulas.join(', ');

--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -9,7 +9,7 @@ const teamMock: IAirtableTeam = {
     'Funding Vehicle': ['Seed'],
     'Network members': ['member_id_01'],
     Logo: [{ id: 'team_logo_01', url: 'http://team01.com/logo.svg' }],
-    Industry: ['IT'],
+    'Tags lookup': ['IT'],
     'Last Audited': new Date('28/02/1904'),
     Notes: 'Some notes.',
     'Last Modified': new Date('28/02/1904'),
@@ -175,7 +175,7 @@ describe('AirtableService', () => {
         fundingStage: teamMock.fields['Funding Stage'],
         fundingVehicle: teamMock.fields['Funding Vehicle'],
         id: teamMock.id,
-        industry: teamMock.fields.Industry,
+        tags: teamMock.fields['Tags lookup'],
         ipfsUser: teamMock.fields['IPFS User'],
         members: teamMock.fields['Network members'],
         logo: teamMock.fields.Logo?.[0].url,
@@ -190,7 +190,7 @@ describe('AirtableService', () => {
         fundingStage: null,
         fundingVehicle: [],
         id: emptyTeamMock.id,
-        industry: [],
+        tags: [],
         ipfsUser: false,
         members: [],
         logo: null,
@@ -215,7 +215,7 @@ describe('AirtableService', () => {
       fundingStage: teamMock.fields['Funding Stage'],
       fundingVehicle: teamMock.fields['Funding Vehicle'],
       id: teamMock.id,
-      industry: teamMock.fields.Industry,
+      tags: teamMock.fields['Tags lookup'],
       ipfsUser: teamMock.fields['IPFS User'],
       members: teamMock.fields['Network members'],
       logo: teamMock.fields.Logo?.[0].url,
@@ -241,7 +241,7 @@ describe('AirtableService', () => {
             'Funding Vehicle': ['Seed'],
             'Network members': ['member_id_01'],
             Logo: [{ id: 'team_logo_01', url: 'http://team01.com/logo.svg' }],
-            Industry: ['IT'],
+            'Tags lookup': ['IT'],
             'Last Audited': new Date('28/02/1904'),
             Notes: 'Some notes.',
             'Last Modified': new Date('28/02/1904'),
@@ -260,7 +260,7 @@ describe('AirtableService', () => {
             'Funding Vehicle': ['Seed'],
             'Network members': ['member_id_02'],
             Logo: [{ id: 'team_logo_02', url: 'http://team02.com/logo.svg' }],
-            Industry: ['IT'],
+            'Tags lookup': ['IT'],
             'Last Audited': new Date('28/02/1904'),
             Notes: 'Some notes.',
             'Last Modified': new Date('28/02/1904'),
@@ -296,7 +296,7 @@ describe('AirtableService', () => {
         fundingStage: null,
         filecoinUser: false,
         fundingVehicle: ['Seed'],
-        industry: ['IT'],
+        tags: ['IT'],
         ipfsUser: false,
       },
       {
@@ -311,7 +311,7 @@ describe('AirtableService', () => {
         fundingStage: null,
         filecoinUser: false,
         fundingVehicle: ['Seed'],
-        industry: ['IT'],
+        tags: ['IT'],
         ipfsUser: false,
       },
     ]);
@@ -324,7 +324,7 @@ describe('AirtableService', () => {
         all: jest.fn().mockReturnValue([
           {
             fields: {
-              Industry: ['Industry 01', 'Industry 02'],
+              'Tags lookup': ['Tag 01', 'Tag 02'],
               'Funding Stage': 'Funding Stage 01',
               'Funding Vehicle': ['Funding Vehicle 01', 'Funding Vehicle 02'],
               'IPFS User': true,
@@ -333,14 +333,14 @@ describe('AirtableService', () => {
           },
           {
             fields: {
-              Industry: ['Industry 01', 'Industry 02', 'Industry 03'],
+              'Tags lookup': ['Tag 01', 'Tag 02', 'Tag 03'],
               'Funding Stage': 'Funding Stage 02',
               'Funding Vehicle': ['Funding Vehicle 02', 'Funding Vehicle 03'],
             },
           },
           {
             fields: {
-              Industry: ['Industry 04', 'Industry 05'],
+              'Tags lookup': ['Tag 04', 'Tag 05'],
               'Funding Stage': 'Funding Stage 03',
               'Funding Vehicle': ['Funding Vehicle 04'],
             },
@@ -354,7 +354,7 @@ describe('AirtableService', () => {
         all: jest.fn().mockReturnValue([
           {
             fields: {
-              Industry: ['Industry 01', 'Industry 02'],
+              'Tags lookup': ['Tag 01', 'Tag 02'],
               'Funding Stage': 'Funding Stage 01',
               'Funding Vehicle': ['Funding Vehicle 01', 'Funding Vehicle 02'],
               'IPFS User': true,
@@ -363,7 +363,7 @@ describe('AirtableService', () => {
           },
           {
             fields: {
-              Industry: ['Industry 01', 'Industry 02', 'Industry 03'],
+              'Tags lookup': ['Tag 01', 'Tag 02', 'Tag 03'],
               'Funding Stage': 'Funding Stage 02',
               'Funding Vehicle': ['Funding Vehicle 02', 'Funding Vehicle 03'],
             },
@@ -378,7 +378,7 @@ describe('AirtableService', () => {
     expect(teamsTableMock.select).toHaveBeenCalledTimes(2);
     expect(teamsTableMock.select).toHaveBeenNthCalledWith(1, {
       fields: [
-        'Industry',
+        'Tags lookup',
         'Funding Stage',
         'Funding Vehicle',
         'IPFS User',
@@ -387,7 +387,7 @@ describe('AirtableService', () => {
     });
     expect(teamsTableMock.select).toHaveBeenNthCalledWith(2, {
       fields: [
-        'Industry',
+        'Tags lookup',
         'Funding Stage',
         'Funding Vehicle',
         'IPFS User',
@@ -398,13 +398,7 @@ describe('AirtableService', () => {
 
     expect(filtersValues).toEqual({
       valuesByFilter: {
-        industry: [
-          'Industry 01',
-          'Industry 02',
-          'Industry 03',
-          'Industry 04',
-          'Industry 05',
-        ],
+        tags: ['Tag 01', 'Tag 02', 'Tag 03', 'Tag 04', 'Tag 05'],
         fundingStage: [
           'Funding Stage 01',
           'Funding Stage 02',
@@ -419,7 +413,7 @@ describe('AirtableService', () => {
         technology: ['Filecoin', 'IPFS'],
       },
       availableValuesByFilter: {
-        industry: ['Industry 01', 'Industry 02', 'Industry 03'],
+        tags: ['Tag 01', 'Tag 02', 'Tag 03'],
         fundingStage: ['Funding Stage 01', 'Funding Stage 02'],
         fundingVehicle: [
           'Funding Vehicle 01',

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -167,7 +167,7 @@ class AirtableService {
       fundingStage: team.fields['Funding Stage'] || null,
       fundingVehicle: team.fields['Funding Vehicle'] || [],
       id: team.id,
-      industry: team.fields.Industry || [],
+      tags: team.fields['Tags lookup'] || [],
       ipfsUser: !!team.fields['IPFS User'],
       members: team.fields['Network members'] || [],
       logo: (team.fields.Logo && team.fields.Logo[0]?.url) || null,
@@ -269,7 +269,7 @@ class AirtableService {
     return (await this._getFiltersValues(
       this._teamsTable,
       [
-        'Industry',
+        'Tags lookup',
         'Funding Stage',
         'Funding Vehicle',
         'IPFS User',
@@ -286,8 +286,8 @@ class AirtableService {
   private _parseTeamsFilters(teams: IAirtableTeam[]) {
     const filtersValues: IAirtableTeamsFiltersValues = teams.reduce(
       (values, team) => {
-        const industry = [
-          ...new Set([...values.industry, ...(team.fields.Industry || [])]),
+        const tags = [
+          ...new Set([...values.tags, ...(team.fields['Tags lookup'] || [])]),
         ];
         const fundingStage = [
           ...new Set([
@@ -311,10 +311,10 @@ class AirtableService {
           ]),
         ];
 
-        return { industry, fundingStage, fundingVehicle, technology };
+        return { tags, fundingStage, fundingVehicle, technology };
       },
       {
-        industry: [],
+        tags: [],
         fundingStage: [],
         fundingVehicle: [],
         technology: [],

--- a/libs/airtable/src/models/team.ts
+++ b/libs/airtable/src/models/team.ts
@@ -14,7 +14,7 @@ export interface IAirtableTeamFields {
   'Funding Vehicle'?: string[];
   'Network members'?: string[];
   Logo?: IAirtableTeamLogo[];
-  Industry?: string[];
+  'Tags lookup'?: string[];
   'Last Audited'?: Date;
   Notes?: string;
   'Last Modified'?: Date;
@@ -46,7 +46,7 @@ export interface IAirtableTeamLogo {
 }
 
 export interface IAirtableTeamsFiltersValues {
-  industry: string[];
+  tags: string[];
   fundingStage: string[];
   fundingVehicle: string[];
   technology: string[];

--- a/libs/api/src/teams.ts
+++ b/libs/api/src/teams.ts
@@ -3,7 +3,7 @@ export interface ITeam {
   fundingStage: string | null;
   fundingVehicle: string[];
   id: string;
-  industry: string[];
+  tags: string[];
   ipfsUser: boolean;
   members: string[];
   logo: string | null;


### PR DESCRIPTION
## Description

♺ Content previously fetched for Team Industries is now fetched from the “Tags lookup” column;

Visual changes:
1. Filters sidebar from teams directory: Copy “Industries” changes to “Tags”;
2. Team Card: If a team doesn’t have a Tag, changes copy to “Tags not provided”;
3. Team Profile sidebar;

Technical changes (function & const naming...) :
1. Query parameters;
2. Components;
4. Airtable;


## Tickets
- https://pixelmatters.atlassian.net/browse/PL-138

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
