### PR TITLE
fix(PL-544): add more complex image name hashing

### DIFF
--- a/apps/web-api/src/images/images.controller.ts
+++ b/apps/web-api/src/images/images.controller.ts
@@ -51,10 +51,16 @@ export class ImagesController {
     },
   })
   @UseInterceptors(FileInterceptor('file'))
-  async uploadImage(@UploadedFile() file: Express.Multer.File) {
-    file.originalname = `${hashFileName(path.parse(file.originalname).name)}${
-      path.parse(file.originalname).ext
-    }`;
+  async uploadImage(
+    @UploadedFile() file: Express.Multer.File,
+    { needsToHashFilename } = { needsToHashFilename: true }
+  ) {
+    // Hash filename if needed
+    file.originalname = needsToHashFilename
+      ? `${hashFileName(
+          `${path.parse(file.originalname).name}-${Date.now()}`
+        )}${path.parse(file.originalname).ext}`
+      : file.originalname;
 
     const dir = './img-tmp';
     // Check if directory exists and create it if it doesn't

--- a/apps/web-api/src/members/members.service.ts
+++ b/apps/web-api/src/members/members.service.ts
@@ -47,7 +47,7 @@ export class MembersService {
         const ppf = member.fields['Profile picture'][0];
 
         const hashedPpf = ppf.filename
-          ? hashFileName(path.parse(ppf.filename).name)
+          ? hashFileName(`${path.parse(ppf.filename).name}-${ppf.id}`)
           : '';
 
         image =

--- a/apps/web-api/src/teams/teams.service.ts
+++ b/apps/web-api/src/teams/teams.service.ts
@@ -102,7 +102,7 @@ export class TeamsService {
         const logo = team.fields.Logo[0];
 
         const hashedLogo = logo.filename
-          ? hashFileName(path.parse(logo.filename).name)
+          ? hashFileName(`${path.parse(logo.filename).name}-${logo.id}`)
           : '';
         image =
           images.find(

--- a/apps/web-api/src/utils/file-migration/file-migration.service.spec.ts
+++ b/apps/web-api/src/utils/file-migration/file-migration.service.spec.ts
@@ -8,6 +8,7 @@ import { ImagesService } from '../../images/images.service';
 import { PrismaService } from '../../prisma.service';
 import { FileEncryptionService } from '../file-encryption/file-encryption.service';
 import { FileUploadService } from '../file-upload/file-upload.service';
+import { hashFileName } from '../hashing';
 import { FileMigrationService } from './file-migration.service';
 jest.spyOn(fs, 'readFileSync').mockImplementation(() => 'readFileSync');
 jest.spyOn(fs, 'createWriteStream').mockImplementation();
@@ -91,19 +92,25 @@ describe('FileMigrationService', () => {
         width: 1,
         height: 1,
       };
+      const hashedFileName = `${hashFileName(
+        `${path.parse('test.png').name}-rec1`
+      )}.webp`;
       await fileMigrationService.migrateFile(airtableImage);
-      expect(imagesController.uploadImage).toHaveBeenCalledWith({
-        filename: 'test.webp',
-        mimetype: 'image/webp',
-        encoding: '7bit',
-        buffer: 'readFileSync',
-        destination: '',
-        fieldname: 'file',
-        originalname: 'test.webp',
-        path: './test.webp',
-        size: 1,
-        stream: undefined,
-      });
+      expect(imagesController.uploadImage).toHaveBeenCalledWith(
+        {
+          filename: hashedFileName,
+          mimetype: 'image/webp',
+          encoding: '7bit',
+          buffer: 'readFileSync',
+          destination: '',
+          fieldname: 'file',
+          originalname: hashedFileName,
+          path: `./${hashedFileName}`,
+          size: 1,
+          stream: undefined,
+        },
+        { needsToHashFilename: false }
+      );
     });
     it('Should return status if file type is not suported', async () => {
       const airtableImage = {

--- a/apps/web-api/src/utils/file-migration/file-migration.service.ts
+++ b/apps/web-api/src/utils/file-migration/file-migration.service.ts
@@ -9,11 +9,12 @@ import {
   FILE_UPLOAD_SIZE_LIMIT,
   IMAGE_UPLOAD_MAX_DIMENSION,
 } from '../constants';
+import { hashFileName } from '../hashing';
 @Injectable()
 export class FileMigrationService {
   constructor(private readonly imagesController: ImagesController) {}
   async migrateFile(airtableImage: IAirtableImage) {
-    const { url, size, type, filename, width, height } = airtableImage;
+    const { id, url, size, type, filename, width, height } = airtableImage;
     if (
       type !== 'image/jpeg' &&
       type !== 'image/png' &&
@@ -32,7 +33,9 @@ export class FileMigrationService {
     const originalFilePath = `./${filename}`;
     const buffer = fs.readFileSync(originalFilePath);
 
-    const compressedFileName = `${path.parse(filename).name}.webp`;
+    const compressedFileName = `${hashFileName(
+      `${path.parse(filename).name}-${id}`
+    )}.webp`;
     let compressedFile;
 
     if (
@@ -73,7 +76,9 @@ export class FileMigrationService {
     };
     let image;
     try {
-      const data = await this.imagesController.uploadImage(newFile);
+      const data = await this.imagesController.uploadImage(newFile, {
+        needsToHashFilename: false,
+      });
       image = data.image;
     } catch (error) {
       throw new Error(`Failed uploading the image - ${error}`);

--- a/apps/web-api/src/utils/forest-admin/agent.ts
+++ b/apps/web-api/src/utils/forest-admin/agent.ts
@@ -6,16 +6,17 @@ import { Readable } from 'stream';
 import { ImagesController } from '../../images/images.controller';
 import { ImagesService } from '../../images/images.service';
 import { PrismaService } from '../../prisma.service';
+import { APP_ENV } from '../../utils/constants';
 import { FileEncryptionService } from '../file-encryption/file-encryption.service';
 import { FileUploadService } from '../file-upload/file-upload.service';
 import { LocationTransferService } from '../location-transfer/location-transfer.service';
 import { generateUid } from './generated-uid';
-import { APP_ENV } from '../../utils/constants';
 
 const prismaService = new PrismaService();
 
 async function executeImageUpload(context) {
   const file = context.formValues.Image;
+
   const builtFile: Express.Multer.File = {
     fieldname: 'field name',
     originalname: file.name,


### PR DESCRIPTION
## Description

Use more than the file name to hash images to avoid having users with the same image name which will cause them to have the same image.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-544

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
