### PR TITLE
fix(PL-220): prefix production URLs with 'www.'

### DIFF
--- a/apps/web-app/seo.config.js
+++ b/apps/web-app/seo.config.js
@@ -1,5 +1,10 @@
 import { getSiteUrl } from './utils/sitemap/sitemap.utils';
 
+const siteUrl = getSiteUrl(
+  process.env.NEXT_PUBLIC_VERCEL_ENV,
+  process.env.NEXT_PUBLIC_VERCEL_URL
+);
+
 export const SEO = {
   titleTemplate: '%s | Protocol Labs Network Directory',
   defaultTitle: 'Protocol Labs Network Directory',
@@ -7,13 +12,10 @@ export const SEO = {
     'The Protocol Labs Network Directory helps network members orient themselves within the network by making it easy to learn about other teams and members, including their roles, capabilities, and experiences.',
   openGraph: {
     type: 'website',
-    url: 'https://plnetwork.io/',
+    url: siteUrl,
     images: [
       {
-        url: `${getSiteUrl(
-          process.env.NEXT_PUBLIC_VERCEL_ENV,
-          process.env.NEXT_PUBLIC_VERCEL_URL
-        )}/assets/images/protocol-labs-network-open-graph.jpg?v1`,
+        url: `${siteUrl}/assets/images/protocol-labs-network-open-graph.jpg?v1`,
         width: 1280,
         height: 640,
         alt: 'Protocol Labs Network Directory',

--- a/apps/web-app/tests/utils/sitemap/sitemap.utils.spec.ts
+++ b/apps/web-app/tests/utils/sitemap/sitemap.utils.spec.ts
@@ -4,7 +4,7 @@ describe('#getSiteUrl', () => {
   const PREVIEW_URL = 'preview-url.com';
 
   it('should return the production URL when environment is production', () => {
-    expect(getSiteUrl('production')).toEqual('https://plnetwork.io');
+    expect(getSiteUrl('production')).toEqual('https://www.plnetwork.io');
   });
 
   it('should return the preview URL when environment is not production and the preview URL is defined', () => {

--- a/apps/web-app/utils/sitemap/sitemap.utils.js
+++ b/apps/web-app/utils/sitemap/sitemap.utils.js
@@ -8,7 +8,7 @@ module.exports = {
    */
   getSiteUrl: function (environment, previewURL) {
     return environment === 'production'
-      ? 'https://plnetwork.io'
+      ? 'https://www.plnetwork.io'
       : previewURL
       ? `https://${previewURL}`
       : 'http://localhost:4200';


### PR DESCRIPTION
## Description

🐞 Prefix production URLs with 'www.' on OpenGraph info and Sitemap

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-220

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] ~~I've added relevant tests for my changes~~
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
