### PR TITLE
fix: autocomplete autofocus

### DIFF
--- a/apps/web-app/components/projects/steps/components/contributors/member-list.tsx
+++ b/apps/web-app/components/projects/steps/components/contributors/member-list.tsx
@@ -234,7 +234,7 @@ export default function MemberList({
             <div>
               <Autocomplete
                 name={'team'}
-                className="custom-grey custom-outline-none border"
+                className="custom-grey custom-outline-none border focus:outline-none focus:ring-transparent"
                 // key={selectedTeam.label}
                 placeholder="All Teams"
                 selectedOption={selectedTeamToFitler}
@@ -249,11 +249,12 @@ export default function MemberList({
           <div className={`${!selectedTeam?'':'w-full'}`}>
             <InputField
               label="Search"
+              tabIndex={-1}
               name="searchBy"
               showLabel={false}
               icon={SearchIcon}
               placeholder={'Search'}
-              className="rounded-[8px] border"
+              className="rounded-[8px] border custom-outline-none focus:outline-none"
               value={searchTerm}
               onKeyUp={(event) => {
                 //   if (event.key === 'Enter' || event.keyCode === 13) {
@@ -290,7 +291,7 @@ export default function MemberList({
           <div className="">
             <input
               type="checkbox"
-              className="relative top-[2px] cursor-pointer"
+              className="relative top-[2px] cursor-pointer focus:outline-none"
               onChange={onShowSelected}
               checked={showSelected}
             />

--- a/libs/ui/src/lib/input-field/input-field.tsx
+++ b/libs/ui/src/lib/input-field/input-field.tsx
@@ -80,6 +80,7 @@ export function InputField({
         ></img>
       ) : null}
       <input
+      autoFocus={false}
         {...props}
         type={showPassword ? 'text' : props.type}
         className={`mt-[12px] block w-full rounded-lg bg-white text-sm leading-6 text-slate-900  shadow-slate-300 transition duration-150 ease-in-out placeholder:text-sm placeholder:text-slate-600 placeholder:opacity-50


### PR DESCRIPTION
Cursor is displayed (focused) in the teams filter when pop-up opened, but on typing team name it is not showing the team list