### PR TITLE
fix: change breadcrumb bar z-index

### DIFF
--- a/libs/ui/src/lib/breadcrumb/breadcrumb.tsx
+++ b/libs/ui/src/lib/breadcrumb/breadcrumb.tsx
@@ -14,7 +14,7 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
   return (
     <nav
       aria-label="breadcrumb"
-      className="navbar top-20 border-t border-t-slate-200 px-16 py-3.5 text-sm leading-6 shadow-[0_1px_4px_0_#e2e8f0]"
+      className="navbar top-20 z-40 border-t border-t-slate-200 px-16 py-3.5 text-sm leading-6 shadow-[0_1px_4px_0_#e2e8f0]"
     >
       <Link href="/">
         <a>


### PR DESCRIPTION
## Description

Join the network dropdown has been covered by breadcrumbs bar, with this z-index change the visual bug is fixed

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-114

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
