### PR TITLE
feat(PL-289): nest the directory within its own sub-folder

### DIFF
--- a/apps/web-app/components/layout/navbar/menu/menu.tsx
+++ b/apps/web-app/components/layout/navbar/menu/menu.tsx
@@ -15,12 +15,12 @@ export function Menu() {
     {
       icon: UserGroupIcon,
       name: 'Teams',
-      path: '/teams',
+      path: '/directory/teams',
     },
     {
       icon: UserIcon,
       name: 'Members',
-      path: '/members',
+      path: '/directory/members',
     },
   ];
 

--- a/apps/web-app/components/layout/navbar/navbar.tsx
+++ b/apps/web-app/components/layout/navbar/navbar.tsx
@@ -7,7 +7,7 @@ export function Navbar() {
   return (
     <nav className="navbar top-0 h-20 justify-between px-12 only-of-type:shadow-[0_1px_4px_0_#e2e8f0]">
       <div className="flex items-center space-x-5">
-        <Link href="/teams">
+        <Link href="/directory">
           <a className="on-focus">
             <ProtocolLabsLogo
               title="Protocol Labs Network Directory Beta Black Logo"

--- a/apps/web-app/components/members/member-profile/member-profile-teams.tsx
+++ b/apps/web-app/components/members/member-profile/member-profile-teams.tsx
@@ -19,7 +19,7 @@ export function MemberProfileTeams({ teams, roles }: MemberProfileTeamsProps) {
       {teams.map((team, i) => (
         <ProfileCard
           key={`${id}.${team.id}`}
-          url={`/teams/${team.id}`}
+          url={`/directory/teams/${team.id}`}
           imageUrl={team.logo}
           avatarIcon={UserGroupIcon}
           name={team.name}

--- a/apps/web-app/components/shared/error-message/error-message.tsx
+++ b/apps/web-app/components/shared/error-message/error-message.tsx
@@ -7,13 +7,13 @@ export function ErrorMessage() {
       <p className="mt-6 w-96 text-base">
         The page you were looking for is not available. <br />
         Please try searching on the {''}
-        <Link href="/teams">
+        <Link href="/directory/teams">
           <a className="text-base text-blue-600 outline-none hover:text-blue-700 focus:text-blue-900 active:text-blue-900">
             teams
           </a>
         </Link>
         {''} or {''}
-        <Link href="/members">
+        <Link href="/directory/members">
           <a className="text-base text-blue-600 outline-none hover:text-blue-700 focus:text-blue-900 active:text-blue-900">
             members
           </a>

--- a/apps/web-app/components/shared/members/member-card/member-card.tsx
+++ b/apps/web-app/components/shared/members/member-card/member-card.tsx
@@ -21,7 +21,7 @@ export function MemberCard({ isGrid = true, member }: MemberCardProps) {
   return (
     <DirectoryCard
       isGrid={isGrid}
-      cardUrl={`/members/${member.id}?backLink=${backLink}`}
+      cardUrl={`/directory/members/${member.id}?backLink=${backLink}`}
     >
       <DirectoryCardHeader
         isGrid={isGrid}

--- a/apps/web-app/components/shared/teams/team-card/team-card.tsx
+++ b/apps/web-app/components/shared/teams/team-card/team-card.tsx
@@ -17,7 +17,7 @@ export function TeamCard({ team, isGrid = true }: TeamCardProps) {
   return (
     <DirectoryCard
       isGrid={isGrid}
-      cardUrl={`/teams/${team.id}?backLink=${backLink}`}
+      cardUrl={`/directory/teams/${team.id}?backLink=${backLink}`}
     >
       <DirectoryCardHeader
         isGrid={isGrid}

--- a/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
@@ -18,7 +18,7 @@ export function TeamProfileMembers({ members }: TeamProfileMembersProps) {
       {members.map((member) => (
         <ProfileCard
           key={`${id}.${member.id}`}
-          url={`/members/${member?.id}`}
+          url={`/directory/members/${member?.id}`}
           isImageRounded
           imageUrl={member.image}
           avatarIcon={UserIcon}

--- a/apps/web-app/next-sitemap.js
+++ b/apps/web-app/next-sitemap.js
@@ -8,11 +8,11 @@ module.exports = {
   generateRobotsTxt: process.env.VERCEL_ENV === 'production',
   sourceDir: 'dist/apps/web-app/.next',
   outDir: 'dist/apps/web-app/public',
-  exclude: ['/members/sitemap.xml', '/teams/sitemap.xml'],
+  exclude: ['/directory/members/sitemap.xml', '/directory/teams/sitemap.xml'],
   robotsTxtOptions: {
     additionalSitemaps: [
-      `${siteUrl}/members/sitemap.xml`,
-      `${siteUrl}/teams/sitemap.xml`,
+      `${siteUrl}/directory/members/sitemap.xml`,
+      `${siteUrl}/directory/teams/sitemap.xml`,
     ],
   },
 };

--- a/apps/web-app/next.config.js
+++ b/apps/web-app/next.config.js
@@ -33,8 +33,39 @@ let nextConfig = {
   async redirects() {
     return [
       {
+        // Redirect from root to teams directory page
         source: '/',
-        destination: '/teams',
+        destination: '/directory/teams',
+        permanent: false,
+      },
+      {
+        // Redirect from directory root to teams directory page
+        source: '/directory',
+        destination: '/directory/teams',
+        permanent: false,
+      },
+      {
+        // Redirect the old teams directory URL to the new `/directory` URL
+        source: '/teams',
+        destination: '/directory/teams',
+        permanent: false,
+      },
+      {
+        // Redirect the old team profile URLs to the new `/directory` URLs
+        source: '/teams/:id*',
+        destination: '/directory/teams/:id*',
+        permanent: false,
+      },
+      {
+        // Redirect the old members directory URL to the new `/directory` URL
+        source: '/members',
+        destination: '/directory/members',
+        permanent: false,
+      },
+      {
+        // Redirect the old member profile URLs to the new `/directory` URLs
+        source: '/members/:id*',
+        destination: '/directory/members/:id*',
         permanent: false,
       },
     ];

--- a/apps/web-app/pages/directory/members/[id].tsx
+++ b/apps/web-app/pages/directory/members/[id].tsx
@@ -2,13 +2,13 @@ import airtableService from '@protocol-labs-network/airtable';
 import { IMember, ITeam } from '@protocol-labs-network/api';
 import { Breadcrumb } from '@protocol-labs-network/ui';
 import { NextSeo } from 'next-seo';
-import { MemberProfileDetails } from '../../components/members/member-profile/member-profile-details/member-profile-details';
-import { MemberProfileHeader } from '../../components/members/member-profile/member-profile-header/member-profile-header';
-import { MemberProfileOfficeHours } from '../../components/members/member-profile/member-profile-office-hours/member-profile-office-hours';
-import { MemberProfileTeams } from '../../components/members/member-profile/member-profile-teams';
-import { AskToEditCard } from '../../components/shared/ask-to-edit-card/ask-to-edit-card';
-import { TEAM_CARD_FIELDS } from '../../components/shared/teams/team-card/team-card.constants';
-import { useProfileBreadcrumb } from '../../hooks/profile/use-profile-breadcrumb.hook';
+import { MemberProfileDetails } from '../../../components/members/member-profile/member-profile-details/member-profile-details';
+import { MemberProfileHeader } from '../../../components/members/member-profile/member-profile-header/member-profile-header';
+import { MemberProfileOfficeHours } from '../../../components/members/member-profile/member-profile-office-hours/member-profile-office-hours';
+import { MemberProfileTeams } from '../../../components/members/member-profile/member-profile-teams';
+import { AskToEditCard } from '../../../components/shared/ask-to-edit-card/ask-to-edit-card';
+import { TEAM_CARD_FIELDS } from '../../../components/shared/teams/team-card/team-card.constants';
+import { useProfileBreadcrumb } from '../../../hooks/profile/use-profile-breadcrumb.hook';
 
 interface MemberProps {
   member: IMember;
@@ -53,7 +53,7 @@ export default function Member({ member, teams, backLink }: MemberProps) {
 }
 
 export const getServerSideProps = async ({ query, res }) => {
-  const { id, backLink = '/members' } = query as {
+  const { id, backLink = '/directory/members' } = query as {
     id: string;
     backLink: string;
   };

--- a/apps/web-app/pages/directory/members/index.tsx
+++ b/apps/web-app/pages/directory/members/index.tsx
@@ -2,18 +2,18 @@ import airtableService from '@protocol-labs-network/airtable';
 import { IMember } from '@protocol-labs-network/api';
 import { GetServerSideProps } from 'next';
 import { NextSeo } from 'next-seo';
-import { DirectoryHeader } from '../../components/directory/directory-header/directory-header';
-import { useViewType } from '../../components/directory/directory-view/use-directory-view-type.hook';
-import { LoadingOverlay } from '../../components/layout/loading-overlay/loading-overlay';
-import { MembersDirectoryFilters } from '../../components/members/members-directory/members-directory-filters/members-directory-filters';
-import { IMembersFiltersValues } from '../../components/members/members-directory/members-directory-filters/members-directory-filters.types';
-import { parseMembersFilters } from '../../components/members/members-directory/members-directory-filters/members-directory-filters.utils';
-import { MembersDirectoryList } from '../../components/members/members-directory/members-directory-list/members-directory-list';
-import { useDirectoryFiltersFathomLogger } from '../../hooks/plugins/use-directory-filters-fathom-logger.hook';
+import { DirectoryHeader } from '../../../components/directory/directory-header/directory-header';
+import { useViewType } from '../../../components/directory/directory-view/use-directory-view-type.hook';
+import { LoadingOverlay } from '../../../components/layout/loading-overlay/loading-overlay';
+import { MembersDirectoryFilters } from '../../../components/members/members-directory/members-directory-filters/members-directory-filters';
+import { IMembersFiltersValues } from '../../../components/members/members-directory/members-directory-filters/members-directory-filters.types';
+import { parseMembersFilters } from '../../../components/members/members-directory/members-directory-filters/members-directory-filters.utils';
+import { MembersDirectoryList } from '../../../components/members/members-directory/members-directory-list/members-directory-list';
+import { useDirectoryFiltersFathomLogger } from '../../../hooks/plugins/use-directory-filters-fathom-logger.hook';
 import {
   getMembersDirectoryListOptions,
   getMembersDirectoryRequestOptionsFromQuery,
-} from '../../utils/api/list.utils';
+} from '../../../utils/api/list.utils';
 
 type MembersProps = {
   members: IMember[];
@@ -38,7 +38,9 @@ export default function Members({ members, filtersValues }: MembersProps) {
     <>
       <NextSeo title="Members" />
 
-      <LoadingOverlay excludeUrlFn={(url) => url.startsWith('/members/')} />
+      <LoadingOverlay
+        excludeUrlFn={(url) => url.startsWith('/directory/members/')}
+      />
 
       <section className="pl-sidebar flex">
         <div className="w-sidebar fixed left-0 z-40 h-full flex-shrink-0 border-r border-r-slate-200 bg-white">

--- a/apps/web-app/pages/directory/members/sitemap.xml.tsx
+++ b/apps/web-app/pages/directory/members/sitemap.xml.tsx
@@ -1,8 +1,8 @@
 import airtableService from '@protocol-labs-network/airtable';
 import { GetServerSideProps } from 'next';
 import { getServerSideSitemap, ISitemapField } from 'next-sitemap';
-import { getMembersDirectoryRequestOptionsFromQuery } from '../../utils/api/list.utils';
-import { getSiteUrl } from '../../utils/sitemap/sitemap.utils';
+import { getMembersDirectoryRequestOptionsFromQuery } from '../../../utils/api/list.utils';
+import { getSiteUrl } from '../../../utils/sitemap/sitemap.utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export default function MembersSitemap() {}
@@ -15,7 +15,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const members = await airtableService.getMembers(membersListOptions);
 
   const membersProfiles: ISitemapField[] = members.map((member) => ({
-    loc: `${siteUrl}/members/${member.id}`,
+    loc: `${siteUrl}/directory/members/${member.id}`,
     lastmod: new Date().toISOString(),
   }));
 

--- a/apps/web-app/pages/directory/teams/[id].tsx
+++ b/apps/web-app/pages/directory/teams/[id].tsx
@@ -3,13 +3,13 @@ import { IMember, ITeam } from '@protocol-labs-network/api';
 import { Breadcrumb } from '@protocol-labs-network/ui';
 import { GetServerSideProps } from 'next';
 import { NextSeo } from 'next-seo';
-import { AskToEditCard } from '../../components/shared/ask-to-edit-card/ask-to-edit-card';
-import { MEMBER_CARD_FIELDS } from '../../components/shared/members/member-card/member-card.constants';
-import { TeamProfileDetails } from '../../components/teams/team-profile/team-profile-details/team-profile-details';
-import { TeamProfileFunding } from '../../components/teams/team-profile/team-profile-funding/team-profile-funding';
-import { TeamProfileHeader } from '../../components/teams/team-profile/team-profile-header/team-profile-header';
-import { TeamProfileMembers } from '../../components/teams/team-profile/team-profile-members/team-profile-members';
-import { useProfileBreadcrumb } from '../../hooks/profile/use-profile-breadcrumb.hook';
+import { AskToEditCard } from '../../../components/shared/ask-to-edit-card/ask-to-edit-card';
+import { MEMBER_CARD_FIELDS } from '../../../components/shared/members/member-card/member-card.constants';
+import { TeamProfileDetails } from '../../../components/teams/team-profile/team-profile-details/team-profile-details';
+import { TeamProfileFunding } from '../../../components/teams/team-profile/team-profile-funding/team-profile-funding';
+import { TeamProfileHeader } from '../../../components/teams/team-profile/team-profile-header/team-profile-header';
+import { TeamProfileMembers } from '../../../components/teams/team-profile/team-profile-members/team-profile-members';
+import { useProfileBreadcrumb } from '../../../hooks/profile/use-profile-breadcrumb.hook';
 
 interface TeamProps {
   team: ITeam;
@@ -50,7 +50,7 @@ export const getServerSideProps: GetServerSideProps<TeamProps> = async ({
   query,
   res,
 }) => {
-  const { id, backLink = '/teams' } = query as {
+  const { id, backLink = '/directory/teams' } = query as {
     id: string;
     backLink: string;
   };

--- a/apps/web-app/pages/directory/teams/index.tsx
+++ b/apps/web-app/pages/directory/teams/index.tsx
@@ -2,18 +2,18 @@ import airtableService from '@protocol-labs-network/airtable';
 import { ITeam } from '@protocol-labs-network/api';
 import { GetServerSideProps } from 'next';
 import { NextSeo } from 'next-seo';
-import { DirectoryHeader } from '../../components/directory/directory-header/directory-header';
-import { useViewType } from '../../components/directory/directory-view/use-directory-view-type.hook';
-import { LoadingOverlay } from '../../components/layout/loading-overlay/loading-overlay';
-import { TeamsDirectoryFilters } from '../../components/teams/teams-directory/teams-directory-filters/teams-directory-filters';
-import { ITeamsFiltersValues } from '../../components/teams/teams-directory/teams-directory-filters/teams-directory-filters.types';
-import { parseTeamsFilters } from '../../components/teams/teams-directory/teams-directory-filters/teams-directory-filters.utils';
-import { TeamsDirectoryList } from '../../components/teams/teams-directory/teams-directory-list/teams-directory-list';
-import { useDirectoryFiltersFathomLogger } from '../../hooks/plugins/use-directory-filters-fathom-logger.hook';
+import { DirectoryHeader } from '../../../components/directory/directory-header/directory-header';
+import { useViewType } from '../../../components/directory/directory-view/use-directory-view-type.hook';
+import { LoadingOverlay } from '../../../components/layout/loading-overlay/loading-overlay';
+import { TeamsDirectoryFilters } from '../../../components/teams/teams-directory/teams-directory-filters/teams-directory-filters';
+import { ITeamsFiltersValues } from '../../../components/teams/teams-directory/teams-directory-filters/teams-directory-filters.types';
+import { parseTeamsFilters } from '../../../components/teams/teams-directory/teams-directory-filters/teams-directory-filters.utils';
+import { TeamsDirectoryList } from '../../../components/teams/teams-directory/teams-directory-list/teams-directory-list';
+import { useDirectoryFiltersFathomLogger } from '../../../hooks/plugins/use-directory-filters-fathom-logger.hook';
 import {
   getTeamsDirectoryListOptions,
   getTeamsDirectoryRequestOptionsFromQuery,
-} from '../../utils/api/list.utils';
+} from '../../../utils/api/list.utils';
 
 type TeamsProps = {
   teams: ITeam[];
@@ -37,7 +37,9 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
     <>
       <NextSeo title="Teams" />
 
-      <LoadingOverlay excludeUrlFn={(url) => url.startsWith('/teams/')} />
+      <LoadingOverlay
+        excludeUrlFn={(url) => url.startsWith('/directory/teams/')}
+      />
 
       <section className="pl-sidebar flex">
         <div className="w-sidebar fixed left-0 z-40 h-full flex-shrink-0 border-r border-r-slate-200 bg-white">

--- a/apps/web-app/pages/directory/teams/sitemap.xml.tsx
+++ b/apps/web-app/pages/directory/teams/sitemap.xml.tsx
@@ -1,8 +1,8 @@
 import airtableService from '@protocol-labs-network/airtable';
 import { GetServerSideProps } from 'next';
 import { getServerSideSitemap, ISitemapField } from 'next-sitemap';
-import { getTeamsDirectoryRequestOptionsFromQuery } from '../../utils/api/list.utils';
-import { getSiteUrl } from '../../utils/sitemap/sitemap.utils';
+import { getTeamsDirectoryRequestOptionsFromQuery } from '../../../utils/api/list.utils';
+import { getSiteUrl } from '../../../utils/sitemap/sitemap.utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export default function TeamsSitemap() {}
@@ -15,7 +15,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const teams = await airtableService.getTeams(teamsListOptions);
 
   const teamsProfiles: ISitemapField[] = teams.map((team) => ({
-    loc: `${siteUrl}/teams/${team.id}`,
+    loc: `${siteUrl}/directory/teams/${team.id}`,
     lastmod: new Date().toISOString(),
   }));
 

--- a/apps/web-app/pages/index.tsx
+++ b/apps/web-app/pages/index.tsx
@@ -6,7 +6,7 @@ export const getServerSideProps = async () => {
   return {
     redirect: {
       permanent: false,
-      destination: '/teams',
+      destination: '/directory/teams',
     },
   };
 };

--- a/apps/web-app/public/manifest.json
+++ b/apps/web-app/public/manifest.json
@@ -61,11 +61,11 @@
   "shortcuts": [
     {
       "name": "Teams",
-      "url": "/teams"
+      "url": "/directory/teams"
     },
     {
       "name": "Members",
-      "url": "/members"
+      "url": "/directory/members"
     }
   ]
 }


### PR DESCRIPTION
## Description

🚀 Nest the Protocol Labs Network Directory pages into a `/directory` sub-folder, updating the URL structure

> **Note**
> - Updates the URL structure of the application
> - Updates the Web Manifest
> - Updates the Sitemaps
> - Update redirects
> - Add new redirects to ensure that the old URLs redirect the user to the new URLs
> - Update all internal links

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-289

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
