### PR TITLE
feat(PL-393): add ability to fetch data from teams lib for teams directory

### DIFF
--- a/apps/web-app/next.config.js
+++ b/apps/web-app/next.config.js
@@ -18,7 +18,12 @@ let nextConfig = {
   images: {
     // List remote domains that have access to Next.js Image Optimization API,
     // to protect the app from malicious users
-    domains: ['dl.airtable.com', 'v5.airtableusercontent.com'],
+    // TODO: remove these domains during code cleanup and removal of the Airtable layer
+    domains: [
+      'dl.airtable.com',
+      'v5.airtableusercontent.com',
+      'loremflickr.com',
+    ],
     // Enable `dangerouslyAllowSVG` and `contentSecurityPolicy` to serve
     // SVG images using the default Image Optimization API
     dangerouslyAllowSVG: true,

--- a/apps/web-app/pages/api/members/index.ts
+++ b/apps/web-app/pages/api/members/index.ts
@@ -1,7 +1,7 @@
 import airtableService from '@protocol-labs-network/airtable';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { env } from 'process';
-import { getMembersDirectoryRequestParametersFromQuery } from '../../../utils/api/list.utils';
+import { getMembersDirectoryRequestParametersFromQuery } from '../../../utils/list.utils';
 
 export default async function getMembersHandler(
   req: NextApiRequest,

--- a/apps/web-app/pages/api/teams/index.ts
+++ b/apps/web-app/pages/api/teams/index.ts
@@ -1,7 +1,7 @@
 import airtableService from '@protocol-labs-network/airtable';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { env } from 'process';
-import { getTeamsDirectoryRequestParametersFromQuery } from '../../../utils/api/list.utils';
+import { getTeamsDirectoryRequestParametersFromQuery } from '../../../utils/list.utils';
 
 export default async function getTeamsHandler(
   req: NextApiRequest,

--- a/apps/web-app/pages/directory/members/index.tsx
+++ b/apps/web-app/pages/directory/members/index.tsx
@@ -16,7 +16,7 @@ import { DIRECTORY_SEO } from '../../../seo.config';
 import {
   getMembersDirectoryListOptions,
   getMembersDirectoryRequestOptionsFromQuery,
-} from '../../../utils/api/list.utils';
+} from '../../../utils/list.utils';
 
 type MembersProps = {
   members: IMember[];

--- a/apps/web-app/pages/directory/members/sitemap.xml.tsx
+++ b/apps/web-app/pages/directory/members/sitemap.xml.tsx
@@ -1,7 +1,7 @@
 import airtableService from '@protocol-labs-network/airtable';
 import { GetServerSideProps } from 'next';
 import { getServerSideSitemap, ISitemapField } from 'next-sitemap';
-import { getMembersDirectoryRequestOptionsFromQuery } from '../../../utils/api/list.utils';
+import { getMembersDirectoryRequestOptionsFromQuery } from '../../../utils/list.utils';
 import { getSiteUrl } from '../../../utils/sitemap/sitemap.utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/apps/web-app/pages/directory/teams/sitemap.xml.tsx
+++ b/apps/web-app/pages/directory/teams/sitemap.xml.tsx
@@ -1,7 +1,7 @@
 import airtableService from '@protocol-labs-network/airtable';
 import { GetServerSideProps } from 'next';
 import { getServerSideSitemap, ISitemapField } from 'next-sitemap';
-import { getTeamsDirectoryRequestOptionsFromQuery } from '../../../utils/api/list.utils';
+import { getTeamsDirectoryRequestOptionsFromQuery } from '../../../utils/list.utils';
 import { getSiteUrl } from '../../../utils/sitemap/sitemap.utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/apps/web-app/tests/pages/api/members/index.spec.ts
+++ b/apps/web-app/tests/pages/api/members/index.spec.ts
@@ -2,7 +2,7 @@ import airtableService from '@protocol-labs-network/airtable';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { env } from 'process';
 import getMembersHandler from '../../../../pages/api/members';
-import { getMembersDirectoryRequestParametersFromQuery } from '../../../../utils/api/list.utils';
+import { getMembersDirectoryRequestParametersFromQuery } from '../../../../utils/list.utils';
 
 const mockMembers = {
   records: [{ Name: 'member_01' }, { Name: 'member_02' }],
@@ -27,7 +27,7 @@ jest.mock('@protocol-labs-network/airtable', () => ({
 }));
 
 const mockQueryParamsString = 'mockQueryParamsString';
-jest.mock('../../../utils/api/list.utils', () => ({
+jest.mock('../../../../utils/list.utils', () => ({
   getMembersDirectoryRequestParametersFromQuery: jest.fn(
     () => mockQueryParamsString
   ),

--- a/apps/web-app/tests/pages/api/teams/index.spec.ts
+++ b/apps/web-app/tests/pages/api/teams/index.spec.ts
@@ -2,7 +2,7 @@ import airtableService from '@protocol-labs-network/airtable';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { env } from 'process';
 import getTeamsHandler from '../../../../pages/api/teams';
-import { getTeamsDirectoryRequestParametersFromQuery } from '../../../../utils/api/list.utils';
+import { getTeamsDirectoryRequestParametersFromQuery } from '../../../../utils/list.utils';
 
 const mockTeams = {
   records: [{ Name: 'team_01' }, { Name: 'team_02' }],
@@ -27,7 +27,7 @@ jest.mock('@protocol-labs-network/airtable', () => ({
 }));
 
 const mockQueryParamsString = 'mockQueryParamsString';
-jest.mock('../../../utils/api/list.utils', () => ({
+jest.mock('../../../../utils/list.utils', () => ({
   getTeamsDirectoryRequestParametersFromQuery: jest.fn(
     () => mockQueryParamsString
   ),

--- a/apps/web-app/utils/list.utils.spec.ts
+++ b/apps/web-app/utils/list.utils.spec.ts
@@ -1,5 +1,5 @@
-import { MEMBER_CARD_FIELDS } from '../../../components/shared/members/member-card/member-card.constants';
-import { TEAM_CARD_FIELDS } from '../../../components/shared/teams/team-card/team-card.constants';
+import { MEMBER_CARD_FIELDS } from '../components/shared/members/member-card/member-card.constants';
+import { TEAM_CARD_FIELDS } from '../components/shared/teams/team-card/team-card.constants';
 import {
   getMembersDirectoryListOptions,
   getMembersDirectoryRequestOptionsFromQuery,
@@ -7,7 +7,8 @@ import {
   getTeamsDirectoryListOptions,
   getTeamsDirectoryRequestOptionsFromQuery,
   getTeamsDirectoryRequestParametersFromQuery,
-} from '../../../utils/api/list.utils';
+  stringifyQueryValues,
+} from './list.utils';
 
 describe('#getTeamsDirectoryRequestOptionsFromQuery', () => {
   it('should return valid options when sort is provided and is valid', () => {
@@ -248,5 +249,15 @@ describe('#getMembersDirectoryRequestParametersFromQuery', () => {
     ).toEqual(
       `fields[]=Name&fields[]=Profile picture&fields[]=Role&fields[]=Teams&fields[]=Team name&fields[]=Country&fields[]=State / Province&fields[]=City&fields[]=Metro Area&fields[]=Team lead&fields[]=Skills&sort[0][field]=Name&sort[0][direction]=asc&filterByFormula=${encodedFormula}&pageSize=9`
     );
+  });
+});
+
+describe('#stringifyQueryValues', () => {
+  it('should return a valid string with the values separated by a comma when provided strings with values separated by vertical bar', () => {
+    expect(stringifyQueryValues('IPFS|Filecoin')).toEqual('IPFS,Filecoin');
+  });
+
+  it('should return a valid string with the values separated by a comma when provided an array of strings', () => {
+    expect(stringifyQueryValues(['IPFS', 'Filecoin'])).toEqual('IPFS,Filecoin');
   });
 });

--- a/apps/web-app/utils/list.utils.ts
+++ b/apps/web-app/utils/list.utils.ts
@@ -3,10 +3,10 @@ import { ParsedUrlQuery } from 'querystring';
 import {
   directorySortOptions,
   TDirectorySortOption,
-} from '../../components/directory/directory-sort/directory-sort.types';
-import { MEMBER_CARD_FIELDS } from '../../components/shared/members/member-card/member-card.constants';
-import { TEAM_CARD_FIELDS } from '../../components/shared/teams/team-card/team-card.constants';
-import { ITEMS_PER_PAGE, URL_QUERY_VALUE_SEPARATOR } from '../../constants';
+} from '../components/directory/directory-sort/directory-sort.types';
+import { MEMBER_CARD_FIELDS } from '../components/shared/members/member-card/member-card.constants';
+import { TEAM_CARD_FIELDS } from '../components/shared/teams/team-card/team-card.constants';
+import { ITEMS_PER_PAGE, URL_QUERY_VALUE_SEPARATOR } from '../constants';
 
 /**
  * Returns the options for requesting the teams on the teams directory,
@@ -183,7 +183,7 @@ export function getMembersDirectoryRequestParametersFromQuery(
 /**
  * Gets sort options by parsing the provided sort query parameter.
  */
-function getSortFromQuery(sortQuery?: string) {
+export function getSortFromQuery(sortQuery?: string) {
   const sort = isSortValid(sortQuery) ? sortQuery : 'Name,asc';
   const sortSettings = sort.split(',');
 
@@ -311,4 +311,12 @@ function getTechnologyFormulaFromQuery(
     : technologyQuery.split(URL_QUERY_VALUE_SEPARATOR);
 
   return values.map((value) => `{${value} User} = TRUE()`).join(', ');
+}
+
+/**
+ * Takes in a single argument values, which can be either a string or an array of strings,
+ * and returns a string with the values separated by a comma.
+ */
+export function stringifyQueryValues(values: string | string[]) {
+  return Array.isArray(values) ? values.toString() : values.replace('|', ',');
 }

--- a/apps/web-app/utils/sitemap/sitemap.utils.spec.ts
+++ b/apps/web-app/utils/sitemap/sitemap.utils.spec.ts
@@ -1,4 +1,4 @@
-import { getSiteUrl } from '../../../utils/sitemap/sitemap.utils';
+import { getSiteUrl } from './sitemap.utils';
 
 describe('#getSiteUrl', () => {
   const PREVIEW_URL = 'preview-url.com';

--- a/apps/web-app/utils/teams.utils.spec.ts
+++ b/apps/web-app/utils/teams.utils.spec.ts
@@ -1,0 +1,71 @@
+import { getTeamsListOptions, getTeamsOptionsFromQuery } from './teams.utils';
+
+describe('#getTeamsOptionsFromQuery', () => {
+  it('should return valid options when sort is provided and is valid', () => {
+    expect(
+      getTeamsOptionsFromQuery({
+        sort: 'Name,desc',
+        tags: 'Analytics',
+        fundingStage: 'Seed',
+        acceleratorPrograms: 'IPFS',
+        searchBy: 'void',
+        technology: 'IPFS',
+        includeFriends: 'true',
+      })
+    ).toEqual({
+      'acceleratorPrograms.title__with': 'IPFS',
+      'fundingStage.title__with': 'Seed',
+      'industryTags.title__with': 'Analytics',
+      name__istartswith: 'void',
+      orderBy: '-name',
+      'technologies.title__with': 'IPFS',
+    });
+  });
+
+  it('should return valid options when sort is provided and is invalid', () => {
+    expect(
+      getTeamsOptionsFromQuery({
+        sort: 'invalid',
+      })
+    ).toEqual({
+      orderBy: 'name',
+      plnFriend: false,
+    });
+  });
+
+  it('should return valid options when sort is not provided', () => {
+    expect(
+      getTeamsOptionsFromQuery({
+        tags: 'Analytics',
+        fundingStage: 'Seed',
+        acceleratorPrograms: 'IPFS',
+        searchBy: 'void',
+        technology: 'IPFS|Filecoin',
+        includeFriends: 'true',
+      })
+    ).toEqual({
+      'acceleratorPrograms.title__with': 'IPFS',
+      'fundingStage.title__with': 'Seed',
+      'industryTags.title__with': 'Analytics',
+      name__istartswith: 'void',
+      orderBy: 'name',
+      'technologies.title__with': 'IPFS,Filecoin',
+    });
+  });
+});
+
+describe('#getTeamsListOptions', () => {
+  it('should append teams cards list properties to the provided options', () => {
+    expect(
+      getTeamsListOptions({
+        'acceleratorPrograms.title__with': 'IPFS',
+        orderBy: '-name',
+      })
+    ).toEqual({
+      'acceleratorPrograms.title__with': 'IPFS',
+      orderBy: '-name',
+      pagination: false,
+      select: 'uid,name,shortDescription,logo.url,industryTags.title',
+    });
+  });
+});

--- a/apps/web-app/utils/teams.utils.ts
+++ b/apps/web-app/utils/teams.utils.ts
@@ -1,0 +1,51 @@
+import { ParsedUrlQuery } from 'querystring';
+import { getSortFromQuery, stringifyQueryValues } from './list.utils';
+
+/**
+ * Returns the options for requesting the teams on the teams directory,
+ * based on the provided query parameters.
+ */
+export function getTeamsOptionsFromQuery(queryParams: ParsedUrlQuery) {
+  const {
+    sort,
+    tags,
+    acceleratorPrograms,
+    fundingStage,
+    searchBy,
+    technology,
+    includeFriends,
+  } = queryParams;
+
+  const sortFromQuery = getSortFromQuery(sort?.toString());
+  const sortField = sortFromQuery.field.toLowerCase();
+
+  return {
+    ...(technology
+      ? { 'technologies.title__with': stringifyQueryValues(technology) }
+      : {}),
+    ...(acceleratorPrograms
+      ? {
+          'acceleratorPrograms.title__with':
+            stringifyQueryValues(acceleratorPrograms),
+        }
+      : {}),
+    ...(fundingStage
+      ? { 'fundingStage.title__with': stringifyQueryValues(fundingStage) }
+      : {}),
+    ...(tags ? { 'industryTags.title__with': stringifyQueryValues(tags) } : {}),
+    ...(includeFriends ? {} : { plnFriend: false }),
+    ...(searchBy ? { name__istartswith: stringifyQueryValues(searchBy) } : {}),
+    orderBy: `${sortFromQuery.direction === 'desc' ? '-' : ''}${sortField}`,
+  };
+}
+
+/**
+ * Get the options for requesting the teams on the teams directory.
+ */
+export function getTeamsListOptions(options) {
+  return {
+    ...options,
+    select: 'uid,name,shortDescription,logo.url,industryTags.title',
+    pagination: false,
+  };
+}

--- a/libs/teams/data-access/src/index.spec.ts
+++ b/libs/teams/data-access/src/index.spec.ts
@@ -261,8 +261,18 @@ describe('getTeamsFilterValues', () => {
     const filters = await getTeamsFilters(options);
 
     expect(filters).toEqual({
-      valuesByFilter: [],
-      availableValuesByFilter: [],
+      availableValuesByFilter: {
+        acceleratorPrograms: [],
+        fundingStage: [],
+        tags: [],
+        technology: [],
+      },
+      valuesByFilter: {
+        acceleratorPrograms: [],
+        fundingStage: [],
+        tags: [],
+        technology: [],
+      },
     });
   });
 });

--- a/libs/teams/data-access/src/index.ts
+++ b/libs/teams/data-access/src/index.ts
@@ -1,8 +1,7 @@
-import { IAirtableTeamsFiltersValues } from '@protocol-labs-network/airtable';
 import { ITeam } from '@protocol-labs-network/api';
 import { TTeamResponse } from '@protocol-labs-network/contracts';
 import { client } from '@protocol-labs-network/shared/data-access';
-import { TTeamListOptions } from './teams.types';
+import { TTeamListOptions, TTeamsFiltersValues } from './teams.types';
 
 /**
  * Get teams list from API
@@ -88,9 +87,16 @@ export const getTeamsFilters = async (options: TTeamListOptions) => {
   ]);
 
   if (valuesByFilter.status !== 200 || availableValuesByFilter.status !== 200) {
+    const emptyFilters = {
+      tags: [],
+      acceleratorPrograms: [],
+      fundingStage: [],
+      technology: [],
+    };
+
     return {
-      valuesByFilter: [],
-      availableValuesByFilter: [],
+      valuesByFilter: emptyFilters,
+      availableValuesByFilter: emptyFilters,
     };
   }
 
@@ -145,7 +151,7 @@ const parseTeamsFilters = (teams: TTeamResponse[]) => {
       acceleratorPrograms: [],
       fundingStage: [],
       technology: [],
-    } as IAirtableTeamsFiltersValues
+    } as TTeamsFiltersValues
   );
 
   Object.values(filtersValues).forEach((value) => value.sort());
@@ -162,3 +168,5 @@ const getUniqueFilterValues = (
 ): string[] => {
   return [...new Set([...uniqueValues, ...(newValues || [])])];
 };
+
+export * from './teams.types';

--- a/libs/teams/data-access/src/teams.types.ts
+++ b/libs/teams/data-access/src/teams.types.ts
@@ -7,3 +7,10 @@ export type TTeamListOptions = TListOptions & {
   'fundingStage.title__with'?: string;
   plnFriend?: boolean;
 };
+
+export type TTeamsFiltersValues = {
+  tags: string[];
+  acceleratorPrograms: string[];
+  fundingStage: string[];
+  technology: string[];
+};


### PR DESCRIPTION
## Description

🚀 Teams Directory - Add ability to fetch data from directory data library:
- Add a domain to the whitelist for the Next.js Image Optimization API (the domain serves the backend mock data phase);
- Add `USE_CUSTOM_PLNETWORK_API` flag: if set to true methods that settle teams' directory page will use the new endpoint of the new backend;

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-393

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
