### PR TITLE
fix(PL-473): change event code from join as team

### DIFF
--- a/apps/web-app/components/layout/navbar/join-network-menu/join-network-menu.tsx
+++ b/apps/web-app/components/layout/navbar/join-network-menu/join-network-menu.tsx
@@ -26,7 +26,7 @@ const JOIN_NETWORK_MENU_OPTIONS: IMenuOption[] = [
     icon: UserGroupIcon,
     label: 'As a Team',
     url: 'https://airtable.com/shrCUt3HKrxd7EDEw',
-    eventCode: FATHOM_EVENTS.directory.joinNetworkAsMember,
+    eventCode: FATHOM_EVENTS.directory.joinNetworkAsTeam,
   },
 ];
 


### PR DESCRIPTION
## Description

🐞 Changes the Fathom event code linked to 'join the network as team' to the proper one. 

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-473

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
