### PR TITLE
fix(PL-472): use fake infinite scroll on members and teams directories

### DIFF
--- a/apps/web-app/components/directory/directory-list/directory-list.tsx
+++ b/apps/web-app/components/directory/directory-list/directory-list.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import { DirectoryEmpty } from '../../../components/directory/directory-empty/directory-empty';
+import { useFakeInfiniteScroll } from '../../../hooks/directory/use-fake-infinite-scroll.hook';
 
 interface DirectoryListProps {
   children: ReactElement[];
@@ -12,9 +13,16 @@ export function DirectoryList({
   itemsCount,
   filterProperties,
 }: DirectoryListProps) {
+  const [visibleItems] = useFakeInfiniteScroll({
+    items: children,
+    lastVisibleItemElementSelector: '.directory-list-items > *:last-child',
+  });
+
   return (
     <>
-      <div className="flex flex-wrap gap-4">{children}</div>
+      <div className="directory-list-items flex flex-wrap gap-4">
+        {visibleItems}
+      </div>
 
       {!itemsCount ? (
         <div className="flex justify-center">

--- a/apps/web-app/hooks/directory/use-fake-infinite-scroll.hook.ts
+++ b/apps/web-app/hooks/directory/use-fake-infinite-scroll.hook.ts
@@ -1,0 +1,61 @@
+import { ReactElement, useCallback, useEffect, useState } from 'react';
+
+type UseFakeInfiniteScrollProps = {
+  items: ReactElement[];
+  lastVisibleItemElementSelector: string;
+};
+
+const ITEMS_PER_PAGE = 30;
+
+export function useFakeInfiniteScroll({
+  items,
+  lastVisibleItemElementSelector,
+}: UseFakeInfiniteScrollProps) {
+  const [visibleItems, setVisibleItems] = useState<typeof items>([]);
+
+  // Set first batch of items based on the items provided
+  useEffect(() => {
+    if (items) {
+      setVisibleItems(items.slice(0, ITEMS_PER_PAGE));
+    }
+  }, [items]);
+
+  useEffect(() => {
+    // Make sure that we show additional items if the first batch of items
+    // is not enough to fill the viewport
+    handleScroll();
+
+    // Listen to the scroll position for showing additional items
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  });
+
+  const handleScroll = useCallback(async () => {
+    // Get last visible item
+    const lastVisibleItem: HTMLDivElement = document.querySelector(
+      lastVisibleItemElementSelector
+    );
+
+    if (lastVisibleItem) {
+      // Get offset from the middle of the last visible item card
+      const lastVisibleItemOffset =
+        lastVisibleItem.offsetTop + lastVisibleItem.clientHeight / 2;
+      const pageOffset = window.pageYOffset + window.innerHeight;
+
+      // Check if user scrolled down till the middle of the last card
+      // and if there are more items to show
+      if (
+        pageOffset > lastVisibleItemOffset &&
+        items.length > visibleItems.length
+      ) {
+        // Show additional items
+        setVisibleItems(items.slice(0, visibleItems.length + ITEMS_PER_PAGE));
+      }
+    }
+  }, [lastVisibleItemElementSelector, items, visibleItems]);
+
+  return [visibleItems] as const;
+}


### PR DESCRIPTION
## Description

🐞 Update teams/members directories to use fake infinite scroll effect to load teams and members cards, to decrease the size of the initial HTML file

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-472
---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
