### PR TITLE
fix(PL-468): add missing nested field types on retrieval endpoints

### DIFF
--- a/apps/web-api/prisma/fixtures/members.ts
+++ b/apps/web-api/prisma/fixtures/members.ts
@@ -51,16 +51,18 @@ export const members = async () => await membersFactory.createList(800);
 
 export const memberRelations = async (members) => {
   const skillUids = await getUidsFrom(Prisma.ModelName.Skill);
-  const randomSkills = sampleSize(skillUids, random(0, skillUids.length));
 
-  return members.map((member) => ({
-    where: {
-      id: member.id,
-    },
-    data: {
-      ...(randomSkills.length && {
-        skills: { connect: randomSkills },
-      }),
-    },
-  }));
+  return members.map((member) => {
+    const randomSkills = sampleSize(skillUids, random(0, 5));
+    return {
+      where: {
+        id: member.id,
+      },
+      data: {
+        ...(randomSkills.length && {
+          skills: { connect: randomSkills },
+        }),
+      },
+    };
+  });
 };

--- a/apps/web-api/src/teams/teams.e2e.spec.ts
+++ b/apps/web-api/src/teams/teams.e2e.spec.ts
@@ -1,13 +1,20 @@
 import supertest from 'supertest';
 import { Cache } from 'cache-manager';
 import { INestApplication } from '@nestjs/common';
-import { ResponseTeamWithRelationsSchema } from 'libs/contracts/src/schema/team';
 import { createTeam } from './__mocks__/teams.mocks';
 import { bootstrapTestingApp } from '../utils/bootstrap-testing-app';
 
 describe('TeamsService', () => {
   let app: INestApplication;
   let cacheManager: Cache;
+  let ResponseTeamWithRelationsSchema;
+
+  beforeAll(() => {
+    // Fix to avoid circular dependency issue:
+    ({ ResponseTeamWithRelationsSchema } = jest.requireActual(
+      'libs/contracts/src/schema/team'
+    ));
+  });
 
   beforeEach(async () => {
     ({ app, cacheManager } = await bootstrapTestingApp());

--- a/libs/contracts/src/schema/member.ts
+++ b/libs/contracts/src/schema/member.ts
@@ -28,9 +28,7 @@ export const ResponseMemberWithRelationsSchema = ResponseMemberSchema.extend({
   image: ResponseImageWithRelationsSchema.optional(),
   location: LocationResponseSchema.optional(),
   skills: ResponseSkillSchema.array().optional(),
-  teamMemberRoles: z.lazy(() =>
-    ResponseTeamMemberRoleSchema.array().optional()
-  ),
+  teamMemberRoles: ResponseTeamMemberRoleSchema.array().optional(),
 });
 
 export const CreateMemberSchema = MemberSchema.pick({

--- a/libs/contracts/src/schema/team-member-role.ts
+++ b/libs/contracts/src/schema/team-member-role.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
-import { ResponseMemberSchema } from './member';
-import { ResponseRoleSchema } from './role';
-import { ResponseTeamSchema } from './team';
+import {
+  ResponseMemberSchema,
+  ResponseTeamSchema,
+  ResponseRoleSchema,
+} from './index';
 
 export const TeamMemberRoleSchema = z.object({
   id: z.number().int(),
@@ -15,7 +17,7 @@ export const TeamMemberRoleSchema = z.object({
 export const ResponseTeamMemberRoleSchema = TeamMemberRoleSchema.extend({
   member: z.lazy(() => ResponseMemberSchema).optional(),
   team: z.lazy(() => ResponseTeamSchema).optional(),
-  role: ResponseRoleSchema.optional(),
+  role: z.lazy(() => ResponseRoleSchema).optional(),
 })
   .omit({
     id: true,

--- a/libs/contracts/src/schema/team.ts
+++ b/libs/contracts/src/schema/team.ts
@@ -49,9 +49,7 @@ export const ResponseTeamWithRelationsSchema = ResponseTeamSchema.extend({
   acceleratorPrograms: ResponseAcceleratorProgramSchema.array().optional(),
   industryTags: ResponseIndustryTagSchema.array().optional(),
   fundingStage: ResponseFundingStageSchema.optional(),
-  teamMemberRoles: z.lazy(() =>
-    ResponseTeamMemberRoleSchema.array().optional()
-  ),
+  teamMemberRoles: ResponseTeamMemberRoleSchema.array().optional(),
   technologies: ResponseTechnologySchema.array().optional(),
 });
 


### PR DESCRIPTION
## Description
Updated the QueryParams helper method to include the missing relational nested fields.

Also, did two minor extra changes:
- Change the number of wanted skills to be connected when seeding members
- Came up with a better fix for a circular dependency

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-468

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- ~I've added relevant tests for my changes~
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
