### PR TITLE
feat(pl-149): add tooltip to social link

### DIFF
--- a/apps/web-app/components/members/member-profile/member-profile-header.tsx
+++ b/apps/web-app/components/members/member-profile/member-profile-header.tsx
@@ -60,9 +60,12 @@ export function MemberProfileHeader({ member }: MemberProfileHeaderProps) {
       </div>
       <div className="border-t border-slate-200 px-7 py-4">
         <SocialLinks
-          email={{ link: member.email }}
-          github={{ link: member.githubHandle }}
-          twitter={{ link: member.twitter }}
+          email={{ link: member.email, label: member.email }}
+          github={{
+            link: member.githubHandle,
+            label: member.githubHandle ? `@${member.githubHandle}` : '',
+          }}
+          twitter={{ link: member.twitter, label: member.twitter }}
         />
       </div>
     </section>

--- a/apps/web-app/components/shared/members/member-card/member-card.tsx
+++ b/apps/web-app/components/shared/members/member-card/member-card.tsx
@@ -118,9 +118,12 @@ export function MemberCard({
         }`}
       >
         <SocialLinks
-          email={{ link: member.email }}
-          twitter={{ link: member.twitter }}
-          github={{ link: member.githubHandle }}
+          email={{ link: member.email, label: member.email }}
+          twitter={{ link: member.twitter, label: member.twitter }}
+          github={{
+            link: member.githubHandle,
+            label: member.githubHandle ? `@${member.githubHandle}` : '',
+          }}
         />
       </div>
     </DirectoryCard>

--- a/apps/web-app/components/shared/social-links/social-link/social-link.tsx
+++ b/apps/web-app/components/shared/social-links/social-link/social-link.tsx
@@ -1,4 +1,4 @@
-import { AnchorLink, isValidEmail } from '@protocol-labs-network/ui';
+import { AnchorLink, isValidEmail, Tooltip } from '@protocol-labs-network/ui';
 import { ISocialLink, TSocialLinkType } from './social-link.types';
 import { getSocialLinkUrl } from './social-link.utils';
 
@@ -18,13 +18,23 @@ export function SocialLink({ linkObj, linkIcon, type }: SocialLinkProps) {
     ...(isActive && { href: url }),
   };
 
-  return (
-    <AnchorLink {...linkProps}>
+  const SocialIcon = () => {
+    return (
       <Icon
         className={`h-5 w-5 ${
           isActive ? 'text-slate-500 hover:text-slate-600' : 'text-slate-300'
         }`}
       />
+    );
+  };
+
+  return (
+    <AnchorLink {...linkProps}>
+      {linkObj.label ? (
+        <Tooltip Trigger={SocialIcon}>{linkObj.label}</Tooltip>
+      ) : (
+        <SocialIcon />
+      )}
     </AnchorLink>
   );
 }

--- a/apps/web-app/components/shared/social-links/social-link/social-link.types.ts
+++ b/apps/web-app/components/shared/social-links/social-link/social-link.types.ts
@@ -1,5 +1,6 @@
 export interface ISocialLink {
   link?: string;
+  label?: string;
 }
 
 export type TSocialLinkType = 'email' | 'twitter' | 'github';

--- a/apps/web-app/components/shared/tags-group/hidden-tags-tooltip.tsx
+++ b/apps/web-app/components/shared/tags-group/hidden-tags-tooltip.tsx
@@ -1,4 +1,4 @@
-import * as HoverCard from '@radix-ui/react-hover-card';
+import { Tooltip } from '@protocol-labs-network/ui';
 import Link from 'next/link';
 import { ITagsGroupItem } from './tags-group';
 
@@ -7,43 +7,37 @@ export interface HiddenTagsTooltipProps {
 }
 
 export function HiddenTagsTooltip({ items }: HiddenTagsTooltipProps) {
+  const hiddenTagsTrigger = () => (
+    <span className="tag tag--clickable group flex h-7 w-7 cursor-pointer items-center justify-center rounded-full">
+      +{items.length}
+    </span>
+  );
+
   return (
-    <HoverCard.Root openDelay={0}>
-      <HoverCard.Trigger>
-        <span className="tag tag--clickable group flex h-7 w-7 cursor-pointer items-center justify-center rounded-full">
-          +{items.length}
-        </span>
-      </HoverCard.Trigger>
-      <HoverCard.Content
-        side="top"
-        align="center"
-        sideOffset={8}
-        className="min-w-[50px] flex-shrink-0 rounded bg-slate-900 p-2 text-xs font-medium text-slate-200"
-      >
-        {items.map((item, i) =>
-          item?.url ? (
-            <Link key={i} href={item.url}>
-              <a
-                className={`${
-                  item.disabled
-                    ? 'pointer-events-none'
-                    : 'hover:text-sky-700 focus:text-sky-700'
-                } block whitespace-nowrap
+    <Tooltip Trigger={hiddenTagsTrigger}>
+      {items.map((item, i) =>
+        item?.url ? (
+          <Link key={i} href={item.url}>
+            <a
+              className={`${
+                item.disabled
+                  ? 'pointer-events-none'
+                  : 'hover:text-sky-700 focus:text-sky-700'
+              } block whitespace-nowrap
                 border-b border-slate-200 p-1 last:border-b-0`}
-              >
-                {item.label}
-              </a>
-            </Link>
-          ) : (
-            <span
-              key={i}
-              className="after:mr-1 after:content-[',']  last:after:content-['']"
             >
               {item.label}
-            </span>
-          )
-        )}
-      </HoverCard.Content>
-    </HoverCard.Root>
+            </a>
+          </Link>
+        ) : (
+          <span
+            key={i}
+            className="after:mr-1 after:content-[',']  last:after:content-['']"
+          >
+            {item.label}
+          </span>
+        )
+      )}
+    </Tooltip>
   );
 }

