### PR TITLE
ci(PL-432): change workflows to use PLN Bot token to perform git operations

### DIFF
--- a/.github/workflows/main-push-sync.yml
+++ b/.github/workflows/main-push-sync.yml
@@ -12,11 +12,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          ref: staging
           fetch-depth: 0
+          token: ${{ secrets.PLN_BOT_TOKEN }}
+
+      - name: Set Git config
+        run: |
+          git config --local user.email "pln-dev@pixelmatters.com"
+          git config --local user.name "PLN-Helper"
 
       - name: Rebase the `main` branch onto the `staging` branch
         run: |
-          git checkout staging
           git rebase origin/main
           git push
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,11 +28,12 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.PLN_BOT_TOKEN }}
 
       - name: Set Git config
         run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "Github Actions"
+          git config --local user.email "pln-dev@pixelmatters.com"
+          git config --local user.name "PLN-Helper"
 
       - name: Rebase the `main` branch onto the `staging` branch
         run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -31,11 +31,12 @@ jobs:
         with:
           ref: staging
           fetch-depth: 0
+          token: ${{ secrets.PLN_BOT_TOKEN }}
 
       - name: Set Git config
         run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "Github Actions"
+          git config --local user.email "pln-dev@pixelmatters.com"
+          git config --local user.name "PLN-Helper"
 
       - name: Rebase the `staging` branch onto the `develop` branch
         run: |


### PR DESCRIPTION
## Description

🛠 Change GitHub workflows to make use of PLN Bot token to perform Git operations to bypass required pull requests on protected branches (`main`, `staging` and `develop`)

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-432

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
