### PR TITLE
fix(pl-270): change clear filters button from directories empty state

### DIFF
--- a/apps/web-app/components/directory/directory-empty/directory-empty.spec.tsx
+++ b/apps/web-app/components/directory/directory-empty/directory-empty.spec.tsx
@@ -23,7 +23,7 @@ describe('DirectoryEmpty', () => {
     );
 
     const clearFiltersBtn = screen.getByRole('button', {
-      name: /clear the filters/i,
+      name: /clear all the criteria/i,
     });
     fireEvent.click(clearFiltersBtn);
     expect(push).toHaveBeenCalledTimes(1);

--- a/apps/web-app/components/directory/directory-empty/directory-empty.tsx
+++ b/apps/web-app/components/directory/directory-empty/directory-empty.tsx
@@ -24,7 +24,7 @@ export function DirectoryEmpty({ filterProperties }: DirectoryEmptyProps) {
         className="text-blue-600 outline-none hover:text-blue-700 focus:text-blue-900 active:text-blue-900"
         onClick={() => clearFilters()}
       >
-        clear the filters
+        clear all the criteria
       </button>
       .
     </div>

--- a/apps/web-app/components/directory/directory-list/directory-list.tsx
+++ b/apps/web-app/components/directory/directory-list/directory-list.tsx
@@ -18,7 +18,9 @@ export function DirectoryList({
 
       {!itemsCount ? (
         <div className="flex justify-center">
-          <DirectoryEmpty filterProperties={filterProperties} />
+          <DirectoryEmpty
+            filterProperties={[...filterProperties, 'searchBy']}
+          />
         </div>
       ) : null}
     </>


### PR DESCRIPTION
## Description

🐞 Change clear filters button from directories empty state:
- modifies so that it also clears the search field
- modify the button text to 'clear the criteria'

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-270

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
