### PR TITLE
fix(PL-539): update office hours query parameter on members list request

### DIFF
--- a/apps/web-app/utils/members.utils.spec.ts
+++ b/apps/web-app/utils/members.utils.spec.ts
@@ -21,7 +21,7 @@ describe('#getMembersOptionsFromQuery', () => {
       'location.country__with': 'Portugal',
       'location.metroArea__with': 'Porto',
       name__istartswith: 'void',
-      officeHours__not: null,
+      officeHours__not: 'null',
       orderBy: '-name',
       'skills.title__with': 'Engineering,Leadership',
     });
@@ -54,7 +54,7 @@ describe('#getMembersOptionsFromQuery', () => {
       'location.country__with': 'Portugal',
       'location.metroArea__with': 'Porto',
       name__istartswith: 'void',
-      officeHours__not: null,
+      officeHours__not: 'null',
       orderBy: 'name',
       'skills.title__with': 'Engineering,Leadership',
     });
@@ -78,12 +78,12 @@ describe('#getMembersListOptions', () => {
     expect(
       getMembersListOptions({
         orderBy: '-name',
-        officeHours__not: null,
+        officeHours__not: 'null',
         'location.metroarea__with': 'Porto',
       })
     ).toEqual({
       'location.metroarea__with': 'Porto',
-      officeHours__not: null,
+      officeHours__not: 'null',
       orderBy: '-name',
       pagination: false,
       select:

--- a/apps/web-app/utils/members.utils.ts
+++ b/apps/web-app/utils/members.utils.ts
@@ -24,7 +24,7 @@ export function getMembersOptionsFromQuery(
   const sortField = sortFromQuery.field.toLowerCase();
 
   return {
-    ...(officeHoursOnly ? { officeHours__not: null } : {}),
+    ...(officeHoursOnly ? { officeHours__not: 'null' } : {}),
     ...(skills ? { 'skills.title__with': stringifyQueryValues(skills) } : {}),
     ...(region
       ? {

--- a/libs/members/data-access/src/members.types.ts
+++ b/libs/members/data-access/src/members.types.ts
@@ -1,7 +1,7 @@
 import { TListOptions } from '@protocol-labs-network/shared/data-access';
 
 export type TMemberListOptions = TListOptions & {
-  officeHours__not?: null;
+  officeHours__not?: 'null';
   'skills.title__with'?: string;
   'location.continent__with'?: string;
   'location.country__with'?: string;


### PR DESCRIPTION
## Description

🐞 Update `officeHoursOnly__not` query parameter when getting the members to show on the Members Directory to use a `"null"` string instead of `null`

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-539

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
