### PR TITLE
feat(pl-150): make cards clickable

### DIFF
--- a/apps/web-app/components/shared/members/member-card/member-card.tsx
+++ b/apps/web-app/components/shared/members/member-card/member-card.tsx
@@ -5,34 +5,21 @@ import { AnchorLink } from '@protocol-labs-network/ui';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { DirectoryCard } from '../../../../components/directory/directory-card/directory-card';
-import { SocialLinks } from '../../../../components/shared/social-links/social-links';
 import { TagsGroup } from '../../tags-group/tags-group';
 
 interface MemberCardProps {
-  isClickable?: boolean;
   isGrid?: boolean;
   member: IMember;
-  showLocation?: boolean;
 }
 
-export function MemberCard({
-  isClickable = false,
-  isGrid = true,
-  member,
-  showLocation = false,
-}: MemberCardProps) {
+export function MemberCard({ isGrid = true, member }: MemberCardProps) {
   const router = useRouter();
   const backLink = encodeURIComponent(router.asPath);
-  const anchorLinkProps = {
-    ...(isClickable
-      ? { href: `/members/${member.id}?backLink=${backLink}` }
-      : {}),
-  };
   const teamsNames = member.teams.map(({ name }) => name);
 
   return (
     <DirectoryCard isGrid={isGrid}>
-      <AnchorLink {...anchorLinkProps}>
+      <AnchorLink href={`/members/${member.id}?backLink=${backLink}`}>
         <div className={`flex ${isGrid ? 'flex-col space-y-4' : 'flex-row'}`}>
           <div className={`${isGrid ? 'w-full' : 'w-[396px]'} flex space-x-4`}>
             <div
@@ -58,38 +45,18 @@ export function MemberCard({
                 {member.name}
               </h3>
               <p className="line-clamp-1">{member.role}</p>
-              {showLocation ? (
-                <div className="mt-2 flex items-center text-sm text-slate-500">
-                  <LocationMarkerIcon className="mr-1 h-4 w-4 flex-shrink-0" />
-                  <span className="line-clamp-1">{member.location}</span>
-                </div>
-              ) : null}
+              <div className="mt-2 flex items-center text-sm text-slate-500">
+                <LocationMarkerIcon className="mr-1 h-4 w-4 flex-shrink-0" />
+                <span className="line-clamp-1">{member.location}</span>
+              </div>
             </div>
           </div>
         </div>
+        <div className={`${isGrid ? 'mt-4' : 'mx-4 w-[348px] self-center'}`}>
+          <h4 className="mb-2 text-sm font-medium text-slate-500">Teams</h4>
+          <TagsGroup items={teamsNames} isSingleLine={true} />
+        </div>
       </AnchorLink>
-
-      <div className={`${isGrid ? 'my-4' : 'mx-4 w-[348px] self-center'}`}>
-        <h4 className="mb-2 text-sm font-medium text-slate-500">Teams</h4>
-        <TagsGroup items={teamsNames} isSingleLine={true} />
-      </div>
-
-      <div
-        className={`border-slate-200 ${
-          isGrid
-            ? 'border-t pt-4'
-            : 'flex h-20 w-[99px] items-center justify-center self-center border-l pl-5'
-        }`}
-      >
-        <SocialLinks
-          email={{ link: member.email, label: member.email }}
-          twitter={{ link: member.twitter, label: member.twitter }}
-          github={{
-            link: member.githubHandle,
-            label: member.githubHandle ? `@${member.githubHandle}` : '',
-          }}
-        />
-      </div>
     </DirectoryCard>
   );
 }

--- a/apps/web-app/components/shared/teams/team-card/team-card.tsx
+++ b/apps/web-app/components/shared/teams/team-card/team-card.tsx
@@ -4,31 +4,20 @@ import { AnchorLink } from '@protocol-labs-network/ui';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { DirectoryCard } from '../../../directory/directory-card/directory-card';
-import { SocialLinks } from '../../social-links/social-links';
 import { TagsGroup } from '../../tags-group/tags-group';
 
 export interface TeamCardProps {
-  isClickable?: boolean;
   team: ITeam;
   isGrid?: boolean;
 }
 
-export function TeamCard({
-  isClickable = false,
-  team,
-  isGrid = true,
-}: TeamCardProps) {
-  const teamNameLastChar = team.name.slice(-1).toLowerCase();
-  const possessiveMark = teamNameLastChar == 's' ? "'" : "'s";
+export function TeamCard({ team, isGrid = true }: TeamCardProps) {
   const router = useRouter();
   const backLink = encodeURIComponent(router.asPath);
-  const anchorLinkProps = {
-    ...(isClickable ? { href: `/teams/${team.id}?backLink=${backLink}` } : {}),
-  };
 
   return (
     <DirectoryCard isGrid={isGrid}>
-      <AnchorLink {...anchorLinkProps}>
+      <AnchorLink href={`/teams/${team.id}?backLink=${backLink}`}>
         <div className={`flex ${isGrid ? 'flex-col space-y-4' : 'flex-row'}`}>
           <div className={`${isGrid ? 'w-full' : 'w-[496px]'} flex space-x-4`}>
             <div
@@ -68,35 +57,21 @@ export function TeamCard({
             </p>
           ) : null}
         </div>
+
+        <div
+          className={`h-[28px] ${
+            isGrid ? 'mt-4' : 'mx-4 w-[248px] self-center'
+          }`}
+        >
+          {team.tags && team.tags.length ? (
+            <TagsGroup isSingleLine items={team.tags} />
+          ) : (
+            <span className="text-xs leading-7 text-slate-400">
+              Tags not provided
+            </span>
+          )}
+        </div>
       </AnchorLink>
-
-      <div
-        className={`h-[28px] ${isGrid ? 'my-4' : 'mx-4 w-[248px] self-center'}`}
-      >
-        {team.tags && team.tags.length ? (
-          <TagsGroup isSingleLine items={team.tags} />
-        ) : (
-          <span className="text-xs leading-7 text-slate-400">
-            Tags not provided
-          </span>
-        )}
-      </div>
-
-      <div
-        className={`border-slate-200 ${
-          isGrid
-            ? 'border-t pt-4'
-            : 'flex h-20 w-[99px] items-center justify-center self-center border-l pl-5'
-        }`}
-      >
-        <SocialLinks
-          website={{
-            link: team.website,
-            label: team.website ? `${team.name}${possessiveMark} website` : '',
-          }}
-          twitter={{ link: team.twitter, label: team.twitter }}
-        />
-      </div>
     </DirectoryCard>
   );
 }

--- a/apps/web-app/pages/members/index.tsx
+++ b/apps/web-app/pages/members/index.tsx
@@ -42,13 +42,7 @@ export default function Members({ members, filtersValues }: MembersProps) {
 
             <div className="flex flex-wrap gap-4">
               {members.map((member) => (
-                <MemberCard
-                  key={member.id}
-                  member={member}
-                  isClickable
-                  isGrid={isGrid}
-                  showLocation
-                />
+                <MemberCard key={member.id} member={member} isGrid={isGrid} />
               ))}
             </div>
 

--- a/apps/web-app/pages/teams/index.tsx
+++ b/apps/web-app/pages/teams/index.tsx
@@ -39,14 +39,7 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
 
             <div className="flex flex-wrap gap-4">
               {teams.map((team) => {
-                return (
-                  <TeamCard
-                    key={team.id}
-                    isClickable
-                    team={team}
-                    isGrid={isGrid}
-                  />
-                );
+                return <TeamCard key={team.id} team={team} isGrid={isGrid} />;
               })}
             </div>
 


### PR DESCRIPTION
## Description

🚀 Removes prop `isClickable` that prevented Teams/Members cards from being clicked and redirected on some pages; 
🚀 It also makes the entire area of the card clickable.

- Removes `SocialLinks` from cards;

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-150

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