--- a/apps/web-app/components/shared/teams/team-card/team-card.tsx
+++ b/apps/web-app/components/shared/teams/team-card/team-card.tsx
@@ -19,6 +19,8 @@ export function TeamCard({
   team,
   isGrid = true,
 }: TeamCardProps) {
+  const teamNameLastChar = team.name.slice(-1).toLowerCase();
+  const possessiveMark = teamNameLastChar == 's' ? "'" : "'s";
   const router = useRouter();
   const backLink = encodeURIComponent(router.asPath);
   const anchorLinkProps = {
@@ -92,8 +94,11 @@ export function TeamCard({
         }`}
       >
         <SocialLinks
-          website={{ link: team.website }}
-          twitter={{ link: team.twitter }}
+          website={{
+            link: team.website,
+            label: team.website ? `${team.name}${possessiveMark} website` : '',
+          }}
+          twitter={{ link: team.twitter, label: team.twitter }}
         />
       </div>
     </DirectoryCard>

--- a/apps/web-app/components/teams/team-profile/team-profile-sidebar/team-profile-sidebar.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-sidebar/team-profile-sidebar.tsx
@@ -10,6 +10,9 @@ interface TeamProfileSidebarProps {
 }
 
 export default function TeamProfileSidebar({ team }: TeamProfileSidebarProps) {
+  const teamNameLastChar = team.name.slice(-1).toLowerCase();
+  const possessiveMark = teamNameLastChar == 's' ? "'" : "'s";
+
   return (
     <div className="card w-80 shrink-0 space-y-4 self-start">
       <div className="flex gap-3">
@@ -47,8 +50,11 @@ export default function TeamProfileSidebar({ team }: TeamProfileSidebarProps) {
       </div>
       <div className="border-t border-slate-200 pt-4">
         <SocialLinks
-          website={{ link: team.website }}
-          twitter={{ link: team.twitter }}
+          website={{
+            link: team.website,
+            label: team.website ? `${team.name}${possessiveMark} website` : '',
+          }}
+          twitter={{ link: team.twitter, label: team.twitter }}
         />
       </div>
     </div>

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -6,3 +6,4 @@ export * from './lib/dropdown/dropdown';
 export * from './lib/icons/arrow/arrow';
 export * from './lib/input-field/input-field';
 export * from './lib/tag/tag';
+export * from './lib/tooltip/tooltip';

--- a/libs/ui/src/lib/tooltip/tooltip.stories.tsx
+++ b/libs/ui/src/lib/tooltip/tooltip.stories.tsx
@@ -1,0 +1,39 @@
+import { PlusCircleIcon } from '@heroicons/react/solid';
+import { Meta, Story } from '@storybook/react';
+import { Tooltip, TooltipProps } from './tooltip';
+
+export default {
+  component: Tooltip,
+  title: 'Tooltip',
+  argTypes: {
+    Trigger: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as Meta;
+
+const TriggerIcon = () => {
+  return <PlusCircleIcon className="h-4 w-4" />;
+};
+
+const Template: Story<TooltipProps> = (args) => (
+  <div className="flex h-52 flex-wrap justify-between">
+    <div className="flex h-1/3 w-1/3 items-start justify-start">
+      <Tooltip Trigger={args.Trigger}>{args.children}</Tooltip>
+    </div>
+    <div className="flex h-1/3 w-1/3 flex-wrap items-center justify-center">
+      <Tooltip Trigger={args.Trigger}>{args.children}</Tooltip>
+    </div>
+    <div className="flex h-1/3 w-1/3 items-end justify-end">
+      <Tooltip Trigger={args.Trigger}>{args.children}</Tooltip>
+    </div>
+  </div>
+);
+
+export const Basic = Template.bind({});
+Basic.args = {
+  Trigger: TriggerIcon,
+  children: 'Lorem Ipsum',
+};

--- a/libs/ui/src/lib/tooltip/tooltip.tsx
+++ b/libs/ui/src/lib/tooltip/tooltip.tsx
@@ -1,0 +1,24 @@
+import * as HoverCard from '@radix-ui/react-hover-card';
+
+export interface TooltipProps {
+  Trigger: React.ElementType;
+  children?: React.ReactNode;
+}
+
+export function Tooltip({ Trigger, children }: TooltipProps) {
+  return (
+    <HoverCard.Root openDelay={0} closeDelay={0}>
+      <HoverCard.Trigger className="cursor-pointer">
+        <Trigger />
+      </HoverCard.Trigger>
+      <HoverCard.Content
+        side="top"
+        align="center"
+        sideOffset={8}
+        className="flex-shrink-0 rounded bg-slate-900 py-1 px-2 text-xs font-medium text-white"
+      >
+        {children}
+      </HoverCard.Content>
+    </HoverCard.Root>
+  );
+}


### PR DESCRIPTION
## Description
🚀 Add `tooltip` to **ui** **components** and **stories**;
- Use this component on `social link` and adapt `hiddenTagsTooltip` to reuse it too;

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-149

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
