### PR TITLE
fix: show friend of pln members on team profiles

### DIFF
--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -802,8 +802,7 @@ describe('AirtableService', () => {
     expect(membersTableMock.select).toHaveBeenCalledTimes(1);
 
     expect(membersTableMock.select).toHaveBeenCalledWith({
-      filterByFormula:
-        'AND({Friend of PLN} = FALSE(), SEARCH("team_id_01",Teams))',
+      filterByFormula: 'SEARCH("team_id_01",Teams)',
       fields: ['Name'],
       sort: [
         { field: 'Team lead', direction: 'desc' },

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -144,14 +144,7 @@ class AirtableService {
    */
   public async getTeamMembers(teamName: string, fields: string[]) {
     const membersOptions: IListOptions = {
-      filterByFormula: [
-        'AND(',
-        [
-          '{Friend of PLN} = FALSE()',
-          this._getSearchFormula(teamName, 'Teams'),
-        ].join(', '),
-        ')',
-      ].join(''),
+      filterByFormula: this._getSearchFormula(teamName, 'Teams'),
       fields,
       sort: [
         { field: 'Team lead', direction: 'desc' },


### PR DESCRIPTION
## Description

🐞 Show "Friend of PLN" members on team profiles (revert previous change)

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-160

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
