### PR TITLE
chore(PL-580): display formatted location on admin

### DIFF
--- a/.forestadmin-schema.json
+++ b/.forestadmin-schema.json
@@ -776,6 +776,22 @@
       {
         "defaultValue": null,
         "enums": null,
+        "field": "formattedLocation",
+        "integration": null,
+        "inverseOf": null,
+        "isFilterable": false,
+        "isPrimaryKey": false,
+        "isReadOnly": true,
+        "isRequired": false,
+        "isSortable": false,
+        "isVirtual": false,
+        "reference": null,
+        "type": "String",
+        "validations": []
+      },
+      {
+        "defaultValue": null,
+        "enums": null,
         "field": "id",
         "integration": null,
         "inverseOf": null,

--- a/apps/web-api/src/utils/forest-admin/agent.ts
+++ b/apps/web-api/src/utils/forest-admin/agent.ts
@@ -129,6 +129,18 @@ agent.customizeCollection('_TeamToTechnology', (collection) => {
 });
 
 agent.customizeCollection('Location', (collection) => {
+  collection.addField('formattedLocation', {
+    columnType: 'String',
+    dependencies: ['city', 'country', 'region', 'continent'],
+    getValues: (records) =>
+      records.map(
+        (r) =>
+          `${r.city ? r.city + ' - ' : ''}${r.region ? r.region + ' : ' : ''}${
+            r.country
+          } (${r.continent})`
+      ),
+  });
+
   collection.addHook('Before', 'Create', async (context) => {
     const { city, country, continent, metroArea } = context.data[0];
     await generateGoogleApiData(city, country, continent, metroArea, context);


### PR DESCRIPTION
## Description
Added a [computed field](https://docs.forestadmin.com/developer-guide-agents-nodejs/agent-customization/fields/computed) for the Location entity that displays a formatted value that includes country, continent, and optionally the city and region.  

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-580

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [x] I've added relevant tests for my changes
- [x] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
