### PR TITLE
feat(PL-384): create method for getting all teams

### DIFF
--- a/libs/shared/data-access/src/index.ts
+++ b/libs/shared/data-access/src/index.ts
@@ -1,6 +1,7 @@
 import { apiNested } from '@protocol-labs-network/contracts';
 import { initClient } from '@ts-rest/core';
 import { env } from 'process';
+export * from './shared.types';
 
 export const client = initClient(apiNested, {
   baseUrl: env['WEB_API_BASE_URL'] as string,

--- a/libs/shared/data-access/src/shared.types.ts
+++ b/libs/shared/data-access/src/shared.types.ts
@@ -1,0 +1,6 @@
+export type TListOptions = {
+  orderBy: string;
+  name__contains?: string;
+  select?: string;
+  with?: string;
+};

--- a/libs/teams/data-access/src/index.ts
+++ b/libs/teams/data-access/src/index.ts
@@ -1,6 +1,24 @@
 import { ITeam } from '@protocol-labs-network/api';
 import { TTeamResponse } from '@protocol-labs-network/contracts';
 import { client } from '@protocol-labs-network/shared/data-access';
+import { TTeamListOptions } from './teams.types';
+
+/**
+ * Get teams list from API
+ */
+export const getTeams = async (options: TTeamListOptions) => {
+  const { body, status } = await client.teams.getTeams({
+    query: {
+      ...options,
+      pagination: false,
+      distinct: 'name', // TODO: remove this when the API is fixed
+    },
+  });
+
+  const teams = status === 200 ? body.map((team) => parseTeam(team)) : [];
+
+  return { teams, status };
+};
 
 /**
  * Get team details from API

--- a/libs/teams/data-access/src/teams.types.ts
+++ b/libs/teams/data-access/src/teams.types.ts
@@ -1,0 +1,9 @@
+import { TListOptions } from '@protocol-labs-network/shared/data-access';
+
+export type TTeamListOptions = TListOptions & {
+  'industryTags.title'?: string;
+  'acceleratorPrograms.title'?: string;
+  'fundingStage.title'?: string;
+  'technologies.title'?: string;
+  plnFriend?: boolean;
+};


### PR DESCRIPTION
## Description

🚀 Create a method for getting all teams under teams Data Library;
- Create a type called `TGetOptions` &  TTeamListOptions` to ensure that the `options` received by this **method** stick to the rules specified in the **teams' contract**. 


## Tickets
- https://pixelmatters.atlassian.net/browse/PL-384

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
