### PR TITLE
fix: client comments

### DIFF
--- a/apps/web-app/components/projects/details/all-contributors-popup.tsx
+++ b/apps/web-app/components/projects/details/all-contributors-popup.tsx
@@ -42,7 +42,8 @@ export default function AllContributorsPopup({
           className="flex cursor-pointer items-center gap-2 hover:bg-slate-100"
           key={'contributor' + uid}
           onClick={() => {
-            router.push('/members/' + uid);
+            window.open('/members/' + uid);
+            // router.push('/members/' + uid);
           }}
         >
           <div className='relative'>

--- a/apps/web-app/components/projects/details/all-teams.tsx
+++ b/apps/web-app/components/projects/details/all-teams.tsx
@@ -61,7 +61,8 @@ export function AllTeamsModal({
     };
 
     const onMaintainerTeamClicked = (team) => {
-        router.push('/teams/' + team.uid);
+        // router.push('/teams/' + team.uid);
+        window.open('/teams/' + team.uid);
         analytics.captureEvent(APP_ANALYTICS_EVENTS.PROJECT_DETAIL_MAINTAINER_TEAM_CLICKED, {
             teamUid: team.uid,
             teamName: team.name,
@@ -69,7 +70,8 @@ export function AllTeamsModal({
     }
 
     const onContributingTeamClicked = (cteam) => {
-        router.push('/teams/' + cteam.uid);
+        // router.push('/teams/' + cteam.uid);
+        window.open('/teams/' + cteam.uid);
         analytics.captureEvent(APP_ANALYTICS_EVENTS.PROJECT_DETAIL_CONTRIBUTING_TEAM_CLICKED, {
             teamUid: cteam.uid,
             teamName: cteam.name,

--- a/apps/web-app/components/projects/details/contributors.tsx
+++ b/apps/web-app/components/projects/details/contributors.tsx
@@ -58,7 +58,7 @@ export default function Contributors({ project, contributingMembers }) {
         {!url && (
           <UserIcon className="relative inline-block h-[36px] w-[36px] rounded-full bg-gray-200 fill-white hover:border-[2px] hover:border-[#156FF7] cursor-pointer" />
         )}
-        {
+        {/* {
         contributorHoverFlag && contributorHoveruid === uid &&
          (
           <ContributorProfileCard
@@ -69,7 +69,7 @@ export default function Contributors({ project, contributingMembers }) {
             teamName={teamName}
             isTeamLead={isTeamLead}
           />
-        )}
+        )} */}
       </div>
     );
   };
@@ -143,7 +143,7 @@ export default function Contributors({ project, contributingMembers }) {
             })}
           {project?.contributors?.length + contributingMembers?.length > 17 && (
             <div
-              className="cursor-pointer relative inline-block h-[36px] w-[36px] rounded-full bg-gray-200 fill-white pt-[5px] text-center"
+              className="cursor-pointer relative inline-block h-[36px] w-[36px] rounded-full bg-gray-200 fill-white pt-[5px] text-center rounded-full hover:border-[2px] hover:border-[#156FF7]"
               onClick={() => {
                 setAllContributors(true);
               }}

--- a/apps/web-app/components/projects/details/teams.tsx
+++ b/apps/web-app/components/projects/details/teams.tsx
@@ -13,7 +13,8 @@ export default function TeamsInvolved({ project }) {
   const analytics = useAppAnalytics();
 
   const onMaintainerTeamClicked = (team) => {
-    router.push('/teams/' + team.uid);
+    // router.push('/teams/' + team.uid);
+    window.open('/teams/' + team.uid);
     analytics.captureEvent(
       APP_ANALYTICS_EVENTS.PROJECT_DETAIL_MAINTAINER_TEAM_CLICKED,
       {
@@ -24,7 +25,8 @@ export default function TeamsInvolved({ project }) {
   };
 
   const onContributingTeamClicked = (cteam) => {
-    router.push('/teams/' + cteam.uid);
+    // router.push('/teams/' + cteam.uid);
+    window.open('/teams/' + cteam.uid);
     analytics.captureEvent(
       APP_ANALYTICS_EVENTS.PROJECT_DETAIL_CONTRIBUTING_TEAM_CLICKED,
       {
@@ -72,17 +74,19 @@ export default function TeamsInvolved({ project }) {
             </div>
           </div>
           <div
-            className="flex cursor-pointer justify-between text-[16px] text-[#64748B] hover:bg-slate-100"
+            className="flex cursor-pointer justify-between text-[16px] text-[#64748B] "
             onClick={() => {
               onMaintainerTeamClicked(project.maintainingTeam);
             }}
           >
             <div className="flex gap-[10px] ">
               {!project.maintainingTeam?.logo && (
-                <UserGroupIcon className="inset-y-0 left-2 my-auto mr-[4px] inline h-[40px] w-[40px] rounded bg-gray-200 fill-white" />
+                <div className='rounded hover:border-[2px] hover:border-[#156FF7] w-[40px] h-[40px]'>
+                  <UserGroupIcon className="inset-y-0 left-2 my-auto mr-[4px] inline h-[40px] w-[40px] rounded bg-gray-200 fill-white" />
+                </div>
               )}
               {project.maintainingTeam?.logo && (
-                <div>
+                <div className='relative rounded hover:border-[2px] hover:border-[#156FF7] w-[40px] h-[40px]'>
                   <Image
                     src={project.maintainingTeam?.logo?.url}
                     alt="project image"
@@ -94,8 +98,15 @@ export default function TeamsInvolved({ project }) {
               )}
               <div className="m-2">{project.maintainingTeam.name}</div>
             </div>
-            <div className="flex p-2" title="Maintainer">
-              <Core />
+            <div className="flex hover:border-[2px] hover:border-[#156FF7]  w-[20px] h-[20px] rounded-full relative top-2" title="Maintainer">
+              {/* <Core /> */}
+              <Image
+                    src='/assets/images/icons/projects/core.svg'
+                    alt="maintainer image"
+                    width={20}
+                    height={20}
+                    className="rounded"
+                  />
             </div>
           </div>
           {project.contributingTeams &&
@@ -112,7 +123,7 @@ export default function TeamsInvolved({ project }) {
                       }}
                     >
                       {cteam.logo && (
-                        <div>
+                        <div className='rounded hover:border-[2px] hover:border-[#156FF7] w-[40px] h-[40px]'>
                           <Image
                             src={cteam.logo}
                             alt="project image"
@@ -123,7 +134,9 @@ export default function TeamsInvolved({ project }) {
                         </div>
                       )}
                       {!cteam.logo && (
-                        <UserGroupIcon className="inset-y-0 left-2 my-auto mr-[4px] inline h-[40px] w-[40px] rounded bg-gray-200 fill-white" />
+                        <div className='rounded hover:border-[2px] hover:border-[#156FF7] w-[40px] h-[40px]'>
+                          <UserGroupIcon className="inset-y-0 left-2 my-auto mr-[4px] inline h-[40px] w-[40px] rounded bg-gray-200 fill-white" />
+                        </div>
                       )}
                       <div className="m-2 max-w-[188px]">{cteam.name}</div>
                     </div>

--- a/apps/web-app/components/projects/steps/components/contributors/members/list.tsx
+++ b/apps/web-app/components/projects/steps/components/contributors/members/list.tsx
@@ -45,7 +45,7 @@ export default function ContributingMembers() {
                   {!member?.logo && (
                     <UserGroupIcon className="h-[28px] w-[28px] shrink-0 rounded-full bg-slate-100 fill-slate-200 cursor-pointer hover:border-[2px] hover:border-[#156FF7]" />
                   )}
-                  {contributorHoverFlag &&
+                  {/* {contributorHoverFlag &&
                     contributorHoveruid === member?.uid && (
                       <ContributorProfileCard
                         uid={member.uid}
@@ -59,7 +59,7 @@ export default function ContributingMembers() {
                         teamName={member.mainTeam?.team?.name}
                         isTeamLead={member.teamLead}
                       />
-                    )}
+                    )} */}
                 </div>
               )}
             </React.Fragment>


### PR DESCRIPTION
1.. Project detail page_Teams section-Clicking on a Team launches the related Team's detail page on the same tab
2. Project detail page_Teams section-Hovering on a team to just highlight the logo
3. Project detail page_Teams section-Hovering over a maintainer team's maintainer-image to highlight only that image and not the whole team/row
5. Project detail page_Contributors section-View profile card on hover to be removed
6. Project detail page_Contributors section-Hovering over the ones on the right the profile card moves out of the screen (happens on 100% zoom) - due to no. 5 this is not required
7. Project detail page_Contributors see all pop up-Clicking on one launches the member detail page on the same tab
8. Project detail page_Contributors section- The +1 to be highlighted on hover
