### PR TITLE
feat(PL-398): adapt skills to new data model

### DIFF
--- a/apps/web-app/components/members/member-profile/member-profile-details/member-profile-details.tsx
+++ b/apps/web-app/components/members/member-profile/member-profile-details/member-profile-details.tsx
@@ -13,7 +13,11 @@ export function MemberProfileDetails({
   return (
     <>
       <div className="mt-6">
-        {skills?.length ? <TagsGroup items={skills} /> : '-'}
+        {skills.length ? (
+          <TagsGroup items={skills.map((skill) => skill.title)} />
+        ) : (
+          '-'
+        )}
       </div>
       <div className="mt-4 flex space-x-6">
         <div className="flex w-1/4 flex-col items-start">

--- a/apps/web-app/components/shared/members/member-card/member-card.tsx
+++ b/apps/web-app/components/shared/members/member-card/member-card.tsx
@@ -85,7 +85,10 @@ export function MemberCard({ isGrid = true, member }: MemberCardProps) {
           )}
         </div>
       </div>
-      <DirectoryCardFooter isGrid={isGrid} tagsArr={member.skills} />
+      <DirectoryCardFooter
+        isGrid={isGrid}
+        tagsArr={member.skills.map((skill) => skill.title)}
+      />
     </DirectoryCard>
   );
 }

--- a/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
+++ b/apps/web-app/components/teams/team-profile/team-profile-members/team-profile-members.tsx
@@ -28,7 +28,7 @@ export function TeamProfileMembers({ members }: TeamProfileMembersProps) {
             name={member.name}
             showTeamLeadBadge={member.teamLead}
             description={team.role}
-            tags={member.skills}
+            tags={member.skills.map((skill) => skill.title)}
           />
         );
       })}

