### PR TITLE
fix(PL-316): fix member profile teams list order

### DIFF
--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -356,25 +356,6 @@ describe('AirtableService', () => {
     (teamsTableMock.select as jest.Mock).mockClear().mockReturnValueOnce({
       all: jest.fn().mockReturnValue([
         {
-          id: 'team_id_01',
-          fields: {
-            Name: 'Team 01',
-            'Short description': 'Short description for Team 01',
-            'Long description': 'Long description for Team 01',
-            Website: 'http://team01.com/ http://team0X.com/',
-            Twitter: '@team01',
-            'Accelerator Programs': ['Seed'],
-            'Network members': ['member_id_01'],
-            Logo: [{ id: 'team_logo_01', url: 'http://team01.com/logo.svg' }],
-            'Tags lookup': ['IT'],
-            'Last Audited': new Date('28/02/1904'),
-            Notes: 'Some notes.',
-            'Last Modified': new Date('28/02/1904'),
-            'Eligible for marketplace credits': true,
-            'Grants program': true,
-          },
-        },
-        {
           id: 'team_id_02',
           fields: {
             Name: 'Team 02',
@@ -393,6 +374,25 @@ describe('AirtableService', () => {
             'Grants program': true,
           },
         },
+        {
+          id: 'team_id_01',
+          fields: {
+            Name: 'Team 01',
+            'Short description': 'Short description for Team 01',
+            'Long description': 'Long description for Team 01',
+            Website: 'http://team01.com/ http://team0X.com/',
+            Twitter: '@team01',
+            'Accelerator Programs': ['Seed'],
+            'Network members': ['member_id_01'],
+            Logo: [{ id: 'team_logo_01', url: 'http://team01.com/logo.svg' }],
+            'Tags lookup': ['IT'],
+            'Last Audited': new Date('28/02/1904'),
+            Notes: 'Some notes.',
+            'Last Modified': new Date('28/02/1904'),
+            'Eligible for marketplace credits': true,
+            'Grants program': true,
+          },
+        },
       ]),
     });
 
@@ -400,15 +400,15 @@ describe('AirtableService', () => {
       [
         { id: 'team_id_01', name: 'team 01' },
         { id: 'team_id_02', name: 'team 02' },
+        { id: 'team_id_03', name: 'team 03' },
       ],
       ['Name']
     );
 
     expect(teamsTableMock.select).toHaveBeenCalledWith({
       filterByFormula:
-        'AND(AND({Name} != "", {Short description} != ""), OR(RECORD_ID()=\'team_id_01\', RECORD_ID()=\'team_id_02\'))',
+        "AND(AND({Name} != \"\", {Short description} != \"\"), OR(RECORD_ID()='team_id_01', RECORD_ID()='team_id_02', RECORD_ID()='team_id_03'))",
       fields: ['Name'],
-      sort: [{ direction: 'asc', field: 'Name' }],
     });
 
     expect(teams).toEqual([

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -70,9 +70,9 @@ class AirtableService {
   /**
    * Get provided fields for provided teams
    */
-  public async getTeamCardsData(teams: IMemberTeam[], fields: string[]) {
-    const teamsId = teams.map(({ id }) => id);
-    const teamsByIdFormula = this._getTeamIdSearchFormula(teamsId);
+  public async getTeamCardsData(memberTeams: IMemberTeam[], fields: string[]) {
+    const teamsIds = memberTeams.map(({ id }) => id);
+    const teamsByIdFormula = this._getTeamIdSearchFormula(teamsIds);
     const listOptions: IListOptions = {
       filterByFormula: [
         'AND(',
@@ -83,10 +83,18 @@ class AirtableService {
         ')',
       ].join(''),
       fields,
-      sort: [{ field: 'Name', direction: 'asc' }],
     };
 
-    return await airtableService.getTeams(listOptions);
+    const teams = await airtableService.getTeams(listOptions);
+    const teamsOnOriginalOrder = teamsIds.reduce((sortedTeams, id) => {
+      const teamWithProvidedId = teams.find((team) => team.id === id);
+
+      !!teamWithProvidedId && sortedTeams.push(teamWithProvidedId as ITeam);
+
+      return sortedTeams;
+    }, <ITeam[]>[]);
+
+    return teamsOnOriginalOrder;
   }
 
   /**


### PR DESCRIPTION
## Description

🐞 Update member's profile page to list its teams in the same order that they're defined on Airtable

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-316

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
