### PR TITLE
fix: return more results in matched fields for autocomplete

### DIFF
--- a/apps/web-api/src/opensearch/opensearch.service.ts
+++ b/apps/web-api/src/opensearch/opensearch.service.ts
@@ -40,4 +40,13 @@ export class OpenSearchService {
   async searchWithLimit(index: string, size: number, body: any) {
     return this.client.search({ index, size, body });
   }
+
+  async getDocsByIds(index: string, ids: string[]) {
+    const mgetResponse = await this.client.mget({
+      index,
+      body: { ids },
+    });
+
+    return mgetResponse.body.docs;
+  }
 }

--- a/apps/web-api/src/utils/formatters.ts
+++ b/apps/web-api/src/utils/formatters.ts
@@ -9,3 +9,7 @@ export const formatDateTime = (date: Date): string => {
   });
   return formatter.format(date);
 };
+
+export const truncate = (str: string, max: number): string => {
+  return str.length > max ? str.slice(0, max - 1).trimEnd() + '…' : str;
+};


### PR DESCRIPTION
## Description

Fix for global search autocomplete matches:
- matches were returned very short which was not correct for the UI

## Tickets

- no ticket

---

## Checklist before requesting a review

- [X] I've performed a self-review of my code
- [X] I've added relevant tests for my changes
- [X] I've confirmed that my code passes linting
- [X] I've confirmed that my code passes all tests
- [X] I've confirmed that my code builds correctly
