### PR TITLE
fix(PL-220): change social share image URL based on environment

### DIFF
--- a/apps/web-app/seo.config.js
+++ b/apps/web-app/seo.config.js
@@ -13,7 +13,7 @@ export const SEO = {
         url: `${getSiteUrl(
           process.env.NEXT_PUBLIC_VERCEL_ENV,
           process.env.NEXT_PUBLIC_VERCEL_URL
-        )}/assets/images/protocol-labs-network-open-graph.jpg`,
+        )}/assets/images/protocol-labs-network-open-graph.jpg?v1`,
         width: 1280,
         height: 640,
         alt: 'Protocol Labs Network Directory',


### PR DESCRIPTION
## Description

🐞 Make social share image work on Facebook, Twitter, Slack and Linkedin
🛠️ Change social share image URL based on environment

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-220

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] ~~I've added relevant tests for my changes~~
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
