### PR TITLE
fix: prevent search input text from overlapping the clear icon

### DIFF
--- a/libs/ui/src/lib/input-field/input-field.tsx
+++ b/libs/ui/src/lib/input-field/input-field.tsx
@@ -44,7 +44,7 @@ export function InputField({
       <input
         {...props}
         className={`block w-full rounded-lg border border-white bg-white text-sm leading-6 text-slate-900 shadow-sm shadow-slate-300 transition duration-150 ease-in-out placeholder:text-sm placeholder:text-slate-600
-        ${icon ? 'pl-8' : 'pl-3'} ${hasClear ? 'pr-6' : ''} h-10 pr-2
+        ${icon ? 'pl-8' : 'pl-3'} ${hasClear ? 'pr-6' : 'pr-3'} h-10
         leading-10 hover:border-slate-200 hover:ring-2 hover:ring-blue-300 focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300 ${
           props.className || ''
         }`}


### PR DESCRIPTION
## Description

🐞 Prevent search input text from overlapping the clear icon

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-121

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
