### PR TITLE
feat(pl-476): log getTeams function failures on sentry

### DIFF
--- a/apps/web-app/sentry.client.config.ts
+++ b/apps/web-app/sentry.client.config.ts
@@ -5,4 +5,5 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.2,
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'development',
+  normalizeDepth: 10,
 });

--- a/apps/web-app/sentry.server.config.ts
+++ b/apps/web-app/sentry.server.config.ts
@@ -5,4 +5,5 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.2,
   environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'development',
+  normalizeDepth: 10,
 });


### PR DESCRIPTION
## Description

🚀 Monitors Airtable failures from `getTeams` and logs error details to sentry;

- `Sentry.withScope` is a method that allows creating new scope for an event in Sentry. It is a container for event metadata, such as tags, extra data, and user information;
-  `scope.setTag` is a method that allows adding tags to the event. Tags are key-value pairs that provide additional context about the event;
-  `scope.setContext` is a method that allows adding extra data to the event. Extra data is any additional information that you want to attach to the event. In this case, it's adding the `requestOptions` object to the event;
- When an error occurs and the `captureException` method is called, it will send an event to Sentry with the metadata that was added to the scope, such as tags and extra data. The browser will not be affected by the event being captured, it will only be sent to Sentry.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-476

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
