### PR TITLE
fix(PL-538): properly map member roles

### DIFF
--- a/apps/web-api/src/team-member-roles/team-member-roles.service.ts
+++ b/apps/web-api/src/team-member-roles/team-member-roles.service.ts
@@ -65,10 +65,9 @@ export class TeamMemberRolesService {
                   }),
               },
               update: {
-                ...(airtableMember.fields?.['Role'] &&
-                  index === 0 && {
-                    role: airtableMember.fields['Role'],
-                  }),
+                ...(airtableMember.fields?.['Role']?.split(', ')[index] && {
+                  role: airtableMember.fields['Role'].split(', ')[index],
+                }),
                 teamLead: airtableMember.fields['Team lead'] || false,
                 ...(airtableMember.fields?.['PLN Start Date'] && {
                   startDate: new Date(airtableMember.fields['PLN Start Date']),
@@ -78,10 +77,9 @@ export class TeamMemberRolesService {
                 }),
               },
               create: {
-                ...(airtableMember.fields?.['Role'] &&
-                  index === 0 && {
-                    role: airtableMember.fields['Role'],
-                  }),
+                ...(airtableMember.fields?.['Role']?.split(', ')?.[index] && {
+                  role: airtableMember.fields['Role'].split(', ')[index],
+                }),
                 mainTeam: false,
                 teamLead: airtableMember.fields['Team lead'] || false,
                 ...(airtableMember.fields?.['PLN Start Date'] && {


### PR DESCRIPTION
## Description
Member roles coming from Airtable are in a string format where each team role is separated by commas that needed to be parsed on the migration script.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-538

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
