### PR TITLE
feat(pl-202): show skills instead of teams

### DIFF
--- a/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
@@ -25,7 +25,7 @@ export function TeamProfileMembers({ members }: TeamProfileMembersProps) {
           name={member.name}
           showTeamLeadBadge={member.teamLead}
           description={member.role}
-          tags={member.teams.map(({ name }) => name)}
+          tags={member.skills}
         />
       ))}
     </ProfileCards>


### PR DESCRIPTION
## Description

🚀 Show skills instead of teams on team profile page member card

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-202

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
