### PR TITLE
feat(pl-303): add teams endpoints

### DIFF
--- a/apps/web-api/src/teams/__mocks__/teams.mocks.ts
+++ b/apps/web-api/src/teams/__mocks__/teams.mocks.ts
@@ -1,0 +1,53 @@
+import { faker } from '@faker-js/faker';
+import { FundingStage, Team } from '@prisma/client';
+import { Factory } from 'fishery';
+import { prisma } from '../../../prisma/index';
+import { TestFactorySeederParams } from '../../utils/factory-interfaces';
+
+async function createFundingStage() {
+  const fundingStageFactory = Factory.define<FundingStage>(({ sequence }) => ({
+    id: sequence,
+    uid: `funding-stage-${sequence}`,
+    title: 'Funding Stage Title',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }));
+
+  const fundingStage = await fundingStageFactory.build();
+  await prisma.fundingStage.create({ data: fundingStage });
+
+  return fundingStage;
+}
+
+export async function createTeam({ amount }: TestFactorySeederParams) {
+  const fundingStage = await createFundingStage();
+
+  const teamFactory = Factory.define<Team>(({ sequence }) => {
+    const team = {
+      id: sequence,
+      uid: `uid-${sequence}`,
+      name: `Team ${sequence}`,
+      logo: 'logo',
+      blog: faker.internet.url(),
+      website: faker.internet.url(),
+      twitterHandler: faker.name.firstName(),
+      shortDescripton: faker.lorem.sentence(),
+      longDescripton: faker.lorem.paragraph(),
+      filecoinUser: true,
+      ipfsUser: true,
+      plnFriend: true,
+      startDate: new Date(),
+      endDate: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      fundingStageUid: fundingStage.uid,
+    };
+
+    return team;
+  });
+
+  const teams = await teamFactory.buildList(amount);
+  await prisma.team.createMany({
+    data: teams,
+  });
+}

--- a/apps/web-api/src/teams/teams.controller.ts
+++ b/apps/web-api/src/teams/teams.controller.ts
@@ -1,44 +1,23 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
-import { Team } from '@prisma/client';
-import { Api, initNestServer } from '@ts-rest/nest';
-import { apiTeams } from 'libs/contracts/src/lib/contract-team';
-import { CreateTeamSchemaDto } from 'libs/contracts/src/schema';
+import { Controller } from '@nestjs/common';
+import { ApiParam } from '@nestjs/swagger';
+import { Api, ApiDecorator, initNestServer } from '@ts-rest/nest';
+import { apiTeam } from 'libs/contracts/src/lib/contract-team';
 import { TeamsService } from './teams.service';
 
