### PR TITLE
fix(PL-294): improve result matching when getting a team's members

### DIFF
--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -897,7 +897,7 @@ describe('AirtableService', () => {
     expect(membersTableMock.select).toHaveBeenCalledTimes(1);
 
     expect(membersTableMock.select).toHaveBeenCalledWith({
-      filterByFormula: 'SEARCH("team_id_01",Teams)',
+      filterByFormula: 'FIND(", team_id_01,", ", " & ARRAYJOIN(Teams) & ",")',
       fields: ['Name'],
       sort: [
         { field: 'Team lead', direction: 'desc' },

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -154,7 +154,7 @@ class AirtableService {
    */
   public async getTeamMembers(teamName: string, fields: string[]) {
     const membersOptions: IListOptions = {
-      filterByFormula: this._getSearchFormula(teamName, 'Teams'),
+      filterByFormula: this._findExactMatchFormula(teamName, 'Teams'),
       fields,
       sort: [
         { field: 'Team lead', direction: 'desc' },
@@ -432,6 +432,14 @@ class AirtableService {
    */
   private _getSearchFormula(queryValue: string, field: string) {
     return `SEARCH("${queryValue}",${field})`;
+  }
+
+  /**
+   * Returns a formula to search results that exactly match provided string
+   * to a given field
+   */
+  private _findExactMatchFormula(queryValue: string, field: string) {
+    return `FIND(", ${queryValue},", ", " & ARRAYJOIN(${field}) & ",")`;
   }
 
   /**


### PR DESCRIPTION
## Description

🐞 Improve result matching when getting a team's members to prevent members from teams whose name is a substring of the provided team's name to show in the resultset

> **Note**
>
> Airtable does not have a direct way of performing such a search, so I've followed what was proposed in [this forum post](https://community.airtable.com/t/filterbyformula-exact-match-on-an-array/20552/3).

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-294

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
