### PR TITLE
feat(PL-268): change other teams label cursor appearance on hover

### DIFF
--- a/apps/web-app/components/shared/members/member-card/member-card.tsx
+++ b/apps/web-app/components/shared/members/member-card/member-card.tsx
@@ -51,8 +51,9 @@ export function MemberCard({ isGrid = true, member }: MemberCardProps) {
             </div>
             {otherTeams.length ? (
               <Tooltip
+                asChild
                 trigger={
-                  <div className="ml-1 flex w-4">
+                  <div className="ml-1 flex w-4 cursor-default">
                     <span className="h-4 w-4 rounded-full bg-slate-100 p-0.5 text-[10px] font-medium leading-3 text-slate-600">
                       +{otherTeams.length}
                     </span>


### PR DESCRIPTION
## Description

🚀 Change cursor appearance on hover to the default appearance, as this element should not appear to be clickable, on members directory cards

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-268

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
