### PR TITLE
fix(pl-132): space between team sidebar and main content

### DIFF
--- a/apps/web-app/pages/teams/index.tsx
+++ b/apps/web-app/pages/teams/index.tsx
@@ -30,7 +30,7 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
           <TeamsDirectoryFilters filtersValues={filtersValues} />
         </div>
 
-        <div className="mx-auto p-8 pl-[291px]">
+        <div className="mx-auto p-8">
           <div className="w-[917px] space-y-10">
             <DirectoryHeader
               title="Teams"


### PR DESCRIPTION
## Description

Fix extra spacing between team directory sidebar and main content

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-132

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
