### PR TITLE
fix(PL-540): link team member roles by rec id

### DIFF
--- a/apps/web-api/src/team-member-roles/team-member-roles.service.ts
+++ b/apps/web-api/src/team-member-roles/team-member-roles.service.ts
@@ -20,7 +20,7 @@ export class TeamMemberRolesService {
         .filter((airtableMember) => !!airtableMember.fields?.Teams)
         .map((airtableMember) => {
           const memberUid = members.find(
-            (member) => member.name === airtableMember.fields.Name
+            (member) => member.airtableRecId === airtableMember.id
           )?.uid;
           const teamUids = teams
             .filter((team) =>


### PR DESCRIPTION
## Description
Changed the member's mapping field from `name` to `airtableRecId` which fixes the issue of members with the same name wrongfully having the same teams.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-540

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
