### PR TITLE
cosmetic changes nw spotlight

### DIFF
--- a/apps/web-app/components/portal/sections/mission/mission-card.tsx
+++ b/apps/web-app/components/portal/sections/mission/mission-card.tsx
@@ -12,13 +12,13 @@ const helpAreas = [
   { icon: <NetworkingIcon />, name: 'Networking' },
   { icon: <FundingIcon />, name: 'Funding' },
   { icon: <AdoptionIcon />, name: 'Adoption' },
-  { icon: <TalentIcon />, name: 'Talent' },
   { icon: <ResearchIcon />, name: 'Research & Engineering' },
+  { icon: <TalentIcon />, name: 'Talent' },
 ];
 
 export const MissionCard = () => {
   return (
-    <div className="mt-8 grid font-medium md:mt-7 md:grid-cols-6 md:text-lg xl:grid-cols-7 ">
+    <div className="mt-8 flex font-medium md:mt-7 md:text-lg justify-between ">
       {helpAreas.map((area, i) => (
         <MissionHelpArea key={i} areaIcon={area.icon} areaName={area.name} index={i}/>
       ))}

--- a/apps/web-app/components/portal/sections/mission/mission-help-area.tsx
+++ b/apps/web-app/components/portal/sections/mission/mission-help-area.tsx
@@ -12,7 +12,7 @@ export const MissionHelpArea = ({
   areaName,
 }: TMissionHelpAreaProps) => {
   return (
-    <div className={`flex items-center gap-x-3 text-left ${index === 5 ? ' col-span-2':''}`}>
+    <div className={`flex items-center gap-x-3 text-left`}>
       <div className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-50">
         {areaIcon}
       </div>

--- a/apps/web-app/components/portal/sections/spotlight/network-spotlight.tsx
+++ b/apps/web-app/components/portal/sections/spotlight/network-spotlight.tsx
@@ -28,8 +28,8 @@ export const NetworkSpotlight = ({ videoDetails, playlistDetails }) => {
         <>
             <section className="border p-[24px] rounded-lg bg-white mt-16 ">
                 <p className="font-extrabold text-[24px] leading-[28px] pb-6 text-left">{NW_SPOTLIGHT_CONSTANTS.HEADING}</p>
-                <div className="flex flex-col md:flex-row justify-evenly gap-[16px]">
-                    <div className="w-[350px] h-[328px] border rounded-[8px] bg-[#F1F5F9] p-[20px]">
+                <div className="flex flex-col md:flex-row justify-between gap-[16px]">
+                    <div className="w-[360px] h-[328px] border rounded-[8px] bg-[#F1F5F9] p-[20px]">
                         <div>
                             <div className="absolute rounded-full w-[45px] h-[20px] mt-[8px] text-[12px] font-medium bg-[#156FF7] ml-[8px] z-[1001]">
                                 <span className="relative p-[5px] text-[#FFFFFF]">{NW_SPOTLIGHT_CONSTANTS.BLOG}</span>
@@ -53,7 +53,7 @@ export const NetworkSpotlight = ({ videoDetails, playlistDetails }) => {
                         </div>
                     </div>
                     {
-                        (videoDetails && <div className="w-[350px] h-[328px] border rounded-[8px] bg-[#F1F5F9] p-[20px]">
+                        (videoDetails && <div className="w-[360px] h-[328px] border rounded-[8px] bg-[#F1F5F9] p-[20px]">
 
                             <div className="flex flex-col">
                                 <div className="relative w-[300px] h-[168px]">
@@ -92,7 +92,7 @@ export const NetworkSpotlight = ({ videoDetails, playlistDetails }) => {
                         </div>)
                     }
                     {
-                        (playlistDetails && <div className="w-[350px] h-[328px] border rounded-[8px] bg-[#F1F5F9] p-[20px]">
+                        (playlistDetails && <div className="w-[360px] h-[328px] border rounded-[8px] bg-[#F1F5F9] p-[20px]">
                             <div>
                                 <div className="absolute rounded-full w-[45px] h-[20px] mt-[8px] text-[12px] font-medium bg-[#156FF7] ml-[8px] z-[1001]">
                                     <span className="relative p-[5px] text-[#FFFFFF]">{NW_SPOTLIGHT_CONSTANTS.SERIES}</span>

--- a/apps/web-app/pages/index.tsx
+++ b/apps/web-app/pages/index.tsx
@@ -9,7 +9,6 @@ import { Mission } from '../components/portal/sections/mission/mission';
 import { Projects } from '../components/portal/sections/projects/projects';
 import { Substack } from '../components/portal/sections/substack/substack';
 import { PortalLayout } from '../layouts/portal-layout';
-import { NetworkSpotlight } from '../components/portal/sections/spotlight/network-spotlight';
 import api from '../utils/api';
 import { NW_SPOTLIGHT_CONSTANTS } from '../constants';
 


### PR DESCRIPTION
-The six items needs to be centred. (The first and last item should be aligned to the network spotlight's container & the items should be distributed with even spacing)

-Network spotlight section padding on the sides and bottom to be 24px

-"Network Spotlight title" should be aligned vertically to the start of the first item.

-Match the font weight of the banner sub text from Figma