### PR TITLE
feat(PL-548): ensure old links to members and teams work when using the backend

### DIFF
--- a/apps/web-app/constants.ts
+++ b/apps/web-app/constants.ts
@@ -90,3 +90,4 @@ export const FATHOM_EVENTS = {
     },
   },
 };
+export const AIRTABLE_REGEX = /^rec[A-Za-z0-9]{14}$/;

--- a/libs/members/data-access/src/index.spec.ts
+++ b/libs/members/data-access/src/index.spec.ts
@@ -6,6 +6,7 @@ import {
   getMember,
   getMembers,
   getMembersFilters,
+  getMemberUIDByAirtableId,
   parseMember,
   parseTeamMember,
 } from './index';
@@ -89,6 +90,51 @@ describe('getMember', () => {
       body: memberResponseMock,
       status: 200,
     });
+  });
+});
+
+describe('getMemberUIDByAirtableId', () => {
+  const airtableUID = 'airtableUID';
+
+  it('should call getMembers appropriately', async () => {
+    (<jest.Mock>client.members.getMembers).mockClear().mockReturnValueOnce({
+      body: [memberResponseMock],
+      status: 200,
+    });
+
+    const response = await getMemberUIDByAirtableId(airtableUID);
+
+    expect(client.members.getMembers).toHaveBeenCalledWith({
+      query: { airtableRecId: airtableUID, select: 'uid' },
+    });
+    expect(response).toEqual(memberResponseMock.uid);
+  });
+
+  it('should call getMembers appropriately', async () => {
+    (<jest.Mock>client.members.getMembers).mockClear().mockReturnValueOnce({
+      body: [],
+      status: 200,
+    });
+
+    const response = await getMemberUIDByAirtableId(airtableUID);
+
+    expect(client.members.getMembers).toHaveBeenCalledWith({
+      query: { airtableRecId: airtableUID, select: 'uid' },
+    });
+    expect(response).toEqual(null);
+  });
+
+  it('should call getMembers appropriately', async () => {
+    (<jest.Mock>client.members.getMembers).mockClear().mockReturnValueOnce({
+      status: 404,
+    });
+
+    const response = await getMemberUIDByAirtableId(airtableUID);
+
+    expect(client.members.getMembers).toHaveBeenCalledWith({
+      query: { airtableRecId: airtableUID, select: 'uid' },
+    });
+    expect(response).toEqual(null);
   });
 });
 

--- a/libs/members/data-access/src/index.ts
+++ b/libs/members/data-access/src/index.ts
@@ -33,6 +33,17 @@ export const getMember = async (
 };
 
 /**
+ * Get member unique id based on provided airtable id
+ */
+export const getMemberUIDByAirtableId = async (id: string) => {
+  const res = await client.members.getMembers({
+    query: { airtableRecId: id, select: 'uid' },
+  });
+
+  return res.status === 200 && res.body[0] ? res.body[0].uid : null;
+};
+
+/**
  * Parse member fields values into a member object.
  **/
 export const parseMember = (member: TMemberResponse): IMember => {

--- a/libs/teams/data-access/src/index.spec.ts
+++ b/libs/teams/data-access/src/index.spec.ts
@@ -1,6 +1,12 @@
 import { TTeamResponse } from '@protocol-labs-network/contracts';
 import { client } from '@protocol-labs-network/shared/data-access';
-import { getTeam, getTeams, getTeamsFilters, parseTeam } from './index';
+import {
+  getTeam,
+  getTeams,
+  getTeamsFilters,
+  getTeamUIDByAirtableId,
+  parseTeam,
+} from './index';
 
 jest.mock('@protocol-labs-network/shared/data-access', () => ({
   client: {
@@ -81,6 +87,51 @@ describe('getTeam', () => {
       body: teamResponseMock,
       status: 200,
     });
+  });
+});
+
+describe('getTeamUIDByAirtableId', () => {
+  const airtableUID = 'airtableUID';
+
+  it('should call getTeams appropriately', async () => {
+    (<jest.Mock>client.teams.getTeams).mockClear().mockReturnValueOnce({
+      body: [teamResponseMock],
+      status: 200,
+    });
+
+    const response = await getTeamUIDByAirtableId(airtableUID);
+
+    expect(client.teams.getTeams).toHaveBeenCalledWith({
+      query: { airtableRecId: airtableUID, select: 'uid' },
+    });
+    expect(response).toEqual(teamResponseMock.uid);
+  });
+
+  it('should call getTeams appropriately', async () => {
+    (<jest.Mock>client.teams.getTeams).mockClear().mockReturnValueOnce({
+      body: [],
+      status: 200,
+    });
+
+    const response = await getTeamUIDByAirtableId(airtableUID);
+
+    expect(client.teams.getTeams).toHaveBeenCalledWith({
+      query: { airtableRecId: airtableUID, select: 'uid' },
+    });
+    expect(response).toEqual(null);
+  });
+
+  it('should call getTeams appropriately', async () => {
+    (<jest.Mock>client.teams.getTeams).mockClear().mockReturnValueOnce({
+      status: 404,
+    });
+
+    const response = await getTeamUIDByAirtableId(airtableUID);
+
+    expect(client.teams.getTeams).toHaveBeenCalledWith({
+      query: { airtableRecId: airtableUID, select: 'uid' },
+    });
+    expect(response).toEqual(null);
   });
 });
 

--- a/libs/teams/data-access/src/index.ts
+++ b/libs/teams/data-access/src/index.ts
@@ -29,6 +29,17 @@ export const getTeam = async (id: string, options: TGetRequestOptions = {}) => {
 };
 
 /**
+ * Get team unique id based on provided airtable id
+ */
+export const getTeamUIDByAirtableId = async (id: string) => {
+  const res = await client.teams.getTeams({
+    query: { airtableRecId: id, select: 'uid' },
+  });
+
+  return res.status === 200 && res.body[0] ? res.body[0].uid : null;
+};
+
+/**
  * Parse team fields values into a team object.
  **/
 export const parseTeam = (team: TTeamResponse): ITeam => {


### PR DESCRIPTION
## Description

🚀 Ensure old links to members' and teams' profile pages still work when using the new backend
  - This is because previously, teams and members were being accessed using their Airtable ID; by using our backend, each team and member gets a new unique ID within our database; that way, the old links do not work anymore. By mapping the Airtable ID to the backend unique ID, we ensure that the old links still work.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-548

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
