### PR TITLE
fix: skip forest admin agent creation if no config provided

### DIFF
--- a/apps/web-api/src/main.ts
+++ b/apps/web-api/src/main.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/node';
 import { AppModule } from './app.module';
 import { mainConfig } from './main.config';
 import { APP_ENV } from './utils/constants';
-import agent from './utils/forest-admin/agent';
+import { createForestAdminAgent } from './utils/forest-admin/agent';
 import { SetupService } from './setup.service';
 
 export async function bootstrap() {
@@ -29,12 +29,15 @@ export async function bootstrap() {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.ENVIRONMENT,
-    enabled:
-      process.env.ENVIRONMENT === APP_ENV.PRODUCTION ||
-      process.env.ENVIRONMENT === APP_ENV.STAGING,
+    enabled: process.env.ENVIRONMENT === APP_ENV.PRODUCTION || process.env.ENVIRONMENT === APP_ENV.STAGING,
   });
 
-  await agent.mountOnNestJs(app).start();
+  // Create forest admin agent if the secret is set
+  if (!!process.env.FOREST_AUTH_SECRET) {
+    const agent = createForestAdminAgent();
+    await agent.mountOnNestJs(app).start();
+  }
+
   await app.listen(process.env.PORT || 3000);
 }
 


### PR DESCRIPTION
## Description

Moved Forest Admin agent creation to separate function that is called only if `FOREST_AUTH_SECRET` is set in env variables. This will allow to run the app without access to Forest Admin.

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [ ] I've added relevant tests for my changes
- [ ] I've confirmed that my code passes linting
- [ ] I've confirmed that my code passes all tests
- [ ] I've confirmed that my code builds correctly
