### PR TITLE
feat(PL-400): adapt membership sources to new data model

### DIFF
--- a/apps/web-app/components/teams/team-profile/team-profile-funding/team-profile-funding.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-funding/team-profile-funding.tsx
@@ -16,7 +16,9 @@ export function TeamProfileFunding({ fundingStage, membershipSources }: ITeam) {
         <div className="grow basis-1/2 p-5 pb-3 even:border-l even:border-l-slate-200">
           <h2 className="detail-label">Membership Source</h2>
           <div>
-            <TagsGroup items={membershipSources} />
+            <TagsGroup
+              items={membershipSources.map((source) => source.title)}
+            />
           </div>
         </div>
       ) : null}

--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -215,7 +215,14 @@ describe('AirtableService', () => {
     expect(teams).toEqual([
       {
         fundingStage: teamMock01.fields['Funding Stage'],
-        membershipSources: teamMock01.fields['Accelerator Programs'],
+        membershipSources: [
+          {
+            createdAt: '',
+            title: 'Seed',
+            uid: '',
+            updatedAt: '',
+          },
+        ],
         id: teamMock01.id,
         industryTags: [
           {
@@ -302,7 +309,14 @@ describe('AirtableService', () => {
     expect(teams).toEqual([
       {
         fundingStage: teamMock01.fields['Funding Stage'],
-        membershipSources: teamMock01.fields['Accelerator Programs'],
+        membershipSources: [
+          {
+            createdAt: '',
+            title: 'Seed',
+            uid: '',
+            updatedAt: '',
+          },
+        ],
         id: teamMock01.id,
         industryTags: [
           {
@@ -378,7 +392,9 @@ describe('AirtableService', () => {
     expect(teamsTableMock.find).toHaveBeenCalledWith(teamMock01.id);
     expect(team).toEqual({
       fundingStage: teamMock01.fields['Funding Stage'],
-      membershipSources: teamMock01.fields['Accelerator Programs'],
+      membershipSources: [
+        { createdAt: '', title: 'Seed', uid: '', updatedAt: '' },
+      ],
       id: teamMock01.id,
       industryTags: [
         {
@@ -494,7 +510,6 @@ describe('AirtableService', () => {
         twitter: '@team01',
         website: 'http://team01.com/',
         fundingStage: null,
-        membershipSources: ['Seed'],
         industryTags: [
           {
             uid: '',
@@ -503,6 +518,9 @@ describe('AirtableService', () => {
             title: 'IT',
             industryCategoryUid: '',
           },
+        ],
+        membershipSources: [
+          { createdAt: '', title: 'Seed', uid: '', updatedAt: '' },
         ],
         contactMethod: null,
       },
@@ -517,7 +535,6 @@ describe('AirtableService', () => {
         twitter: '@team02',
         website: 'http://team02.com/',
         fundingStage: null,
-        membershipSources: ['Seed'],
         industryTags: [
           {
             uid: '',
@@ -526,6 +543,9 @@ describe('AirtableService', () => {
             title: 'IT',
             industryCategoryUid: '',
           },
+        ],
+        membershipSources: [
+          { createdAt: '', title: 'Seed', uid: '', updatedAt: '' },
         ],
         contactMethod: null,
       },
@@ -1124,7 +1144,9 @@ describe('AirtableService', () => {
     expect(airtableService.parseTeams(teamsMock)).toEqual([
       {
         fundingStage: teamMock01.fields['Funding Stage'],
-        membershipSources: teamMock01.fields['Accelerator Programs'],
+        membershipSources: [
+          { createdAt: '', title: 'Seed', uid: '', updatedAt: '' },
+        ],
         id: teamMock01.id,
         industryTags: [
           {

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -247,9 +247,17 @@ class AirtableService {
       });
     }
 
+    const membershipSources =
+      team.fields['Accelerator Programs']?.map((program: string) => ({
+        uid: '',
+        createdAt: '',
+        updatedAt: '',
+        title: program,
+      })) || [];
+
     return {
       fundingStage: team.fields['Funding Stage'] || null,
-      membershipSources: team.fields['Accelerator Programs'] || [],
+      membershipSources,
       id: team.id,
       industryTags,
       technologies,

--- a/libs/api/src/teams.ts
+++ b/libs/api/src/teams.ts
@@ -10,7 +10,7 @@ export interface ITeam {
   twitter: string | null;
   contactMethod: string | null;
   fundingStage: string | null;
-  membershipSources: string[];
+  membershipSources: TTeamResponse['membershipSources'];
   industryTags: TTeamResponse['industryTags'];
   technologies: TTeamResponse['technologies'];
   members: string[];

--- a/libs/teams/data-access/src/index.spec.ts
+++ b/libs/teams/data-access/src/index.spec.ts
@@ -138,7 +138,6 @@ describe('parseTeam', () => {
         },
       ],
       fundingStage: 'Seed',
-      membershipSources: ['Membership Source A', 'Membership Source B'],
       industryTags: [
         {
           createdAt: '',
@@ -153,6 +152,14 @@ describe('parseTeam', () => {
           title: 'Blockchain',
           uid: '',
           updatedAt: '',
+        },
+      ],
+      membershipSources: [
+        {
+          title: 'Membership Source A',
+        },
+        {
+          title: 'Membership Source B',
         },
       ],
       members: ['456', '789'],

--- a/libs/teams/data-access/src/index.ts
+++ b/libs/teams/data-access/src/index.ts
@@ -48,8 +48,6 @@ export const parseTeam = (team: TTeamResponse): ITeam => {
     contactMethod,
   } = team;
 
-  const membershipSourceTitles =
-    membershipSources?.map((source) => source.title) || [];
   const memberIds = teamMemberRoles?.length
     ? [
         ...new Set(
@@ -70,8 +68,8 @@ export const parseTeam = (team: TTeamResponse): ITeam => {
     longDescription: longDescription || null,
     technologies: technologies || [],
     fundingStage: fundingStage?.title || null,
-    membershipSources: membershipSourceTitles,
     industryTags: industryTags || [],
+    membershipSources: membershipSources || [],
     members: memberIds,
     contactMethod: contactMethod || null,
   };


### PR DESCRIPTION
## Description

🚀  Adapt membership sources to be used as they come from the backend:

>  It makes the code more consistent according to the backend and the most recent frontend adjustments  


**This is a feature of a primary task**: Adapt the team's profile and directory UI to use the data as it comes from the new backend. Remove the parser (Airtable version) used to convert data from backend models to the old UI models; 


## Tickets
- https://pixelmatters.atlassian.net/browse/PL-399
- https://pixelmatters.atlassian.net/browse/PL-400

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
