### PR TITLE
fix: redirect profile page of a member that has no teams to 404

### DIFF
--- a/apps/web-app/pages/members/[id].tsx
+++ b/apps/web-app/pages/members/[id].tsx
@@ -55,6 +55,14 @@ export const getServerSideProps = async ({ query, res }) => {
     backLink: string;
   };
   const member = await airtableService.getMember(id);
+
+  // Redirects user to the 404 page if the member has no teams
+  if (!member.teams.length) {
+    return {
+      notFound: true,
+    };
+  }
+
   const teams = await airtableService.getTeamCardsData(
     member.teams,
     TEAM_CARD_FIELDS


### PR DESCRIPTION
## Description

🐞 Sends visitors from a member profile page with no teams to a 404 error page. 

> I used **Ryan Murphy** with the Record ID **reccPxNtOp3raircl** to test this

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-214

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
