### PR TITLE
fix: run local nx on pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-nx format:write && nx affected:lint
+npx nx format:write && npx nx affected:lint


### PR DESCRIPTION
## Description
The pre-commit hook was trying to execute `nx` in a global context which required having it globally installed so in order to fix that I've appended the `npx` command to remove that dependency.

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [ ] ~I've added relevant tests for my changes~
- [ ] ~I've confirmed that my code passes linting~
- [ ] ~I've confirmed that my code passes all tests~
- [ ] ~I've confirmed that my code builds correctly~
