### PR TITLE
fix(PL-440): add new airtable domain to allowed image domains

### DIFF
--- a/apps/web-app/next.config.js
+++ b/apps/web-app/next.config.js
@@ -18,7 +18,7 @@ let nextConfig = {
   images: {
     // List remote domains that have access to Next.js Image Optimization API,
     // to protect the app from malicious users
-    domains: ['dl.airtable.com'],
+    domains: ['dl.airtable.com', 'v5.airtableusercontent.com'],
     // Enable `dangerouslyAllowSVG` and `contentSecurityPolicy` to serve
     // SVG images using the default Image Optimization API
     dangerouslyAllowSVG: true,


### PR DESCRIPTION
## Description

🐞 Add new Airtable domain to list of allowed images domains

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-440

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
