### PR TITLE
feat: add utils for getting a query parameters string from members directory query parameters

### DIFF
--- a/apps/web-app/tests/utils/api/list.utils.spec.ts
+++ b/apps/web-app/tests/utils/api/list.utils.spec.ts
@@ -4,6 +4,7 @@ import { ITEMS_PER_PAGE } from '../../../constants';
 import {
   getMembersDirectoryListOptions,
   getMembersDirectoryRequestOptionsFromQuery,
+  getMembersDirectoryRequestParametersFromQuery,
   getTeamsDirectoryListOptions,
   getTeamsDirectoryRequestOptionsFromQuery,
   getTeamsDirectoryRequestParametersFromQuery,
@@ -169,6 +170,45 @@ describe('#getTeamsDirectoryRequestParametersFromQuery', () => {
       })
     ).toEqual(
       'fields[]=Name&fields[]=Logo&fields[]=Short description&fields[]=Tags lookup&fields[]=Website&fields[]=Twitter&sort[0][field]=Name&sort[0][direction]=asc&filterByFormula=AND({Name} != "", {Short description} != "", {Friend of PLN} = FALSE(), REGEX_MATCH({Name}, "(?i)^(void)"), SEARCH("Analytics", ARRAYJOIN({Tags lookup})), SEARCH("IPFS", {Accelerator Programs}), SEARCH("Seed", {Funding Stage}), {IPFS User} = TRUE(), {Filecoin User} = TRUE())&pageSize=9'
+    );
+  });
+});
+
+describe('#getMembersDirectoryRequestParametersFromQuery', () => {
+  it('should return a valid query parameters string when sort is provided and is valid', () => {
+    expect(
+      getMembersDirectoryRequestParametersFromQuery({
+        country: 'Portugal',
+        metroArea: 'Porto',
+        searchBy: 'void',
+        skills: 'Engineering|Leadership',
+        sort: 'Name,desc',
+      })
+    ).toEqual(
+      'fields[]=Name&fields[]=Profile picture&fields[]=Role&fields[]=Teams&fields[]=Team name&fields[]=Country&fields[]=State / Province&fields[]=City&fields[]=Metro Area&fields[]=Email&fields[]=Twitter&fields[]=Github Handle&fields[]=Team lead&sort[0][field]=Name&sort[0][direction]=desc&filterByFormula=AND({Name} != "", {Teams} != "", {Friend of PLN} = FALSE(), REGEX_MATCH({Name}, "(?i)^(void)"), SEARCH("Engineering", {Skills}), SEARCH("Leadership", {Skills}), SEARCH("Portugal", {Country}), SEARCH("Porto", {Metro Area}))&pageSize=9'
+    );
+  });
+
+  it('should return a valid query parameters string when sort is provided and is invalid', () => {
+    expect(
+      getMembersDirectoryRequestParametersFromQuery({
+        sort: 'invalid',
+      })
+    ).toEqual(
+      'fields[]=Name&fields[]=Profile picture&fields[]=Role&fields[]=Teams&fields[]=Team name&fields[]=Country&fields[]=State / Province&fields[]=City&fields[]=Metro Area&fields[]=Email&fields[]=Twitter&fields[]=Github Handle&fields[]=Team lead&sort[0][field]=Name&sort[0][direction]=asc&filterByFormula=AND({Name} != "", {Teams} != "", {Friend of PLN} = FALSE())&pageSize=9'
+    );
+  });
+
+  it('should return a valid query parameters string when sort is not provided', () => {
+    expect(
+      getMembersDirectoryRequestParametersFromQuery({
+        country: 'Portugal',
+        metroArea: 'Porto',
+        searchBy: 'void',
+        skills: 'Engineering|Leadership',
+      })
+    ).toEqual(
+      'fields[]=Name&fields[]=Profile picture&fields[]=Role&fields[]=Teams&fields[]=Team name&fields[]=Country&fields[]=State / Province&fields[]=City&fields[]=Metro Area&fields[]=Email&fields[]=Twitter&fields[]=Github Handle&fields[]=Team lead&sort[0][field]=Name&sort[0][direction]=asc&filterByFormula=AND({Name} != "", {Teams} != "", {Friend of PLN} = FALSE(), REGEX_MATCH({Name}, "(?i)^(void)"), SEARCH("Engineering", {Skills}), SEARCH("Leadership", {Skills}), SEARCH("Portugal", {Country}), SEARCH("Porto", {Metro Area}))&pageSize=9'
     );
   });
 });

--- a/apps/web-app/utils/api/list.utils.ts
+++ b/apps/web-app/utils/api/list.utils.ts
@@ -118,6 +118,34 @@ export function getTeamsDirectoryRequestParametersFromQuery(
 }
 
 /**
+ * Returns the query parameters string for requesting the members on
+ * the members directory, by parsing the provided query parameters.
+ */
+export function getMembersDirectoryRequestParametersFromQuery(
+  queryParams: ParsedUrlQuery
+): string {
+  const { sort, searchBy, skills, country, metroArea } = queryParams;
+
+  const fieldsParam = MEMBER_CARD_FIELDS.map(
+    (field) => `fields[]=${field}`
+  ).join('&');
+  const sortFromQuery = getSortFromQuery(sort?.toString());
+  const sortFieldParam = `sort[0][field]=${sortFromQuery.field}`;
+  const sortDirectionParam = `sort[0][direction]=${sortFromQuery.direction}`;
+  const sortParam = `${sortFieldParam}&${sortDirectionParam}`;
+  const membersDirectoryFormula = getMembersDirectoryFormula({
+    searchBy,
+    skills,
+    country,
+    metroArea,
+  });
+  const filterByFormulaParam = `filterByFormula=${membersDirectoryFormula}`;
+  const pageSizeParam = `pageSize=${ITEMS_PER_PAGE}`;
+
+  return `${fieldsParam}&${sortParam}&${filterByFormulaParam}&${pageSizeParam}`;
+}
+
+/**
  * Gets sort options by parsing the provided sort query parameter.
  */
 function getSortFromQuery(sortQuery?: string) {


### PR DESCRIPTION
## Description

🚀 Add utils for getting a query parameters string from Members Directory query parameters

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-83

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
