### PR TITLE
feat: add theme-color meta tag

### DIFF
--- a/apps/web-app/pages/_app.tsx
+++ b/apps/web-app/pages/_app.tsx
@@ -18,6 +18,7 @@ function CustomApp({ Component, pageProps }: AppProps) {
     <>
       <Head>
         <meta name="viewport" content="width=1272, user-scalable=no" />
+        <meta content="#f1f5f9" name="theme-color"></meta>
       </Head>
       <DefaultSeo {...SEO} />
       <main className="app min-w-[1272px] pt-20">


### PR DESCRIPTION
## Description

🚀 Add `theme-color` meta tag

> **Note**
> This meta tag definition, as per the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color), is as follows:
> > The theme-color value for the `name` attribute of the `<meta>` element indicates a suggested color that user agents should use to customize the display of the page or of the surrounding user interface. If specified, the `content` attribute must contain a valid CSS `<color>`.
>
> It can be used, for example, to set which color the Android's Chrome address bar should use, as seen in the following image.
> ![theme-color](https://user-images.githubusercontent.com/2746363/184388488-ad6608db-0bbf-4cca-b1f6-c4ce74f37b60.png)

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-58
- https://pixelmatters.atlassian.net/browse/PL-215

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
