### PR TITLE
feat: prevent cards from overlapping the directories sidebars

### DIFF
--- a/apps/web-app/pages/members/index.tsx
+++ b/apps/web-app/pages/members/index.tsx
@@ -41,7 +41,7 @@ export default function Members({ members, filtersValues }: MembersProps) {
       <LoadingOverlay excludeUrlFn={(url) => url.startsWith('/members/')} />
 
       <section className="pl-sidebar flex">
-        <div className="w-sidebar fixed left-0 h-full flex-shrink-0 border-r border-r-slate-200 bg-white">
+        <div className="w-sidebar fixed left-0 z-40 h-full flex-shrink-0 border-r border-r-slate-200 bg-white">
           <MembersDirectoryFilters
             filtersValues={filtersValues}
             filterProperties={filterProperties}

--- a/apps/web-app/pages/teams/index.tsx
+++ b/apps/web-app/pages/teams/index.tsx
@@ -40,7 +40,7 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
       <LoadingOverlay excludeUrlFn={(url) => url.startsWith('/teams/')} />
 
       <section className="pl-sidebar flex">
-        <div className="w-sidebar fixed left-0 h-full flex-shrink-0 border-r border-r-slate-200 bg-white">
+        <div className="w-sidebar fixed left-0 z-40 h-full flex-shrink-0 border-r border-r-slate-200 bg-white">
           <TeamsDirectoryFilters
             filtersValues={filtersValues}
             filterProperties={filterProperties}


### PR DESCRIPTION
## Description

🚀 Prevent cards from overlapping the directories sidebars

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-211

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
