### PR TITLE
chore(pl-250): conceal ids from API responses

### DIFF
--- a/apps/web-api/src/app.module.ts
+++ b/apps/web-api/src/app.module.ts
@@ -11,6 +11,7 @@ import type { ClientOpts } from 'redis';
 import { AppController } from './app.controller';
 import { HealthModule } from './health/health.module';
 import { MyCacheInterceptor } from './interceptors/cache.interceptor';
+import { ConcealEntityIDInterceptor } from './interceptors/conceal-entity-id.interceptor';
 import { MembersModule } from './members/members.module';
 import { ContentTypeMiddleware } from './middlewares/content-type.middleware';
 import { PrismaService } from './prisma.service';
@@ -44,6 +45,10 @@ import { TeamsModule } from './teams/teams.module';
     {
       provide: APP_INTERCEPTOR,
       useClass: MyCacheInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ConcealEntityIDInterceptor,
     },
   ],
 })

--- a/apps/web-api/src/interceptors/conceal-entity-id.interceptor.spec.ts
+++ b/apps/web-api/src/interceptors/conceal-entity-id.interceptor.spec.ts
@@ -1,0 +1,137 @@
+import { ConcealEntityIDInterceptor } from './conceal-entity-id.interceptor';
+
+jest.mock('@nestjs/common');
+jest.mock('rxjs');
+jest.mock('rxjs/operators', () => ({
+  map: jest.fn((data) => data),
+}));
+
+describe('ConcealEntityIDInterceptor', () => {
+  let concealEntityIDInterceptor: ConcealEntityIDInterceptor;
+  const contextMock = null;
+  const getNextMock = jest.fn(function (data) {
+    return {
+      handle: jest.fn().mockReturnThis(),
+      pipe: jest.fn((callback) => callback(data)),
+    };
+  });
+
+  beforeEach(() => {
+    concealEntityIDInterceptor = new ConcealEntityIDInterceptor();
+  });
+
+  describe('when delivering an API response', () => {
+    describe('and the response is just a string', () => {
+      it('should not conceal ids', () => {
+        const responseData = 'String with id: 123';
+        const finalResponse = concealEntityIDInterceptor.intercept(
+          contextMock,
+          getNextMock(responseData)
+        );
+        expect(finalResponse).toBe(responseData);
+      });
+    });
+
+    describe('and the response is just a number', () => {
+      it('should not conceal ids', () => {
+        const responseData = 123;
+        const finalResponse = concealEntityIDInterceptor.intercept(
+          contextMock,
+          getNextMock(responseData)
+        );
+        expect(finalResponse).toBe(responseData);
+      });
+    });
+
+    describe('and the response is an object', () => {
+      describe("and the object hasn't ids", () => {
+        it("shouldn't conceal ids", () => {
+          const responseData = {
+            uid: 123,
+            nested: {
+              uid: '123',
+            },
+          };
+          const finalResponse = concealEntityIDInterceptor.intercept(
+            contextMock,
+            getNextMock(responseData)
+          );
+          expect(finalResponse).toStrictEqual(responseData);
+        });
+      });
+      describe('and the object has ids', () => {
+        it('should conceal ids', () => {
+          const responseData = {
+            id: 123,
+            nested: {
+              id: '123',
+            },
+          };
+          const finalResponse = concealEntityIDInterceptor.intercept(
+            contextMock,
+            getNextMock(responseData)
+          );
+          expect(finalResponse).toStrictEqual({
+            nested: {},
+          });
+        });
+      });
+    });
+
+    describe('and the response is an array with objects', () => {
+      describe("and the objects don't have ids", () => {
+        it("shouldn't conceal ids", () => {
+          const responseData = [
+            {
+              uid: 123,
+              nested: {
+                uid: '123',
+              },
+            },
+            {
+              uid: 123,
+              nested: {
+                uid: '123',
+              },
+            },
+          ];
+          const finalResponse = concealEntityIDInterceptor.intercept(
+            contextMock,
+            getNextMock(responseData)
+          );
+          expect(finalResponse).toStrictEqual(responseData);
+        });
+      });
+      describe('and the objects have ids', () => {
+        it('should conceal ids', () => {
+          const responseData = [
+            {
+              id: 123,
+              nested: {
+                id: '123',
+              },
+            },
+            {
+              id: 123,
+              nested: {
+                id: '123',
+              },
+            },
+          ];
+          const finalResponse = concealEntityIDInterceptor.intercept(
+            contextMock,
+            getNextMock(responseData)
+          );
+          expect(finalResponse).toStrictEqual([
+            {
+              nested: {},
+            },
+            {
+              nested: {},
+            },
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/apps/web-api/src/interceptors/conceal-entity-id.interceptor.ts
+++ b/apps/web-api/src/interceptors/conceal-entity-id.interceptor.ts
@@ -1,0 +1,25 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+/**
+ * This interceptor exists as a security measure because
+ * all the API responses must never include auto-incremental IDs
+ */
+export class ConcealEntityIDInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle().pipe(
+      map((data) => {
+        // Match all ocurrences of id props:
+        const matchIdPropsRegex =
+          /(,?)(\s*)("|'?)\bid("|'?):(\s*)("|'?)\d*("|'?)(\s*)(,?|}?)/gm;
+        // Replace ocurrences with a an empty string:
+        const dataWithoutIds = JSON.stringify(data).replace(
+          matchIdPropsRegex,
+          ''
+        );
+        return typeof data == 'object' ? JSON.parse(dataWithoutIds) : data;
+      })
+    );
+  }
+}


### PR DESCRIPTION
## Description
Added an interceptor to conceal any ids that may appear on every API response.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-250

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