--- a/libs/airtable/src/lib/airtable.spec.ts
+++ b/libs/airtable/src/lib/airtable.spec.ts
@@ -678,7 +678,14 @@ describe('AirtableService', () => {
         },
         name: memberMock01.fields.Name,
         officeHours: memberMock01.fields['Office hours link'],
-        skills: [memberMock01.fields.Skills?.[0]],
+        skills: [
+          {
+            createdAt: '',
+            title: 'Product',
+            uid: '',
+            updatedAt: '',
+          },
+        ],
         teamLead: memberMock01.fields['Team lead'],
         teams: [
           {
@@ -778,7 +785,14 @@ describe('AirtableService', () => {
       },
       name: memberMock01.fields.Name,
       officeHours: memberMock01.fields['Office hours link'],
-      skills: [memberMock01.fields.Skills?.[0]],
+      skills: [
+        {
+          createdAt: '',
+          title: 'Product',
+          uid: '',
+          updatedAt: '',
+        },
+      ],
       teamLead: memberMock01.fields['Team lead'],
       teams: [
         {
@@ -1195,7 +1209,14 @@ describe('AirtableService', () => {
         },
         name: memberMock01.fields.Name,
         officeHours: memberMock01.fields['Office hours link'],
-        skills: [memberMock01.fields.Skills?.[0]],
+        skills: [
+          {
+            createdAt: '',
+            title: 'Product',
+            uid: '',
+            updatedAt: '',
+          },
+        ],
         teamLead: memberMock01.fields['Team lead'],
         teams: [
           {

--- a/libs/airtable/src/lib/airtable.ts
+++ b/libs/airtable/src/lib/airtable.ts
@@ -282,6 +282,13 @@ class AirtableService {
   private _parseMember(member: IAirtableMember): IMember {
     const teams = this._parseMemberTeams(member);
     const mainTeam = teams[0] || null;
+    const skills =
+      member.fields.Skills?.map((skill: string) => ({
+        uid: '',
+        createdAt: '',
+        updatedAt: '',
+        title: skill,
+      })) || [];
 
     return {
       discordHandle: member.fields['Discord handle'] || null,
@@ -297,7 +304,7 @@ class AirtableService {
       mainTeam,
       name: member.fields.Name || null,
       officeHours: member.fields['Office hours link'] || null,
-      skills: member.fields.Skills || [],
+      skills,
       teamLead: !!member.fields['Team lead'],
       teams,
       twitter: member.fields.Twitter || null,

--- a/libs/api/src/members.ts
+++ b/libs/api/src/members.ts
@@ -1,3 +1,5 @@
+import { TMemberResponse } from '@protocol-labs-network/contracts';
+
 export interface IMember {
   discordHandle: string | null;
   email: string | null;
@@ -7,7 +9,7 @@ export interface IMember {
   location: string;
   name: string | null;
   officeHours: string | null;
-  skills: string[];
+  skills: TMemberResponse['skills'];
   teamLead: boolean;
   teams: IMemberTeam[];
   mainTeam: IMemberTeam | null;

--- a/libs/members/data-access/src/index.spec.ts
+++ b/libs/members/data-access/src/index.spec.ts
@@ -101,7 +101,10 @@ describe('parseMember', () => {
       image: { url: 'https://example.com/image.jpg' },
       location: { country: 'USA', region: 'New York Region', city: 'New York' },
       officeHours: 'https://example.com/office-hours',
-      skills: [{ title: 'JavaScript' }, { title: 'TypeScript' }],
+      skills: [
+        { uid: '', createdAt: '', updatedAt: '', title: 'JavaScript' },
+        { uid: '', createdAt: '', updatedAt: '', title: 'TypeScript' },
+      ],
       teamMemberRoles: [
         {
           role: 'Developer',
@@ -129,8 +132,20 @@ describe('parseMember', () => {
       twitter: 'jsmith',
       officeHours: 'https://example.com/office-hours',
       location: 'New York, USA',
-
-      skills: ['JavaScript', 'TypeScript'],
+      skills: [
+        {
+          uid: '',
+          createdAt: '',
+          updatedAt: '',
+          title: 'JavaScript',
+        },
+        {
+          uid: '',
+          createdAt: '',
+          updatedAt: '',
+          title: 'TypeScript',
+        },
+      ],
       teamLead: true,
       teams: [
         {
@@ -239,7 +254,10 @@ describe('parseTeamMember', () => {
     image: { url: 'https://example.com/image.jpg' },
     location: { country: 'USA', region: 'New York Region', city: 'New York' },
     officeHours: 'https://example.com/office-hours',
-    skills: [{ title: 'JavaScript' }, { title: 'TypeScript' }],
+    skills: [
+      { uid: '', createdAt: '', updatedAt: '', title: 'JavaScript' },
+      { uid: '', createdAt: '', updatedAt: '', title: 'TypeScript' },
+    ],
     teamMemberRoles: [
       {
         role: 'Developer',
@@ -269,7 +287,10 @@ describe('parseTeamMember', () => {
       officeHours: 'https://example.com/office-hours',
       location: 'New York, USA',
 
-      skills: ['JavaScript', 'TypeScript'],
+      skills: [
+        { uid: '', createdAt: '', updatedAt: '', title: 'JavaScript' },
+        { uid: '', createdAt: '', updatedAt: '', title: 'TypeScript' },
+      ],
       teamLead: true,
       teams: [
         {
@@ -298,7 +319,10 @@ describe('parseTeamMember', () => {
       officeHours: 'https://example.com/office-hours',
       location: 'New York, USA',
 
-      skills: ['JavaScript', 'TypeScript'],
+      skills: [
+        { uid: '', createdAt: '', updatedAt: '', title: 'JavaScript' },
+        { uid: '', createdAt: '', updatedAt: '', title: 'TypeScript' },
+      ],
       teamLead: false,
       teams: [
         {
@@ -328,7 +352,10 @@ describe('getMembersFilters', () => {
   };
 
   const member01 = {
-    skills: [{ title: 'Skill 1' }, { title: 'Skill 2' }],
+    skills: [
+      { uid: '', createdAt: '', updatedAt: '', title: 'Skill 1' },
+      { uid: '', createdAt: '', updatedAt: '', title: 'Skill 2' },
+    ],
     location: {
       continent: 'Continent 1',
       country: 'Country 1',
@@ -337,7 +364,10 @@ describe('getMembersFilters', () => {
     },
   } as TMemberResponse;
   const member02 = {
-    skills: [{ title: 'Skill 2' }, { title: 'Skill 3' }],
+    skills: [
+      { uid: '', createdAt: '', updatedAt: '', title: 'Skill 2' },
+      { uid: '', createdAt: '', updatedAt: '', title: 'Skill 3' },
+    ],
     location: {
       continent: 'Continent 2',
       country: 'Country 2',

--- a/libs/members/data-access/src/index.ts
+++ b/libs/members/data-access/src/index.ts
@@ -37,7 +37,6 @@ export const getMember = async (
  **/
 export const parseMember = (member: TMemberResponse): IMember => {
   const location = parseMemberLocation(member.location);
-  const skills = member.skills?.map((skill) => skill.title) || [];
   const teams =
     member.teamMemberRoles?.map((teamMemberRole) => ({
       id: teamMemberRole.team?.uid || '',
@@ -59,7 +58,7 @@ export const parseMember = (member: TMemberResponse): IMember => {
     twitter: member.twitterHandler || null,
     officeHours: member.officeHours || null,
     location,
-    skills,
+    skills: member.skills || [],
     teamLead,
     teams,
     mainTeam,


### PR DESCRIPTION
## Description

🚀  Adapt skills to be used as they come from the backend:

>  It makes the code more consistent according to the backend and the most recent frontend adjustments  


**This is a feature of a primary task**: Adapt the member's profile and directory UI to use the data as it comes from the new backend. Remove the parser (Airtable version) used to convert data from backend models to the old UI models; 


## Tickets
- https://pixelmatters.atlassian.net/browse/PL-397
- https://pixelmatters.atlassian.net/browse/PL-398

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
