### PR TITLE
fix: remove misplaced canonical seo config

### DIFF
--- a/apps/web-app/seo.config.js
+++ b/apps/web-app/seo.config.js
@@ -1,7 +1,6 @@
 export const SEO = {
   titleTemplate: '%s | Protocol Labs Network Directory',
   defaultTitle: 'Protocol Labs Network Directory',
-  canonical: 'https://plnetwork.io/',
   description:
     'The Protocol Labs Network Directory helps network members orient themselves within the network by making it easy to learn about other teams and members, including their roles, capabilities, and experiences.',
   openGraph: {


### PR DESCRIPTION
## Description

🐞 Remove misplaced canonical SEO config, that's causing Fathom to track all page visits as root route visits (`/`)

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
