### PR TITLE
fix(PL-542): fetch only contries when no city is provided

### DIFF
--- a/apps/web-api/src/utils/location-transfer/location-transfer.service.spec.ts
+++ b/apps/web-api/src/utils/location-transfer/location-transfer.service.spec.ts
@@ -6,7 +6,6 @@ import { LocationTransferService } from './location-transfer.service';
 
 describe('LocationTransferService', () => {
   let locationTransferService: LocationTransferService;
-  let prismaService: PrismaService;
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       providers: [LocationTransferService, PrismaService],

--- a/apps/web-api/src/utils/location-transfer/location-transfer.service.ts
+++ b/apps/web-api/src/utils/location-transfer/location-transfer.service.ts
@@ -77,25 +77,25 @@ export class LocationTransferService {
       return { status: 'NO_PREDICTIONS' };
     }
 
-    /**
-     * This catches the islands like Kauai, Maui, etc
-     */
+    let requiredPlace;
 
-    let requiredPlace =
-      placeResponse.data.predictions &&
-      placeResponse.data.predictions.find(
-        (place) =>
-          place.types && place.types.find((type) => type === 'locality')
-      );
-
-    if (!requiredPlace)
+    if (city) {
       requiredPlace =
         placeResponse.data.predictions &&
         placeResponse.data.predictions.find(
           (place) =>
-            place.types &&
-            place.types.find((type) => type === 'administrative_area_level_1')
+            place.types && place.types.find((type) => type === 'locality')
         );
+
+      if (!requiredPlace)
+        requiredPlace =
+          placeResponse.data.predictions &&
+          placeResponse.data.predictions.find(
+            (place) =>
+              place.types &&
+              place.types.find((type) => type === 'administrative_area_level_1')
+          );
+    }
 
     if (!requiredPlace)
       requiredPlace =
@@ -105,6 +105,9 @@ export class LocationTransferService {
             place.types && place.types.find((type) => type === 'country')
         );
 
+    /**
+     * This catches the islands like Kauai, Maui, etc
+     */
     if (!requiredPlace)
       requiredPlace =
         placeResponse.data.predictions &&


### PR DESCRIPTION
## Description
Fetch only countries when no city is provided on the location service


## Tickets

- https://pixelmatters.atlassian.net/browse/PL-542

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
