### PR TITLE
fix(PL-526): sort tags both by length and alphabetically

### DIFF
--- a/apps/web-app/components/shared/tags-group/use-hide-overflowing-tags.hook.ts
+++ b/apps/web-app/components/shared/tags-group/use-hide-overflowing-tags.hook.ts
@@ -1,3 +1,4 @@
+import sortBy from 'lodash/sortBy';
 import { useRouter } from 'next/router';
 import { MutableRefObject, useCallback, useEffect, useReducer } from 'react';
 
@@ -10,7 +11,10 @@ export function useHideOverflowingTags(
   containerRef: MutableRefObject<HTMLDivElement>,
   tags: string[]
 ) {
-  const sortedTags = [...tags].sort((a, b) => a.length - b.length);
+  const sortedTags = sortBy(tags, [
+    (tag) => tag.length,
+    (tag) => tag.toLowerCase(),
+  ]);
   const [state, setState] = useReducer(
     (state: IReducerState, newState: Partial<IReducerState>) => ({
       ...state,


### PR DESCRIPTION
## Description

🐞 Sort tags both by length and alphabetically when using the React hook for hiding overflowing tags — covers the following scenarios:

  - Teams Directory - cards
  - Members Directory - cards
  - Team Profile - header and team's members' cards
  - Member Profile - header and member's teams' cards

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-526

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
