### PR TITLE
fix: show friend of pln teams on member profiles

### DIFF
--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -333,7 +333,7 @@ describe('AirtableService', () => {
 
     expect(teamsTableMock.select).toHaveBeenCalledWith({
       filterByFormula:
-        'AND(AND({Name} != "", {Short description} != "", {Friend of PLN} = FALSE()), OR(RECORD_ID()=\'team_id_01\', RECORD_ID()=\'team_id_02\'))',
+        'AND(AND({Name} != "", {Short description} != ""), OR(RECORD_ID()=\'team_id_01\', RECORD_ID()=\'team_id_02\'))',
       fields: ['Name'],
       sort: [{ direction: 'asc', field: 'Name' }],
     });

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -73,11 +73,7 @@ class AirtableService {
       filterByFormula: [
         'AND(',
         'AND(',
-        [
-          '{Name} != ""',
-          '{Short description} != ""',
-          '{Friend of PLN} = FALSE()',
-        ].join(', '),
+        ['{Name} != ""', '{Short description} != ""'].join(', '),
         '), ',
         `OR(${teamsByIdFormula.join(', ')})`,
         ')',


### PR DESCRIPTION
## Description

🐞 Show "Friend of PLN" teams on member profiles (revert previous change)

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-158
---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