-const server = initNestServer(apiTeams);
-
-@Controller({
-  version: '1',
-})
+const server = initNestServer(apiTeam);
+type RouteShape = typeof server.routeShapes;
+@Controller()
 export class TeamsController {
   constructor(private readonly teamsService: TeamsService) {}
 
-  @Post('teams')
-  create(@Body() createTeamDto: CreateTeamSchemaDto): Promise<Team> {
-    return this.teamsService.create(createTeamDto);
-  }
-
-  @Get('teams:uid')
-  findOne(@Param('uid') uid: string): Promise<Team | null> {
-    return this.teamsService.findOne({ uid });
-  }
-
   @Api(server.route.getTeams)
   findAll() {
-    const teams = this.teamsService.findAll();
-    return teams;
+    return this.teamsService.findAll();
   }
 
-  @Post('teams:uid')
-  update(
-    @Param('uid') uid: string,
-    @Body() updateTeamDto: CreateTeamSchemaDto
-  ): Promise<Team | null> {
-    return this.teamsService.update(updateTeamDto, { uid: uid });
-  }
-
-  @Delete('teams:uid')
-  delete(@Param('uid') uid: string): Promise<Team | null> {
-    return this.teamsService.delete({ uid: uid });
+  @Api(server.route.getTeam)
+  @ApiParam({ name: 'uid', type: 'string' })
+  findOne(@ApiDecorator() { params: { uid } }: RouteShape['getTeam']) {
+    return this.teamsService.findOne(uid);
   }
 }

--- a/apps/web-api/src/teams/teams.service.ts
+++ b/apps/web-api/src/teams/teams.service.ts
@@ -1,46 +1,15 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma, Team } from '@prisma/client';
-import { CreateTeamSchemaDto } from 'libs/contracts/src/schema/team';
 import { PrismaService } from '../prisma.service';
 
 @Injectable()
 export class TeamsService {
   constructor(private prisma: PrismaService) {}
 
-  async findOne(
-    teamWhereUniqueInput: Prisma.TeamWhereUniqueInput
-  ): Promise<Team | null> {
-    return this.prisma.team.findUnique({
-      where: teamWhereUniqueInput,
-      include: {
-        members: true,
-      },
-    });
-  }
-
-  async findAll(): Promise<Team[]> {
+  async findAll() {
     return this.prisma.team.findMany();
   }
 
-  create(createTeamInput: Prisma.TeamCreateInput) {
-    return this.prisma.team.create({
-      data: createTeamInput,
-    });
-  }
-
-  async update(
-    updateTeamInput: CreateTeamSchemaDto,
-    where: Prisma.TeamWhereUniqueInput
-  ): Promise<Team | null> {
-    return this.prisma.team.update({
-      where,
-      data: updateTeamInput,
-    });
-  }
-
-  async delete(where: Prisma.TeamWhereUniqueInput): Promise<Team | null> {
-    return this.prisma.team.delete({
-      where,
-    });
+  findOne(uid: string) {
+    return this.prisma.team.findUniqueOrThrow({ where: { uid } });
   }
 }

--- a/libs/contracts/src/lib/contract-team.ts
+++ b/libs/contracts/src/lib/contract-team.ts
@@ -1,24 +1,24 @@
 import { initContract } from '@ts-rest/core';
-import { CreateTeamSchema, GetTeamSchema, TeamSchema } from '../schema';
+import { ResponseTeamSchema } from '../schema/team';
+import { getAPIVersionAsPath } from '../utils/versioned-path';
 
 const contract = initContract();
 
-export const apiTeams = contract.router({
+export const apiTeam = contract.router({
   getTeams: {
     method: 'GET',
-    path: '/teams',
+    path: `${getAPIVersionAsPath('1')}/teams`,
     responses: {
-      200: GetTeamSchema.array(),
+      200: ResponseTeamSchema.array(),
+    },
+    summary: 'Get all teams',
+  },
+  getTeam: {
+    method: 'GET',
+    path: `${getAPIVersionAsPath('1')}/teams/:uid`,
+    responses: {
+      200: ResponseTeamSchema,
     },
     summary: 'Get a team',
-  },
-  createTeam: {
-    method: 'POST',
-    path: '/team',
-    responses: {
-      201: TeamSchema,
-    },
-    body: CreateTeamSchema,
-    summary: 'Create a team',
   },
 });

--- a/libs/contracts/src/schema/team.ts
+++ b/libs/contracts/src/schema/team.ts
@@ -35,20 +35,7 @@ export const CreateTeamSchema = TeamSchema.pick({
   fundingStageUid: true,
 });
 
-export const GetTeamSchema = TeamSchema.pick({
-  uid: true,
-  name: true,
-  logo: true,
-  blog: true,
-  website: true,
-  twitterHandler: true,
-  shortDescripton: true,
-  longDescripton: true,
-  filecoinUser: true,
-  ipfsUser: true,
-  plnFriend: true,
-  fundingStageUid: true,
-});
+export const ResponseTeamSchema = TeamSchema.omit({ id: true });
 
 export class TeamDto extends createZodDto(TeamSchema) {}
 


### PR DESCRIPTION
## Description

- Endpoint follows the OpenAPI spec
- Response follows the following schema:

```
  uid: string
  name: string
  logo: string
  blog: string
  website: string
  twitterHandler: string
  shortDescripton: string
  longDescripton: string
  filecoinUser: boolean
  ipfsUser: boolean
  plnFriend: boolean
  startDate: date
  endDate: date
  createdAt: date
  updatedAt: date
  fundingStageUid: string

```

Missing requirements:

- Needs to allow searching/filtering results by name, shortDescription, `plnFriend`, `industryTags`, `acceleratorPrograms`, `fundingStage`, `filecoinUser`  and `ipfsUser`
- Needs to allow choosing only specific fields to be included in the response
- Needs to be paginated
- Needs to be able to return a response with all the results
- Endpoint allows the sorting of results (ascending, descending) by multiple fields

## Tickets

- https://pixelmatters.atlassian.net/jira/software/projects/PL/boards/96?selectedIssue=PL-303

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
