### PR TITLE
feat: track the usage of the views buttons

### DIFF
--- a/apps/web-app/components/directory/directory-header/directory-header.tsx
+++ b/apps/web-app/components/directory/directory-header/directory-header.tsx
@@ -1,16 +1,19 @@
 import { DirectorySearch } from '../../../components/directory/directory-search/directory-search';
 import { DirectorySort } from '../../../components/directory/directory-sort/directory-sort';
 import { DirectoryView } from '../../../components/directory/directory-view/directory-view';
+import { TDirectoryType } from '../directory.types';
 
 type DirectoryHeaderProps = {
   searchPlaceholder: string;
   title: string;
+  directoryType: TDirectoryType;
   count: number;
 };
 
 export function DirectoryHeader({
   searchPlaceholder,
   title,
+  directoryType,
   count,
 }: DirectoryHeaderProps) {
   return (
@@ -23,7 +26,7 @@ export function DirectoryHeader({
         <DirectorySearch placeholder={searchPlaceholder} />
         <span className="h-6 w-px bg-slate-300" />
         <DirectorySort />
-        <DirectoryView />
+        <DirectoryView directoryType={directoryType} />
       </div>
     </div>
   );

--- a/apps/web-app/components/directory/directory-view/directory-view-type-button/directory-view-type-button.tsx
+++ b/apps/web-app/components/directory/directory-view/directory-view-type-button/directory-view-type-button.tsx
@@ -1,12 +1,14 @@
 import { Tooltip } from '@protocol-labs-network/ui';
+import { TDirectoryType } from '../../directory.types';
 import { TViewType } from '../directory-view.types';
 
 interface DirectoryViewTypeButtonProps {
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   label: string;
-  onClick: (clickedViewType: TViewType) => void;
+  onClick: (clickedViewType: TViewType, directoryType: TDirectoryType) => void;
   selectedViewType: TViewType;
   viewType: TViewType;
+  directoryType: TDirectoryType;
 }
 
 export function DirectoryViewTypeButton({
@@ -15,6 +17,7 @@ export function DirectoryViewTypeButton({
   onClick,
   selectedViewType,
   viewType,
+  directoryType,
 }: DirectoryViewTypeButtonProps) {
   const ViewTypeIcon = icon;
   const isActive = viewType === selectedViewType;
@@ -33,7 +36,7 @@ export function DirectoryViewTypeButton({
         trigger={
           <button
             className="on-focus flex h-10 w-10 items-center justify-center"
-            onClick={() => onClick(viewType)}
+            onClick={() => onClick(viewType, directoryType)}
             disabled={isActive}
           >
             <span className="sr-only">{label}</span>

--- a/apps/web-app/components/directory/directory-view/directory-view.spec.tsx
+++ b/apps/web-app/components/directory/directory-view/directory-view.spec.tsx
@@ -7,7 +7,7 @@ describe('DirectoryView', () => {
   it('should show grid button as active and disable at first render', () => {
     render(
       <RouterContext.Provider value={createMockRouter()}>
-        <DirectoryView />
+        <DirectoryView directoryType="teams" />
       </RouterContext.Provider>
     );
 
@@ -27,7 +27,7 @@ describe('DirectoryView', () => {
 
     render(
       <RouterContext.Provider value={createMockRouter({ push })}>
-        <DirectoryView />
+        <DirectoryView directoryType="teams" />
       </RouterContext.Provider>
     );
 
@@ -50,7 +50,7 @@ describe('DirectoryView', () => {
       <RouterContext.Provider
         value={createMockRouter({ query: { viewType: 'list' } })}
       >
-        <DirectoryView />
+        <DirectoryView directoryType="teams" />
       </RouterContext.Provider>
     );
 
@@ -72,7 +72,7 @@ describe('DirectoryView', () => {
       <RouterContext.Provider
         value={createMockRouter({ query: { viewType: 'list' }, push })}
       >
-        <DirectoryView />
+        <DirectoryView directoryType="teams" />
       </RouterContext.Provider>
     );
 

--- a/apps/web-app/components/directory/directory-view/directory-view.tsx
+++ b/apps/web-app/components/directory/directory-view/directory-view.tsx
@@ -1,8 +1,13 @@
+import { TDirectoryType } from '../directory.types';
 import { DirectoryViewTypeButton } from './directory-view-type-button/directory-view-type-button';
 import { DIRECTORY_VIEW_TYPE_OPTIONS } from './directory-view.constants';
 import { useViewType } from './use-directory-view-type.hook';
 
-export function DirectoryView() {
+type DirectoryViewProps = {
+  directoryType: TDirectoryType;
+};
+
+export function DirectoryView({ directoryType }: DirectoryViewProps) {
   const { selectedViewType, changeView } = useViewType();
 
   return (
@@ -16,6 +21,7 @@ export function DirectoryView() {
             onClick={changeView}
             selectedViewType={selectedViewType}
             viewType={option.viewType}
+            directoryType={directoryType}
           />
         );
       })}

--- a/apps/web-app/components/directory/directory-view/use-directory-view-type.hook.ts
+++ b/apps/web-app/components/directory/directory-view/use-directory-view-type.hook.ts
@@ -1,5 +1,8 @@
+import { trackGoal } from 'fathom-client';
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
+import { FATHOM_EVENTS } from '../../../constants';
+import { TDirectoryType } from './../directory.types';
 import { DEFAULT_VIEW_TYPE } from './directory-view.constants';
 import { TViewType, viewTypes } from './directory-view.types';
 
@@ -12,8 +15,18 @@ export function useViewType() {
       : DEFAULT_VIEW_TYPE;
 
   const changeView = useCallback(
-    (newViewType: TViewType) => {
+    (newViewType: TViewType, directoryType: TDirectoryType) => {
       const { viewType, ...restQuery } = query;
+
+      const viewTypeChange =
+        newViewType === 'grid' ? 'viewTypeListToGrid' : 'viewTypeGridToList';
+
+      const generalEventCode = FATHOM_EVENTS.directory.controls[viewTypeChange];
+      generalEventCode && trackGoal(generalEventCode, 0);
+
+      const directoryTypeEventCode =
+        FATHOM_EVENTS[directoryType].directory.controls[viewTypeChange];
+      directoryTypeEventCode && trackGoal(directoryTypeEventCode, 0);
 
       push(
         {

--- a/apps/web-app/components/directory/directory.types.ts
+++ b/apps/web-app/components/directory/directory.types.ts
@@ -1,0 +1,1 @@
+export type TDirectoryType = 'teams' | 'members';

--- a/apps/web-app/constants.ts
+++ b/apps/web-app/constants.ts
@@ -1,6 +1,12 @@
 export const URL_QUERY_VALUE_SEPARATOR = '|';
 export const ITEMS_PER_PAGE = 9;
 export const FATHOM_EVENTS = {
+  directory: {
+    controls: {
+      viewTypeListToGrid: 'BFUWBQXV',
+      viewTypeGridToList: 'L5UM9LWA',
+    },
+  },
   members: {
     directory: {
       filters: {
@@ -15,6 +21,8 @@ export const FATHOM_EVENTS = {
         searchBy: '8BWPXHVB',
         sort: 'WOZNMS0E',
         viewType: 'ZZYU8VJV',
+        viewTypeListToGrid: 'PZUNLXST',
+        viewTypeGridToList: 'QUCCIPTW',
       },
     },
   },
@@ -31,6 +39,8 @@ export const FATHOM_EVENTS = {
         searchBy: 'E5KGF8SF',
         sort: 'R0U6VIQR',
         viewType: '9E11MZ5Q',
+        viewTypeListToGrid: 'KHBW7DAV',
+        viewTypeGridToList: 'RPBE1AWN',
       },
     },
   },

--- a/apps/web-app/pages/members/index.tsx
+++ b/apps/web-app/pages/members/index.tsx
@@ -52,6 +52,7 @@ export default function Members({ members, filtersValues }: MembersProps) {
           <div className="w-[917px] space-y-10">
             <DirectoryHeader
               title="Members"
+              directoryType="members"
               searchPlaceholder="Search for a member"
               count={members.length}
             />

--- a/apps/web-app/pages/teams/index.tsx
+++ b/apps/web-app/pages/teams/index.tsx
@@ -51,6 +51,7 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
           <div className="w-[917px] space-y-10">
             <DirectoryHeader
               title="Teams"
+              directoryType="teams"
               searchPlaceholder="Search for a team"
               count={teams.length}
             />


### PR DESCRIPTION
## Description

1. Events were added to the fathom platform in order to track how frequently the grid view and the list view are used, andidentify the type of directory we are in when the view changes. 

Fathom Events  (Event name | Event ID )
- Directory - Controls - View Type - Grid | BFUWBQXV
- Directory - Controls - View Type - List | L5UM9LWA
- Teams - Controls - View Type - Change from Grid to List | RPBE1AWN
- Teams - Controls - View Type - Change from List to Grid | KHBW7DAV
- Members - Controls - View Type - Change from Grid to List | QUCCIPTW
- Members - Controls - View Type - Change from List to Grid | PZUNLXST

2. Those events are being used with `trackGoal` at the function `useViewType`

## Tickets
- https://pixelmatters.atlassian.net/browse/PL-236

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
