### PR TITLE
feat(PL-288): move directory pages layout into its own page layout

### DIFF
--- a/apps/web-app/components/layout/navbar/menu/menu.spec.tsx
+++ b/apps/web-app/components/layout/navbar/menu/menu.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 import { createMockRouter } from '../../../../utils/test/createMockRouter';
-import Menu from './menu';
+import { Menu } from './menu';
 
 describe('Menu', () => {
   it('should render teams link', () => {

--- a/apps/web-app/components/layout/navbar/menu/menu.tsx
+++ b/apps/web-app/components/layout/navbar/menu/menu.tsx
@@ -58,5 +58,3 @@ export function Menu() {
     </ul>
   );
 }
-
-export default Menu;

--- a/apps/web-app/components/layout/navbar/navbar.tsx
+++ b/apps/web-app/components/layout/navbar/navbar.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { JoinNetworkMenu } from './join-network-menu/join-network-menu';
-import Menu from './menu/menu';
+import { Menu } from './menu/menu';
 import { ReactComponent as ProtocolLabsLogo } from '/public/assets/images/protocol-labs-network-logo-horizontal-black.svg';
 
 export function Navbar() {
@@ -23,5 +23,3 @@ export function Navbar() {
     </nav>
   );
 }
-
-export default Navbar;

--- a/apps/web-app/layouts/directory-layout.tsx
+++ b/apps/web-app/layouts/directory-layout.tsx
@@ -1,0 +1,10 @@
+import { Navbar } from '../components/layout/navbar/navbar';
+
+export function DirectoryLayout({ children }) {
+  return (
+    <>
+      <Navbar />
+      <main className="min-w-[1272px] pt-20">{children}</main>
+    </>
+  );
+}

--- a/apps/web-app/pages/_app.tsx
+++ b/apps/web-app/pages/_app.tsx
@@ -2,26 +2,38 @@ import '@fontsource/inter/400.css';
 import '@fontsource/inter/500.css';
 import '@fontsource/inter/600.css';
 import '@fontsource/inter/700.css';
+import type { NextPage } from 'next';
 import { DefaultSeo } from 'next-seo';
-import { AppProps } from 'next/app';
-import Navbar from '../components/layout/navbar/navbar';
+import type { AppProps } from 'next/app';
+import type { ReactElement } from 'react';
+import { ReactNode } from 'react';
 import { useFathom } from '../hooks/plugins/use-fathom.hook';
 import { SEO } from '../seo.config';
 import './styles.css';
 
-function CustomApp({ Component, pageProps }: AppProps) {
+/* eslint-disable-next-line @typescript-eslint/ban-types */
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+export default function CustomApp({
+  Component,
+  pageProps,
+}: AppPropsWithLayout) {
   // Load Fathom web analytics tracker
   useFathom();
 
-  return (
+  // Use the layout defined at the page level, if available
+  const getLayout = Component.getLayout || ((page: ReactNode) => page);
+
+  return getLayout(
     <>
       <DefaultSeo {...SEO} />
-      <main className="app min-w-[1272px] pt-20">
-        <Navbar />
-        <Component {...pageProps} />
-      </main>
+      <Component {...pageProps} />
     </>
   );
 }
-
-export default CustomApp;

--- a/apps/web-app/pages/directory/members/[id].tsx
+++ b/apps/web-app/pages/directory/members/[id].tsx
@@ -2,6 +2,7 @@ import airtableService from '@protocol-labs-network/airtable';
 import { IMember, ITeam } from '@protocol-labs-network/api';
 import { Breadcrumb } from '@protocol-labs-network/ui';
 import { NextSeo } from 'next-seo';
+import { ReactElement } from 'react';
 import { MemberProfileDetails } from '../../../components/members/member-profile/member-profile-details/member-profile-details';
 import { MemberProfileHeader } from '../../../components/members/member-profile/member-profile-header/member-profile-header';
 import { MemberProfileOfficeHours } from '../../../components/members/member-profile/member-profile-office-hours/member-profile-office-hours';
@@ -9,6 +10,7 @@ import { MemberProfileTeams } from '../../../components/members/member-profile/m
 import { AskToEditCard } from '../../../components/shared/ask-to-edit-card/ask-to-edit-card';
 import { TEAM_CARD_FIELDS } from '../../../components/shared/teams/team-card/team-card.constants';
 import { useProfileBreadcrumb } from '../../../hooks/profile/use-profile-breadcrumb.hook';
+import { DirectoryLayout } from '../../../layouts/directory-layout';
 
 interface MemberProps {
   member: IMember;
@@ -51,6 +53,10 @@ export default function Member({ member, teams, backLink }: MemberProps) {
     </>
   );
 }
+
+Member.getLayout = function getLayout(page: ReactElement) {
+  return <DirectoryLayout>{page}</DirectoryLayout>;
+};
 
 export const getServerSideProps = async ({ query, res }) => {
   const { id, backLink = '/directory/members' } = query as {

--- a/apps/web-app/pages/directory/members/index.tsx
+++ b/apps/web-app/pages/directory/members/index.tsx
@@ -2,6 +2,7 @@ import airtableService from '@protocol-labs-network/airtable';
 import { IMember } from '@protocol-labs-network/api';
 import { GetServerSideProps } from 'next';
 import { NextSeo } from 'next-seo';
+import { ReactElement } from 'react';
 import { DirectoryHeader } from '../../../components/directory/directory-header/directory-header';
 import { useViewType } from '../../../components/directory/directory-view/use-directory-view-type.hook';
 import { LoadingOverlay } from '../../../components/layout/loading-overlay/loading-overlay';
@@ -10,6 +11,7 @@ import { IMembersFiltersValues } from '../../../components/members/members-direc
 import { parseMembersFilters } from '../../../components/members/members-directory/members-directory-filters/members-directory-filters.utils';
 import { MembersDirectoryList } from '../../../components/members/members-directory/members-directory-list/members-directory-list';
 import { useDirectoryFiltersFathomLogger } from '../../../hooks/plugins/use-directory-filters-fathom-logger.hook';
+import { DirectoryLayout } from '../../../layouts/directory-layout';
 import {
   getMembersDirectoryListOptions,
   getMembersDirectoryRequestOptionsFromQuery,
@@ -70,6 +72,10 @@ export default function Members({ members, filtersValues }: MembersProps) {
     </>
   );
 }
+
+Members.getLayout = function getLayout(page: ReactElement) {
+  return <DirectoryLayout>{page}</DirectoryLayout>;
+};
 
 export const getServerSideProps: GetServerSideProps<MembersProps> = async ({
   query,

--- a/apps/web-app/pages/directory/teams/[id].tsx
+++ b/apps/web-app/pages/directory/teams/[id].tsx
@@ -3,6 +3,7 @@ import { IMember, ITeam } from '@protocol-labs-network/api';
 import { Breadcrumb } from '@protocol-labs-network/ui';
 import { GetServerSideProps } from 'next';
 import { NextSeo } from 'next-seo';
+import { ReactElement } from 'react';
 import { AskToEditCard } from '../../../components/shared/ask-to-edit-card/ask-to-edit-card';
 import { MEMBER_CARD_FIELDS } from '../../../components/shared/members/member-card/member-card.constants';
 import { TeamProfileDetails } from '../../../components/teams/team-profile/team-profile-details/team-profile-details';
@@ -10,6 +11,7 @@ import { TeamProfileFunding } from '../../../components/teams/team-profile/team-
 import { TeamProfileHeader } from '../../../components/teams/team-profile/team-profile-header/team-profile-header';
 import { TeamProfileMembers } from '../../../components/teams/team-profile/team-profile-members/team-profile-members';
 import { useProfileBreadcrumb } from '../../../hooks/profile/use-profile-breadcrumb.hook';
+import { DirectoryLayout } from '../../../layouts/directory-layout';
 
 interface TeamProps {
   team: ITeam;
@@ -45,6 +47,10 @@ export default function Team({ team, members, backLink }: TeamProps) {
     </>
   );
 }
+
+Team.getLayout = function getLayout(page: ReactElement) {
+  return <DirectoryLayout>{page}</DirectoryLayout>;
+};
 
 export const getServerSideProps: GetServerSideProps<TeamProps> = async ({
   query,

--- a/apps/web-app/pages/directory/teams/index.tsx
+++ b/apps/web-app/pages/directory/teams/index.tsx
@@ -2,6 +2,7 @@ import airtableService from '@protocol-labs-network/airtable';
 import { ITeam } from '@protocol-labs-network/api';
 import { GetServerSideProps } from 'next';
 import { NextSeo } from 'next-seo';
+import { ReactElement } from 'react';
 import { DirectoryHeader } from '../../../components/directory/directory-header/directory-header';
 import { useViewType } from '../../../components/directory/directory-view/use-directory-view-type.hook';
 import { LoadingOverlay } from '../../../components/layout/loading-overlay/loading-overlay';
@@ -10,6 +11,7 @@ import { ITeamsFiltersValues } from '../../../components/teams/teams-directory/t
 import { parseTeamsFilters } from '../../../components/teams/teams-directory/teams-directory-filters/teams-directory-filters.utils';
 import { TeamsDirectoryList } from '../../../components/teams/teams-directory/teams-directory-list/teams-directory-list';
 import { useDirectoryFiltersFathomLogger } from '../../../hooks/plugins/use-directory-filters-fathom-logger.hook';
+import { DirectoryLayout } from '../../../layouts/directory-layout';
 import {
   getTeamsDirectoryListOptions,
   getTeamsDirectoryRequestOptionsFromQuery,
@@ -69,6 +71,10 @@ export default function Teams({ teams, filtersValues }: TeamsProps) {
     </>
   );
 }
+
+Teams.getLayout = function getLayout(page: ReactElement) {
+  return <DirectoryLayout>{page}</DirectoryLayout>;
+};
 
 export const getServerSideProps: GetServerSideProps<TeamsProps> = async ({
   query,

--- a/apps/web-app/tailwind.config.js
+++ b/apps/web-app/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
   content: [
     join(__dirname, 'pages/**/*.{js,ts,jsx,tsx}'),
     join(__dirname, 'components/**/*.{js,ts,jsx,tsx}'),
+    join(__dirname, 'layouts/**/*.{js,ts,jsx,tsx}'),
     ...createGlobPatternsForDependencies(__dirname),
   ],
 };


### PR DESCRIPTION
## Description

🚀 Move the directory pages layout into its own page layout

> **Note**
> Documentation for this feature is available [here](https://nextjs.org/docs/basic-features/layouts).

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-288

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] ~~I've added relevant tests for my changes~~
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
