### PR TITLE
ci(PL-555): stop previous commits action runs

### DIFF
--- a/.github/workflows/ci-check-up.yml
+++ b/.github/workflows/ci-check-up.yml
@@ -3,6 +3,10 @@ name: 'CI Check-up'
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Description

Stop previous ci-check action to run if new commit is done

Context:
`${{ github.workflow }}:` the workflow name is used to generate the concurrency group (e.g. Workflow 1). That allows you to have more than one different workflow (eg. workflow1.yaml and workflow2.yaml) triggered on the same event (e.g. a PR). Otherwise, workflow1.yaml would cancel workflow2.yaml or viceversa.
`${{ github.event.pull_request.number`: when the trigger event is a PR, it will use the PR number to generate the concurrency group (e.g. workflow1-33).
`|| github.ref }}`: when the trigger is not a PR but a push, it will use the branch or tag name to generate the concurrency group (e.g. workflow1-branch1).
cancel-in-progress: true: if cancel-in-progress is omitted or set to false, when a new workflow is triggered, the currently running workflow won’t be cancelled, and the new workflow will be queued pending until the previous one is done.

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-555

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
