### PR TITLE
fix: redirects from profile to 404 page when team or member is invalid

### DIFF
--- a/apps/web-app/components/shared/error-message/error-message.tsx
+++ b/apps/web-app/components/shared/error-message/error-message.tsx
@@ -5,14 +5,20 @@ export function ErrorMessage() {
     <div className="text-center text-sm text-slate-600">
       <h1 className="text-3xl font-bold">Error 404</h1>
       <p className="mt-6 w-96 text-base">
-        We couldn’t find the page you were looking for. <br />
-        Try search what you’re looking for on the {''}
+        The page you were looking for is not available. <br />
+        Please try searching on the {''}
         <Link href="/teams">
           <a className="text-base text-blue-600 outline-none hover:text-blue-700 focus:text-blue-900 active:text-blue-900">
-            teams page
+            teams
           </a>
         </Link>
-        .
+        {''} or {''}
+        <Link href="/members">
+          <a className="text-base text-blue-600 outline-none hover:text-blue-700 focus:text-blue-900 active:text-blue-900">
+            members
+          </a>
+        </Link>
+        {''} pages.
       </p>
     </div>
   );

--- a/apps/web-app/pages/members/[id].tsx
+++ b/apps/web-app/pages/members/[id].tsx
@@ -56,8 +56,9 @@ export const getServerSideProps = async ({ query, res }) => {
   };
   const member = await airtableService.getMember(id);
 
-  // Redirects user to the 404 page if the member has no teams
-  if (!member.teams.length) {
+  // Redirects user to the 404 page if response from
+  // getMember is undefined or the member has no teams
+  if (!member || !member.teams.length) {
     return {
       notFound: true,
     };

--- a/apps/web-app/pages/teams/[id].tsx
+++ b/apps/web-app/pages/teams/[id].tsx
@@ -55,6 +55,15 @@ export const getServerSideProps: GetServerSideProps<TeamProps> = async ({
     backLink: string;
   };
   const team = await airtableService.getTeam(id);
+
+  // Redirects user to the 404 page when we're unable to fetch
+  // a valid team with the provided ID
+  if (!team) {
+    return {
+      notFound: true,
+    };
+  }
+
   const members = await airtableService.getTeamMembers(
     team.name,
     MEMBER_CARD_FIELDS

--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -342,6 +342,16 @@ describe('AirtableService', () => {
     });
   });
 
+  it('should retrieve undefined when Airtable fails to fetch a team', async () => {
+    (<jest.Mock>teamsTableMock.find).mockClear().mockImplementationOnce(() => {
+      throw new Error();
+    });
+
+    const team = await airtableService.getTeam('wrongID');
+    expect(teamsTableMock.find).toHaveBeenCalledTimes(1);
+    expect(team).toEqual(undefined);
+  });
+
   it('should be able to get teams details with the provided id from teams table', async () => {
     (teamsTableMock.select as jest.Mock).mockClear().mockReturnValueOnce({
       all: jest.fn().mockReturnValue([
@@ -683,6 +693,18 @@ describe('AirtableService', () => {
       ],
       twitter: memberMock01.fields.Twitter,
     });
+  });
+
+  it('should retrieve undefined when Airtable fails to fetch a member', async () => {
+    (<jest.Mock>membersTableMock.find)
+      .mockClear()
+      .mockImplementationOnce(() => {
+        throw new Error();
+      });
+
+    const member = await airtableService.getMember('wrongID');
+    expect(membersTableMock.find).toHaveBeenCalledTimes(1);
+    expect(member).toEqual(undefined);
   });
 
   it('should be able to get all members filter values and available members filter values from members table', async () => {

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -58,9 +58,13 @@ class AirtableService {
    * Get a specific team from Airtable.
    */
   public async getTeam(id: string) {
-    const team: IAirtableTeam = await this._teamsTable.find(id);
+    try {
+      const team: IAirtableTeam = await this._teamsTable.find(id);
 
-    return this._parseTeam(team);
+      return this._parseTeam(team);
+    } catch (error) {
+      return;
+    }
   }
 
   /**
@@ -118,9 +122,13 @@ class AirtableService {
    * Get a specific member from Airtable.
    */
   public async getMember(id: string) {
-    const member: IAirtableMember = await this._membersTable.find(id);
+    try {
+      const member: IAirtableMember = await this._membersTable.find(id);
 
-    return this._parseMember(member);
+      return this._parseMember(member);
+    } catch (error) {
+      return;
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

🐞  Redirects to 404 error page, when accessing a member or a team profile with an invalid ID.
✏️  Update 404 error message to include also the Members page with the correspondent link;


## Tickets
- https://pixelmatters.atlassian.net/browse/PL-213

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
