### PR TITLE
fix: change member card photo to cover the whole container

### DIFF
--- a/apps/web-app/components/shared/members/member-card/member-card.tsx
+++ b/apps/web-app/components/shared/members/member-card/member-card.tsx
@@ -35,7 +35,7 @@ export function MemberCard({ isGrid = true, member }: MemberCardProps) {
                     alt={`${member.name} Logo`}
                     src={member.image}
                     layout="fill"
-                    objectFit="contain"
+                    objectFit="cover"
                     objectPosition="center"
                   />
                 ) : (


### PR DESCRIPTION
## Description

🐞 Change member card photo to cover the whole container (see example below)

<img width="936" alt="Screenshot 2022-07-26 at 12 27 30" src="https://user-images.githubusercontent.com/2746363/180995706-4fd35e82-9c94-4f6b-8f4f-d1792eb6bf6f.png">

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
