### PR TITLE
fix(PL-545): hide friend of pln exclusive filter values

### DIFF
--- a/libs/members/data-access/src/index.spec.ts
+++ b/libs/members/data-access/src/index.spec.ts
@@ -396,6 +396,7 @@ describe('getMembersFilters', () => {
         select:
           'skills.title,location.metroArea,location.city,location.continent,location.country',
         teamMemberRoles__not: 'null',
+        plnFriend: false,
       },
     });
     expect(client.members.getMembers).toHaveBeenNthCalledWith(2, {

--- a/libs/members/data-access/src/index.ts
+++ b/libs/members/data-access/src/index.ts
@@ -115,7 +115,9 @@ const parseMemberLocation = (
  */
 export const getMembersFilters = async (options: TMemberListOptions) => {
   const [valuesByFilter, availableValuesByFilter] = await Promise.all([
-    getMembersFiltersValues(),
+    getMembersFiltersValues({
+      plnFriend: false,
+    }),
     getMembersFiltersValues(options),
   ]);
 

--- a/libs/teams/data-access/src/index.spec.ts
+++ b/libs/teams/data-access/src/index.spec.ts
@@ -265,6 +265,7 @@ describe('getTeamsFilterValues', () => {
         pagination: false,
         select:
           'industryTags.title,membershipSources.title,fundingStage.title,technologies.title',
+        plnFriend: false,
       },
     });
     expect(client.teams.getTeams).toHaveBeenNthCalledWith(2, {

--- a/libs/teams/data-access/src/index.ts
+++ b/libs/teams/data-access/src/index.ts
@@ -80,7 +80,9 @@ export const parseTeam = (team: TTeamResponse): ITeam => {
  */
 export const getTeamsFilters = async (options: TTeamListOptions) => {
   const [valuesByFilter, availableValuesByFilter] = await Promise.all([
-    getTeamsFiltersValues(),
+    getTeamsFiltersValues({
+      plnFriend: false,
+    }),
     getTeamsFiltersValues(options),
   ]);
 


### PR DESCRIPTION
## Description

🐞 Hide filter values that are exclusively linked to Friend of PLN teams/members on the corresponding directories

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-545

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
