### PR TITLE
fix: update members directory to properly request the filters values

### DIFF
--- a/apps/web-app/pages/members/index.tsx
+++ b/apps/web-app/pages/members/index.tsx
@@ -8,7 +8,10 @@ import { MembersDirectoryFilters } from '../../components/members/members-direct
 import { IMembersFiltersValues } from '../../components/members/members-directory/members-directory-filters/members-directory-filters.types';
 import { parseMembersFilters } from '../../components/members/members-directory/members-directory-filters/members-directory-filters.utils';
 import { MemberCard } from '../../components/shared/members/member-card/member-card';
-import { getMembersDirectoryRequestOptionsFromQuery } from '../../utils/api/list.utils';
+import {
+  getMembersDirectoryListOptions,
+  getMembersDirectoryRequestOptionsFromQuery,
+} from '../../utils/api/list.utils';
 
 type MembersProps = {
   members: IMember[];
@@ -63,10 +66,11 @@ export const getServerSideProps: GetServerSideProps<MembersProps> = async ({
   query,
   res,
 }) => {
-  const options = getMembersDirectoryRequestOptionsFromQuery(query);
+  const optionsFromQuery = getMembersDirectoryRequestOptionsFromQuery(query);
+  const listOptions = getMembersDirectoryListOptions(optionsFromQuery);
   const [members, filtersValues] = await Promise.all([
-    airtableService.getMembers(options),
-    airtableService.getMembersFiltersValues(options),
+    airtableService.getMembers(listOptions),
+    airtableService.getMembersFiltersValues(optionsFromQuery),
   ]);
   const parsedFilters = parseMembersFilters(filtersValues, query);
 

--- a/apps/web-app/tests/utils/api/list.utils.spec.ts
+++ b/apps/web-app/tests/utils/api/list.utils.spec.ts
@@ -1,6 +1,7 @@
 import { MEMBER_CARD_FIELDS } from '../../../components/shared/members/member-card/member-card.constants';
 import { TEAM_CARD_FIELDS } from '../../../components/shared/teams/team-card/team-card.constants';
 import {
+  getMembersDirectoryListOptions,
   getMembersDirectoryRequestOptionsFromQuery,
   getTeamsDirectoryRequestOptionsFromQuery,
 } from '../../../utils/api/list.utils';
@@ -65,7 +66,6 @@ describe('#getMembersDirectoryRequestOptionsFromQuery', () => {
         sort: 'Name,desc',
       })
     ).toEqual({
-      fields: MEMBER_CARD_FIELDS,
       sort: [{ field: 'Name', direction: 'desc' }],
       filterByFormula:
         'AND({Name} != "", {Teams} != "", REGEX_MATCH({Name}, "(?i)^(void)"), SEARCH("Engineering", {Skills}), SEARCH("Leadership", {Skills}), SEARCH("Portugal", {Country}), SEARCH("Porto", {Metro Area}))',
@@ -78,7 +78,6 @@ describe('#getMembersDirectoryRequestOptionsFromQuery', () => {
         sort: 'invalid',
       })
     ).toEqual({
-      fields: MEMBER_CARD_FIELDS,
       sort: [{ field: 'Name', direction: 'asc' }],
       filterByFormula: 'AND({Name} != "", {Teams} != "")',
     });
@@ -93,10 +92,24 @@ describe('#getMembersDirectoryRequestOptionsFromQuery', () => {
         skills: 'Engineering|Leadership',
       })
     ).toEqual({
-      fields: MEMBER_CARD_FIELDS,
       sort: [{ field: 'Name', direction: 'asc' }],
       filterByFormula:
         'AND({Name} != "", {Teams} != "", REGEX_MATCH({Name}, "(?i)^(void)"), SEARCH("Engineering", {Skills}), SEARCH("Leadership", {Skills}), SEARCH("Portugal", {Country}), SEARCH("Porto", {Metro Area}))',
+    });
+  });
+});
+
+describe('#getMembersDirectoryListOptions', () => {
+  it('should append members cards list properties to the provided options', () => {
+    expect(
+      getMembersDirectoryListOptions({
+        sort: [{ field: 'Name', direction: 'desc' }],
+        filterByFormula: 'AND({Name} != "", {Teams} != "")',
+      })
+    ).toEqual({
+      sort: [{ field: 'Name', direction: 'desc' }],
+      filterByFormula: 'AND({Name} != "", {Teams} != "")',
+      fields: MEMBER_CARD_FIELDS,
     });
   });
 });

--- a/apps/web-app/utils/api/list.utils.ts
+++ b/apps/web-app/utils/api/list.utils.ts
@@ -33,7 +33,7 @@ export function getTeamsDirectoryRequestOptionsFromQuery(
 
 /**
  * Returns the options for requesting the members on the members directory,
- * by parsing the provided query parameters.
+ * based on the provided query parameters.
  */
 export function getMembersDirectoryRequestOptionsFromQuery(
   queryParams: ParsedUrlQuery
@@ -41,7 +41,6 @@ export function getMembersDirectoryRequestOptionsFromQuery(
   const { sort, searchBy, skills, country, metroArea } = queryParams;
 
   return {
-    fields: MEMBER_CARD_FIELDS,
     sort: [getSortFromQuery(sort?.toString())],
     filterByFormula: getMembersDirectoryFormula({
       searchBy,
@@ -49,6 +48,18 @@ export function getMembersDirectoryRequestOptionsFromQuery(
       country,
       metroArea,
     }),
+  };
+}
+
+/**
+ * Get the options for requesting the members on the members directory.
+ */
+export function getMembersDirectoryListOptions(
+  options: IListOptions
+): IListOptions {
+  return {
+    ...options,
+    fields: MEMBER_CARD_FIELDS,
   };
 }
 


### PR DESCRIPTION
## Description

🐞 Update Members Directory to properly request the filters values (prevents unexpectedly disabled filters)

> **Note**
> Teams Directory fix will come along with the infinite scroll.

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
