### PR TITLE
fix(PL-520): hash images filenames before uploading

### DIFF
--- a/apps/web-api/src/members/members.service.ts
+++ b/apps/web-api/src/members/members.service.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { PrismaService } from '../prisma.service';
 import { AirtableMemberSchema } from '../utils/airtable/schema/airtable-member.schema';
 import { FileMigrationService } from '../utils/file-migration/file-migration.service';
+import { hashFileName } from '../utils/hashing';
 import { LocationTransferService } from '../utils/location-transfer/location-transfer.service';
 
 @Injectable()
@@ -43,8 +44,9 @@ export class MembersService {
 
       if (member.fields['Profile picture']) {
         const ppf = member.fields['Profile picture'][0];
+        const hashedPpf = hashFileName(ppf.filename || '');
         image =
-          images.find((image) => image.filename === ppf.filename) ||
+          images.find((image) => image.filename === hashedPpf) ||
           (await this.fileMigrationService.migrateFile({
             id: ppf.id || '',
             url: ppf.url || '',

--- a/apps/web-api/src/teams/teams.service.ts
+++ b/apps/web-api/src/teams/teams.service.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { PrismaService } from '../prisma.service';
 import { AirtableTeamSchema } from '../utils/airtable/schema/airtable-team.schema';
 import { FileMigrationService } from '../utils/file-migration/file-migration.service';
+import { hashFileName } from '../utils/hashing';
 
 @Injectable()
 export class TeamsService {
@@ -98,8 +99,9 @@ export class TeamsService {
 
       if (team.fields.Logo) {
         const logo = team.fields.Logo[0];
+        const hashedLogo = hashFileName(logo.filename || '');
         image =
-          images.find((image) => image.filename === logo.filename) ||
+          images.find((image) => image.filename === hashedLogo) ||
           (await this.fileMigrationService.migrateFile({
             id: logo.id ? logo.id : '',
             url: logo.url ? logo.url : '',

--- a/apps/web-api/src/utils/file-migration/file-migration.service.spec.ts
+++ b/apps/web-api/src/utils/file-migration/file-migration.service.spec.ts
@@ -9,7 +9,6 @@ import { PrismaService } from '../../prisma.service';
 import { FileEncryptionService } from '../file-encryption/file-encryption.service';
 import { FileUploadService } from '../file-upload/file-upload.service';
 import { FileMigrationService } from './file-migration.service';
-
 jest.spyOn(fs, 'readFileSync').mockImplementation(() => 'readFileSync');
 jest.spyOn(fs, 'createWriteStream').mockImplementation();
 jest.spyOn(fs, 'unlink').mockImplementation();
@@ -32,7 +31,6 @@ jest.mock('sharp', () =>
     })),
   }))
 );
-
 describe('FileMigrationService', () => {
   let fileMigrationService: FileMigrationService;
   let imagesController: ImagesController;
@@ -56,7 +54,6 @@ describe('FileMigrationService', () => {
       .overrideProvider(PrismaService)
       .useValue(prisma)
       .compile();
-
     fileMigrationService = app.get<FileMigrationService>(FileMigrationService);
     imagesController = app.get<ImagesController>(ImagesController);
     jest.spyOn(imagesController, 'uploadImage').mockImplementation(() => {
@@ -79,12 +76,10 @@ describe('FileMigrationService', () => {
         },
       });
     });
-
     jest.spyOn(fileMigrationService, 'download').mockImplementation(() => {
       return Promise.resolve();
     });
   });
-
   describe('When receiving a file', () => {
     it('Should call uploadImage with a valid image', async () => {
       const airtableImage = {

--- a/apps/web-api/src/utils/file-migration/file-migration.service.ts
+++ b/apps/web-api/src/utils/file-migration/file-migration.service.ts
@@ -9,14 +9,11 @@ import {
   FILE_UPLOAD_SIZE_LIMIT,
   IMAGE_UPLOAD_MAX_DIMENSION,
 } from '../constants';
-
 @Injectable()
 export class FileMigrationService {
   constructor(private readonly imagesController: ImagesController) {}
-
   async migrateFile(airtableImage: IAirtableImage) {
     const { url, size, type, filename, width, height } = airtableImage;
-
     if (
       type !== 'image/jpeg' &&
       type !== 'image/png' &&
@@ -24,17 +21,14 @@ export class FileMigrationService {
     ) {
       return { status: 'File type not supported' };
     }
-
     if (width < 1 && height < 1) {
       return { status: 'File is not an image' };
     }
-
     try {
       await this.download(url, filename);
     } catch (error) {
       throw new Error(`Failed downloading the image - ${error}`);
     }
-
     const originalFilePath = `./${filename}`;
     const buffer = fs.readFileSync(originalFilePath);
 
@@ -84,7 +78,6 @@ export class FileMigrationService {
     } catch (error) {
       throw new Error(`Failed uploading the image - ${error}`);
     }
-
     if (image) {
       fs.unlink(filePath, function (err) {
         if (err) throw err;
@@ -95,10 +88,8 @@ export class FileMigrationService {
         });
       }
     }
-
     return image;
   }
-
   download(url, filepath) {
     return new Promise((resolve, reject) => {
       client.get(

--- a/apps/web-api/src/utils/hashing.ts
+++ b/apps/web-api/src/utils/hashing.ts
@@ -1,0 +1,7 @@
+import * as crypto from 'crypto';
+
+export function hashFileName(filename: string): string {
+  const hash = crypto.createHash('sha256');
+  hash.update(filename);
+  return hash.digest('hex').substring(0, 16);
+}


### PR DESCRIPTION
## Description

Has the images filenames to avoid them from not rendering

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-520

---

## Checklist before requesting a review

- [ ] I've performed a self-review of my code
- [ ] I've added relevant tests for my changes
- [ ] I've confirmed that my code passes linting
- [ ] I've confirmed that my code passes all tests
- [ ] I've confirmed that my code builds correctly
