### PR TITLE
fix: require redis tls only for remote environments

### DIFF
--- a/apps/web-api/src/app.module.ts
+++ b/apps/web-api/src/app.module.ts
@@ -21,6 +21,7 @@ import { ContentTypeMiddleware } from './middlewares/content-type.middleware';
 import { PrismaService } from './prisma.service';
 import { SkillsModule } from './skills/skills.module';
 import { TeamsModule } from './teams/teams.module';
+import { IS_DEV_ENVIRONMENT } from './utils/constants';
 
 @Module({
   controllers: [AppController],
@@ -38,10 +39,12 @@ import { TeamsModule } from './teams/teams.module';
       isGlobal: true,
       ttl: 86400, // 1 day in seconds
       max: 100, // maximum number of items in cache
-      tls: {
-        rejectUnauthorized: false,
-        requestCert: true,
-      },
+      tls: !IS_DEV_ENVIRONMENT
+        ? {
+            rejectUnauthorized: false,
+            requestCert: true,
+          }
+        : null,
     }),
     BullModule.forRoot({
       redis: {

--- a/apps/web-api/src/utils/constants.ts
+++ b/apps/web-api/src/utils/constants.ts
@@ -9,3 +9,5 @@ export const ALLOWED_CORS_ORIGINS = {
   [APP_ENV.STAGING]: /.-protocol-labs-spaceport.vercel.app/,
   [APP_ENV.PRODUCTION]: 'https://www.plnetwork.io',
 };
+
+export const IS_DEV_ENVIRONMENT = process.env.ENVIRONMENT !== APP_ENV.DEV;


### PR DESCRIPTION
## Description
Previously we've applied a fix to make the cache module configuration work with Heroku (which applies TLS) that we currently don't have locally which caused almost any API requests to fail.

So for the time being, we'll only enforce TLS on remote environments.

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [ ] ~~I've added relevant tests for my changes~~
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
