### PR TITLE
fix: add missing inter font weights

### DIFF
--- a/apps/web-app/pages/_document.tsx
+++ b/apps/web-app/pages/_document.tsx
@@ -5,7 +5,7 @@ export default function Document() {
     <Html>
       <Head>
         <link
-          href="https://fonts.googleapis.com/css2?family=Inter&display=optional"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
       </Head>


### PR DESCRIPTION
## Description

🐞 Add missing Inter font weights

> **Note**
> I've changed `display` strategy from `optional` to `swap`, which makes the browser initially show a fallback font, and then, once the Google Font has been downloaded, it will swap the fonts. More on this [here](https://fontsplugin.com/google-fonts-font-display-swap/).

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
