### PR TITLE
fix: add performant database cloning for e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       postgres:
-        image: postgres
+        image: postgres:14
         env:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: postgres
@@ -40,6 +40,14 @@ jobs:
 
       - name: Derive base and head SHAs required for `nx affected` commands
         uses: nrwl/nx-set-shas@v2
+
+      # - name: Match PostgreSQL client version with the server's (v13)
+      #   run: |
+      #     sudo apt-get update && sudo apt-get -y install wget ca-certificates apt-transport-https gnupg
+      #     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 13" > /etc/apt/sources.list.d/pgdg.list'
+      #     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+      #     sudo apt-get -y remove postgres*
+      #     sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get -y install postgresql-13
 
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache --check-cache

--- a/apps/web-api/jest.config.js
+++ b/apps/web-api/jest.config.js
@@ -7,6 +7,8 @@ module.exports = {
     },
   },
   testEnvironment: 'node',
+  // Temporary fix for CI/CD issue: https://d.pr/i/x1Qfk7
+  testTimeout: 30000,
   transform: {
     '^.+\\.[tj]s$': 'ts-jest',
   },

--- a/apps/web-api/prisma/__mocks__/index.ts
+++ b/apps/web-api/prisma/__mocks__/index.ts
@@ -1,21 +1,33 @@
 import { PrismaClient } from '@prisma/client';
+import { IS_DEV_ENVIRONMENT } from 'apps/web-api/src/utils/constants';
 import { execSync } from 'child_process';
 import { join } from 'path';
 import { URL } from 'url';
 import { v4 } from 'uuid';
 
+const defaultPrisma = new PrismaClient({
+  datasources: { db: { url: process.env.DATABASE_URL } },
+});
+
 // Retrieves the full database URL with the provided schema name
