### PR TITLE
fix(pl-206): change width for tags container on profile cards

### DIFF
--- a/apps/web-app/components/shared/members/member-card/member-card.tsx
+++ b/apps/web-app/components/shared/members/member-card/member-card.tsx
@@ -41,7 +41,7 @@ export function MemberCard({ isGrid = true, member }: MemberCardProps) {
 
         <div
           className={`${isGrid ? 'mt-2 justify-center' : 'mt-1'}
-            } flex items-center text-sm text-slate-600`}
+            flex items-center text-sm text-slate-600`}
         >
           {member.location ? (
             <>

--- a/apps/web-app/components/shared/profile/profile-cards/profile-card.tsx
+++ b/apps/web-app/components/shared/profile/profile-cards/profile-card.tsx
@@ -56,13 +56,19 @@ export function ProfileCard({
               </div>
             ) : null}
           </div>
-          <div className="mr-4 w-64">
+          <div className="mr-4 w-64 shrink-0">
             <h3 className="line-clamp-1 text-sm font-semibold">{name}</h3>
             <p className="line-clamp-2 leading-3.5 text-xs text-slate-600">
               {description || '-'}
             </p>
           </div>
-          {tags?.length ? <TagsGroup items={tags} isSingleLine={true} /> : '-'}
+          <div className="w-96">
+            {tags?.length ? (
+              <TagsGroup items={tags} isSingleLine={true} />
+            ) : (
+              '-'
+            )}
+          </div>
           <div className="ml-auto w-12">
             <ChevronRightIcon className="h-4 w-4 fill-slate-500 group-hover:fill-slate-900" />
           </div>


### PR DESCRIPTION
## Description

🐞 Change width for tags container on profile cards to prevent showing tags out of bounds.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-206

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
