### PR TITLE
chore(PL-534): invalidate cache on data changes

### DIFF
--- a/apps/web-api/src/utils/forest-admin/agent.ts
+++ b/apps/web-api/src/utils/forest-admin/agent.ts
@@ -11,6 +11,7 @@ import { FileEncryptionService } from '../file-encryption/file-encryption.servic
 import { FileUploadService } from '../file-upload/file-upload.service';
 import { LocationTransferService } from '../location-transfer/location-transfer.service';
 import { generateUid } from './generated-uid';
+import { resetCacheAfterCreateOrUpdateOrDelete } from './reset-cache-after-cud';
 
 const prismaService = new PrismaService();
 
@@ -167,6 +168,8 @@ agent.customizeCollection('Location', (collection) => {
     await generateGoogleApiData(city, country, continent, metroArea, context);
   });
 });
+
+agent.use(resetCacheAfterCreateOrUpdateOrDelete);
 
 async function generateGoogleApiData(
   city,

--- a/apps/web-api/src/utils/forest-admin/reset-cache-after-cud.ts
+++ b/apps/web-api/src/utils/forest-admin/reset-cache-after-cud.ts
@@ -1,0 +1,51 @@
+import { CollectionCustomizer } from '@forestadmin/agent';
+import cacheManager from 'cache-manager';
+import redisStore from 'cache-manager-redis-store';
+
+/**
+ * This is a quick & short-term solution
+ * to avoid having stale data on our in-memory cache.
+ *
+ * TODO:
+ * Implement a better cache invalidation mechanism that's able
+ * to map the Forest Admin collection being created/updated/deleted
+ * to all of our API endpoints that are affected by those data changes.
+ *
+ * @param dataSource
+ * @param collection
+ */
+export async function resetCacheAfterCreateOrUpdateOrDelete(
+  dataSource,
+  collection
+) {
+  // Allow the plugin to be used both on the dataSource or on individual collections
+  const collections: CollectionCustomizer[] = collection
+    ? [collection]
+    : dataSource.collections;
+  const redisCache = cacheManager.caching({
+    store: redisStore,
+    host: process.env.REDIS_HOST,
+    url: process.env.REDIS_URL,
+    port: Number(process.env.REDIS_PORT),
+    password: process.env.REDIS_PASSWORD,
+    tls: process.env.REDIS_WITH_TLS
+      ? {
+          rejectUnauthorized: false,
+          requestCert: true,
+        }
+      : null,
+  });
+
+  // Clear cache after create or update
+  for (const currentCollection of collections) {
+    currentCollection.addHook('After', 'Create', async () => {
+      await redisCache.reset();
+    });
+    currentCollection.addHook('After', 'Update', async () => {
+      await redisCache.reset();
+    });
+    currentCollection.addHook('After', 'Delete', async () => {
+      await redisCache.reset();
+    });
+  }
+}


### PR DESCRIPTION
## Description
Added a custom Forest Admin plugin that will add hooks on create, update, and delete for all collections to reset the in-memory cache to avoid stale data.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-534

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