-const generateDatabaseURL = (schema: string) => {
-  if (!process.env.DATABASE_URL) {
+const generateDatabaseURL = (newId: string) => {
+  if (!sourceUrl) {
     throw new Error('please provide a database url');
   }
-  const url = new URL(process.env.DATABASE_URL);
-  url.searchParams.append('schema', schema);
-  return url.toString();
+  const currentUrl = /:\d+\/(?<name>\w+)(\??)/.exec(sourceUrl);
+  const databaseName = currentUrl?.groups?.name || '';
+  const newUrl = new URL(
+    IS_DEV_ENVIRONMENT ? sourceUrl.replace(databaseName, newId) : sourceUrl
+  );
+  if (!IS_DEV_ENVIRONMENT) {
+    newUrl.searchParams.append('schema', newId);
+  }
+  return newUrl.toString();
 };
 
 //  Build a new database URL from a randomly generated schema name:
-const schemaId = `test-${v4()}`;
+let baseId;
+const newId = `test-${v4()}`;
 const prismaBinary = join(
   __dirname,
   '..',
@@ -27,7 +39,9 @@ const prismaBinary = join(
   'prisma'
 );
 const schemaPath = join(__dirname, '..', 'schema.prisma');
-const url = generateDatabaseURL(schemaId);
+const sourceUrl = process.env.DATABASE_URL || '';
+const url = generateDatabaseURL(newId);
+
 // Reassign the default database URL environment variable from the newly generated URL:
 process.env.DATABASE_URL = url;
 
@@ -36,20 +50,59 @@ export const prisma = new PrismaClient({
   datasources: { db: { url } },
 });
 
+const getDatabaseUrlWithoutParams = (dbUrl: string) => dbUrl.split('?')[0];
+
+// Create the base database to clone from:
+beforeAll(async () => {
+  if (!IS_DEV_ENVIRONMENT) return;
+  baseId = `original-${v4()}`;
+  await defaultPrisma.$executeRawUnsafe(`CREATE DATABASE "${baseId}";`);
+  execSync(
+    `pg_dump --no-owner --no-privileges --if-exists --clean --schema-only ${getDatabaseUrlWithoutParams(
+      sourceUrl
+    )} | psql ${getDatabaseUrlWithoutParams(url.replace(newId, baseId))}`
+  );
+});
+
 // Create a new & isolated database right before running each test
-beforeEach(() => {
-  execSync(`${prismaBinary} db push --schema=${schemaPath}`, {
-    env: {
-      ...process.env,
-      DATABASE_URL: generateDatabaseURL(schemaId),
-    },
-  });
+beforeEach(async () => {
+  if (!IS_DEV_ENVIRONMENT) {
+    execSync(`${prismaBinary} db push --schema=${schemaPath}`, {
+      env: {
+        ...process.env,
+        DATABASE_URL: generateDatabaseURL(newId),
+      },
+    });
+    return;
+  }
+
+  execSync(
+    `psql ${getDatabaseUrlWithoutParams(
+      sourceUrl
+    )} -c 'CREATE DATABASE "${newId}" WITH TEMPLATE "${baseId}";'`
+  );
 });
 
 // Delete each new testing database right after running a test
 afterEach(async () => {
-  await prisma.$executeRawUnsafe(
-    `DROP SCHEMA IF EXISTS "${schemaId}" CASCADE;`
-  );
+  if (!IS_DEV_ENVIRONMENT) {
+    await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${newId}" CASCADE;`);
+  }
+
   await prisma.$disconnect();
+  // Terminate active connections before dropping cloned database:
+  await defaultPrisma.$executeRawUnsafe(
+    `SELECT pg_terminate_backend(pg_stat_activity.pid) 
+     FROM pg_stat_activity 
+     WHERE pg_stat_activity.datname = '${newId}' 
+     AND pid <> pg_backend_pid();`
+  );
+  // Drop cloned database:
+  await defaultPrisma.$executeRawUnsafe(`DROP DATABASE IF EXISTS "${newId}";`);
+});
+
+// Delete base database:
+afterAll(async () => {
+  if (!IS_DEV_ENVIRONMENT) return;
+  await defaultPrisma.$executeRawUnsafe(`DROP DATABASE IF EXISTS "${baseId}";`);
 });

--- a/apps/web-api/src/accelerator-programs/__mocks__/accelerator-programs.mocks.ts
+++ b/apps/web-api/src/accelerator-programs/__mocks__/accelerator-programs.mocks.ts
@@ -1,6 +1,6 @@
 import { AcceleratorProgram } from '@prisma/client';
 import { Factory } from 'fishery';
-import { prisma } from '../../../prisma/index';
+import { prisma } from '../../../prisma/__mocks__/index';
 import { TestFactorySeederParams } from '../../utils/factory-interfaces';
 
 export async function createAcceleratorProgram({

--- a/apps/web-api/src/app.e2e.spec.ts
+++ b/apps/web-api/src/app.e2e.spec.ts
@@ -8,7 +8,7 @@ import { mainConfig } from './main.config';
 describe('App', () => {
   let app: INestApplication;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule],
       controllers: [AppController],
@@ -18,6 +18,10 @@ describe('App', () => {
     app = moduleRef.createNestApplication();
     mainConfig(app);
     await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
   });
 
   describe('when requesting the /token endpoint', () => {

--- a/apps/web-api/src/app.module.spec.ts
+++ b/apps/web-api/src/app.module.spec.ts
@@ -2,7 +2,6 @@ import { BullModule } from '@nestjs/bull';
 import { CacheModule } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ThrottlerModule } from '@nestjs/throttler';
-import { prisma } from '../prisma/__mocks__';
 import { AppController } from './app.controller';
 import { AppModule } from './app.module';
 
@@ -14,10 +13,6 @@ describe('App Module', () => {
       imports: [AppModule],
       controllers: [AppController],
     }).compile();
-  });
-
-  afterEach(async () => {
-    await prisma.$disconnect();
   });
 
   describe('when loading the app module', () => {

--- a/apps/web-api/src/funding-stages/__mocks__/funding-stages.mocks.ts
+++ b/apps/web-api/src/funding-stages/__mocks__/funding-stages.mocks.ts
@@ -1,6 +1,6 @@
 import { FundingStage } from '@prisma/client';
 import { Factory } from 'fishery';
-import { prisma } from '../../../prisma/index';
+import { prisma } from '../../../prisma/__mocks__/index';
 import { TestFactorySeederParams } from '../../utils/factory-interfaces';
 
 export async function createFundingStage({ amount }: TestFactorySeederParams) {

--- a/apps/web-api/src/industry-tags/__mocks__/industry-tags.mocks.ts
+++ b/apps/web-api/src/industry-tags/__mocks__/industry-tags.mocks.ts
@@ -1,6 +1,6 @@
 import { IndustryCategory, IndustryTag } from '@prisma/client';
 import { Factory } from 'fishery';
-import { prisma } from '../../../prisma/index';
+import { prisma } from '../../../prisma/__mocks__/index';
 import { TestFactorySeederParams } from '../../utils/factory-interfaces';
 
 async function createIndustryCategory() {

--- a/apps/web-api/src/members/__mocks__/members.mocks.ts
+++ b/apps/web-api/src/members/__mocks__/members.mocks.ts
@@ -1,6 +1,6 @@
 import { Location, Member } from '@prisma/client';
 import { Factory } from 'fishery';
-import { prisma } from '../../../prisma/index';
+import { prisma } from '../../../prisma/__mocks__/index';
 import { TestFactorySeederParams } from '../../utils/factory-interfaces';
 
 async function createLocation() {

--- a/apps/web-api/src/skills/__mocks__/skills.mocks.ts
+++ b/apps/web-api/src/skills/__mocks__/skills.mocks.ts
@@ -1,6 +1,6 @@
 import { Skill } from '@prisma/client';
 import { Factory } from 'fishery';
-import { prisma } from '../../../prisma/index';
+import { prisma } from '../../../prisma/__mocks__/index';
 import { TestFactorySeederParams } from '../../utils/factory-interfaces';
 
 export async function createSkill({ amount }: TestFactorySeederParams) {

--- a/apps/web-api/src/teams/__mocks__/teams.mocks.ts
+++ b/apps/web-api/src/teams/__mocks__/teams.mocks.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { FundingStage, Team } from '@prisma/client';
 import { Factory } from 'fishery';
-import { prisma } from '../../../prisma/index';
+import { prisma } from '../../../prisma/__mocks__/index';
 import { TestFactorySeederParams } from '../../utils/factory-interfaces';
 
 async function createFundingStage() {

--- a/apps/web-api/src/utils/constants.ts
+++ b/apps/web-api/src/utils/constants.ts
@@ -10,4 +10,4 @@ export const ALLOWED_CORS_ORIGINS = {
   [APP_ENV.PRODUCTION]: 'https://www.plnetwork.io',
 };
 
-export const IS_DEV_ENVIRONMENT = process.env.ENVIRONMENT !== APP_ENV.DEV;
+export const IS_DEV_ENVIRONMENT = process.env.ENVIRONMENT == APP_ENV.DEV;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,11 +17,11 @@
     "paths": {
       "@protocol-labs-network/airtable": ["libs/airtable/src/index.ts"],
       "@protocol-labs-network/api": ["libs/api/src/index.ts"],
+      "@protocol-labs-network/contracts": ["libs/contracts/src/index.ts"],
       "@protocol-labs-network/storybook-host": [
         "libs/storybook-host/src/index.ts"
       ],
-      "@protocol-labs-network/ui": ["libs/ui/src/index.ts"],
-      "@protocol-labs-network/contracts": ["libs/contracts/src/index.ts"]
+      "@protocol-labs-network/ui": ["libs/ui/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Description
Our previous method of cloning our database (duplicating schemas) for e2e tests was performing poorly, leading us to implement a new approach to address the issue (cloning the whole database).

For now, this will only be applied locally but we might consider reusing it in our CI/CD pipeline if the new method proves as the best possible option. 

## Tickets
- https://pixelmatters.atlassian.net/browse/PL-382

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [ ] ~~I've added relevant tests for my changes~~
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
