### PR TITLE
add accessLevel filtering to all findMany and findAll queries (…

### DIFF
--- a/apps/web-api/src/home/home.controller.ts
+++ b/apps/web-api/src/home/home.controller.ts
@@ -40,8 +40,8 @@ export class HomeController {
   async getAllFeaturedData(
     @Req() request: Request,
   ) {
-    const loggedlnMember = request['userEmail'] ? await this.memberService.findMemberByEmail(request['userEmail']) : null;
-    return await this.homeService.fetchAllFeaturedData(loggedlnMember);
+    const loggedInMember = request['userEmail'] ? await this.memberService.findMemberByEmail(request['userEmail']) : null;
+    return await this.homeService.fetchAllFeaturedData(loggedInMember);
   }
 
   @Api(server.route.getAllDiscoveryQuestions)
@@ -117,7 +117,7 @@ export class HomeController {
 
   /**
    * Retrieves a list of teams and projects based on search query.
-   * 
+   *
    * @param request - HTTP request object containing query parameters
    * @returns Array of projects and teams.
    */

--- a/apps/web-api/src/home/home.service.ts
+++ b/apps/web-api/src/home/home.service.ts
@@ -18,10 +18,10 @@ export class HomeService {
     private plEventLocationService: PLEventLocationsService
   ) { }
 
-  async fetchAllFeaturedData(loggedlnMember) {
+  async fetchAllFeaturedData(loggedInMember: string) {
     try {
       return {
-        members: await this.memberService.findAll({
+        members: await this.memberService.findAllFiltered({
           where: { isFeatured: true },
           include: {
             image: true,
@@ -35,14 +35,14 @@ export class HomeService {
               },
             },
           },
-        }),
+        }, loggedInMember),
         teams: await this.teamsService.findAll({
           where: { isFeatured: true },
           include: { logo: true }
         }),
         events: await this.plEventsService.getPLEvents({ where: { isFeatured: true } }),
         projects: await this.projectsService.getProjects({ where: { isFeatured: true } }),
-        locations: await this.plEventLocationService.getFeaturedLocationsWithSubscribers({ where: { isFeatured: true } }, loggedlnMember)
+        locations: await this.plEventLocationService.getFeaturedLocationsWithSubscribers({ where: { isFeatured: true } }, loggedInMember)
       };
     } catch (error) {
       throw new InternalServerErrorException(`Error occured while retrieving featured data: ${error.message}`);
@@ -52,7 +52,7 @@ export class HomeService {
   /**
    * Retrieves a list of teams and projects based on search term.
    * Builds a Prisma query from the queryable fields and adds filters for team and project name.
-   * 
+   *
    * @param request - HTTP request object containing query parameters
    * @returns Array of projects and teams.
    */
@@ -73,7 +73,7 @@ export class HomeService {
   /**
    * Retrieves a list of teams based on search term.
    * Builds a Prisma query from the queryable fields and adds filters for team name.
-   * 
+   *
    * @param name - name of the team to be searched for.
    * @returns Array of resultant teams.
    */
@@ -103,7 +103,7 @@ export class HomeService {
   /**
    * Retrieves a list of projects based on search term.
    * Builds a Prisma query from the queryable fields and adds filters for project name.
-   * 
+   *
    * @param name - name of the project to be searched for.
    * @returns Array of resultant projects.
    */

--- a/apps/web-api/src/husky/tools/members.tool.ts
+++ b/apps/web-api/src/husky/tools/members.tool.ts
@@ -60,9 +60,13 @@ export class MembersTool {
     if (args.isFeatured !== undefined) where.isFeatured = args.isFeatured;
     if (args.openToWork !== undefined) where.openToWork = args.openToWork;
     if (args.plnFriend !== undefined) where.plnFriend = args.plnFriend;
-
     const members = await this.prisma.member.findMany({
-      where,
+      where: {
+        ...where,
+        accessLevel: {
+          notIn: ['L0', 'L1'],
+        },
+      },
       include: {
         image: true,
         location: true,
@@ -93,10 +97,10 @@ export class MembersTool {
       },
       orderBy: args.orderBy
         ? {
-            ...(args.orderBy === 'name' && { name: 'asc' }),
-            ...(args.orderBy === 'date' && { createdAt: 'desc' }),
-            ...(args.orderBy === 'plnStartDate' && { plnStartDate: 'desc' }),
-          }
+          ...(args.orderBy === 'name' && { name: 'asc' }),
+          ...(args.orderBy === 'date' && { createdAt: 'desc' }),
+          ...(args.orderBy === 'plnStartDate' && { plnStartDate: 'desc' }),
+        }
         : undefined,
       take: 10,
     });

--- a/apps/web-api/src/husky/tools/members.tool.ts
+++ b/apps/web-api/src/husky/tools/members.tool.ts
@@ -64,7 +64,7 @@ export class MembersTool {
       where: {
         ...where,
         accessLevel: {
-          notIn: ['L0', 'L1'],
+          notIn: ['L0', 'L1', 'Rejected'],
         },
       },
       include: {

--- a/apps/web-api/src/member-experiences/member-experiences.service.ts
+++ b/apps/web-api/src/member-experiences/member-experiences.service.ts
@@ -159,7 +159,7 @@ export class MemberExperiencesService {
           member: {
             uid: uid,
             accessLevel: {
-              notIn: ['L0', 'L1'],
+              notIn: ['L0', 'L1', 'Rejected'],
             },
           },
         },

--- a/apps/web-api/src/member-experiences/member-experiences.service.ts
+++ b/apps/web-api/src/member-experiences/member-experiences.service.ts
@@ -8,9 +8,9 @@ import {
 import { Prisma, MemberExperience } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
 import { LogService } from '../shared/log.service';
-import { 
-  CreateMemberExperienceDto, 
-  UpdateMemberExperienceDto 
+import {
+  CreateMemberExperienceDto,
+  UpdateMemberExperienceDto
 } from '../../../../libs/contracts/src/schema/member-experience';
 import { ParticipantsRequestService } from '../participants-request/participants-request.service';
 import { CacheService } from '../utils/cache/cache.service';
@@ -27,7 +27,7 @@ export class MemberExperiencesService {
 
   /**
    * Creates a new member experience in the database.
-   * 
+   *
    * @param dto - The data transfer object for the new member experience
    * @returns The created member experience record
    */
@@ -52,7 +52,7 @@ export class MemberExperiencesService {
 
   /**
    * Retrieves a single member experience by its UID.
-   * 
+   *
    * @param uid - The UID of the member experience to retrieve
    * @param options - Additional query options
    * @returns The requested member experience record
@@ -79,7 +79,7 @@ export class MemberExperiencesService {
 
   /**
    * Updates a member experience by its UID.
-   * 
+   *
    * @param uid - The UID of the member experience to update
    * @param dto - The data transfer object with fields to update
    * @returns The updated member experience record
@@ -88,13 +88,13 @@ export class MemberExperiencesService {
     try {
       const existingExperience = await this.findOne(uid);
       const { memberUid, ...experienceData } = updateMemberExperiencedto;
-      
+
       const updateData: Prisma.MemberExperienceUpdateInput = {
         ...experienceData,
         userUpdatedAt: new Date(),
         isModifiedByUser: true,
       };
-      
+
       const experience = await this.prisma.$transaction(async (tx) => {
         const updatedExperience = await tx.memberExperience.update({
           where: { uid },
@@ -126,10 +126,10 @@ export class MemberExperiencesService {
 
  /**
    * Removes a member experience by its UID.
-   * 
+   *
    * @param uid - The UID of the member experience to remove
    * @returns The deleted member experience record
-   */ 
+   */
   async remove(uid: string) {
     try {
       const experience = await this.prisma.memberExperience.delete({
@@ -145,7 +145,7 @@ export class MemberExperiencesService {
   /**
    * Retrieves all member experiences for a specific member,
    * sorted with current positions first, then by end date (most recent first).
-   * 
+   *
    * @param uid - The UID of the member to retrieve experiences for
    * @returns An array of member experiences
    */
@@ -153,18 +153,21 @@ export class MemberExperiencesService {
     try {
       const experiences = await this.prisma.memberExperience.findMany({
         include: {
-          member: true
+          member: true,
         },
         where: {
           member: {
-            uid: uid
-          }
+            uid: uid,
+            accessLevel: {
+              notIn: ['L0', 'L1'],
+            },
+          },
         },
         orderBy: [
           { isCurrent: 'desc' },
           { endDate: 'desc' },
-          { startDate: 'desc' }
-        ]
+          { startDate: 'desc' },
+        ],
       });
       return experiences;
     } catch (error) {

--- a/apps/web-api/src/member-follow-ups/member-follow-ups.service.ts
+++ b/apps/web-api/src/member-follow-ups/member-follow-ups.service.ts
@@ -1,8 +1,8 @@
-import { 
-  Injectable, 
-  BadRequestException, 
-  ConflictException, 
-  NotFoundException 
+import {
+  Injectable,
+  BadRequestException,
+  ConflictException,
+  NotFoundException
 } from '@nestjs/common';
 import { LogService } from '../shared/log.service';
 import { PrismaService } from '../shared/prisma.service';
@@ -17,9 +17,9 @@ export class MemberFollowUpsService {
 
   async createFollowUp(
     followUp: Prisma.MemberFollowUpUncheckedCreateInput,
-    interaction, 
+    interaction,
     tx?: Prisma.TransactionClient
-  ) { 
+  ) {
     try {
       await (tx || this.prisma).memberFollowUp.create({
         data: {
@@ -32,12 +32,22 @@ export class MemberFollowUpsService {
   }
 
   async getFollowUps(
-    query: Prisma.MemberFollowUpFindManyArgs, 
+    query: Prisma.MemberFollowUpFindManyArgs,
     tx?: Prisma.TransactionClient
   ) {
     try {
       return await (tx || this.prisma).memberFollowUp.findMany({
         ...query,
+        where: {
+          ...query.where,
+          interaction: {
+            sourceMember: {
+              accessLevel: {
+                notIn: ['L0', 'L1'],
+              },
+            },
+          },
+        },
         include: {
           interaction: {
             select: {
@@ -45,28 +55,29 @@ export class MemberFollowUpsService {
               type: true,
               sourceMember: {
                 select: {
-                  name:true,
-                  image:true
-                }
+                  name: true,
+                  image: true,
+                },
               },
-              targetMember:  {
+              targetMember: {
                 select: {
-                  name:true,
-                  image:true
-                }
-              }      
-            }
-          }
-        }
+                  name: true,
+                  image: true,
+                },
+              },
+            },
+          },
+        },
       });
-    } catch(error) {
+    } catch (error) {
       this.handleErrors(error);
     }
   }
 
+
   async updateFollowUpStatusByUid(
-    uid: string, 
-    status, 
+    uid: string,
+    status,
     tx?: Prisma.TransactionClient
   ) {
     try {
@@ -84,7 +95,7 @@ export class MemberFollowUpsService {
   }
 
   buildDelayedFollowUpQuery() {
-    const daysAgo = parseInt(process.env.INTERACTION_FOLLOWUP_DELAY_IN_DAYS || "7") 
+    const daysAgo = parseInt(process.env.INTERACTION_FOLLOWUP_DELAY_IN_DAYS || "7")
     const dateOfNthWeekAgo = new Date();
     dateOfNthWeekAgo.setDate(dateOfNthWeekAgo.getDate() - daysAgo);
     return {
@@ -101,7 +112,7 @@ export class MemberFollowUpsService {
             lte: dateOfNthWeekAgo,
           }
         }
-      ] 
+      ]
     }
   };
 

--- a/apps/web-api/src/member-follow-ups/member-follow-ups.service.ts
+++ b/apps/web-api/src/member-follow-ups/member-follow-ups.service.ts
@@ -43,7 +43,7 @@ export class MemberFollowUpsService {
           interaction: {
             sourceMember: {
               accessLevel: {
-                notIn: ['L0', 'L1'],
+                notIn: ['L0', 'L1', 'Rejected'],
               },
             },
           },

--- a/apps/web-api/src/member-subscriptions/member-subscriptions.service.ts
+++ b/apps/web-api/src/member-subscriptions/member-subscriptions.service.ts
@@ -80,7 +80,7 @@ export class MemberSubscriptionService {
         where: {
           ...query.where,
           member: {
-            accessLevel: { notIn: ['L0', 'L1'] },
+            accessLevel: { notIn: ['L0', 'L1', 'Rejected'] },
           },
         },
       });

--- a/apps/web-api/src/member-subscriptions/member-subscriptions.service.ts
+++ b/apps/web-api/src/member-subscriptions/member-subscriptions.service.ts
@@ -58,28 +58,37 @@ export class MemberSubscriptionService {
 
   /**
    * Retrieves multiple member subscription records based on the provided query criteria.
-   * 
-   * This method leverages Prisma's `findMany` to perform a flexible query. 
-   * The query object allows the caller to specify filters, sorting, pagination, 
+   *
+   * This method leverages Prisma's `findMany` to perform a flexible query.
+   * The query object allows the caller to specify filters, sorting, pagination,
    * and include related entities as needed.
-   * 
+   *
    * @param query - A `Prisma.MemberFollowFindManyArgs` object that defines the query criteria.
    *   - `where`: Conditions to filter the records (e.g., by `memberUid` or `status`).
    *   - `orderBy`: Sorting criteria for the results (e.g., by `createdAt` in ascending order).
    *   - `skip`: The number of records to skip for pagination.
    *   - `take`: The number of records to retrieve (limit for pagination).
    *   - `include`: Related entities to include in the results (e.g., `member`).
-   * 
+   *
    * @returns An array of member subscription records matching the query criteria.
-   * 
+   *
    */
   async getSubscriptions(query: Prisma.MemberSubscriptionFindManyArgs) {
     try {
-      return await this.prisma.memberSubscription.findMany(query);
+      return await this.prisma.memberSubscription.findMany({
+        ...query,
+        where: {
+          ...query.where,
+          member: {
+            accessLevel: { notIn: ['L0', 'L1'] },
+          },
+        },
+      });
     } catch (error) {
       this.handleErrors(error);
     }
   }
+
 
   /**
    * Handles errors occurring during database operations.

--- a/apps/web-api/src/members/members.service.ts
+++ b/apps/web-api/src/members/members.service.ts
@@ -88,7 +88,7 @@ export class MembersService {
       const where = {
         ...queryOptions.where,
         accessLevel: {
-          notIn: ['L0', 'L1'],
+          notIn: ['L0', 'L1', 'Rejected'],
         },
       };
 
@@ -128,7 +128,7 @@ export class MembersService {
       };
 
       const accessLevelFilter: Prisma.MemberWhereInput = {
-        accessLevel: { notIn: ['L0', 'L1'] },
+        accessLevel: { notIn: ['L0', 'L1', 'Rejected'] },
       };
 
       queryOptions.where = {

--- a/apps/web-api/src/projects/projects.service.ts
+++ b/apps/web-api/src/projects/projects.service.ts
@@ -96,11 +96,28 @@ export class ProjectsService {
 
   async getProjects(queryOptions: Prisma.ProjectFindManyArgs) {
     try {
+      const whereWithFilter: Prisma.ProjectWhereInput = {
+        ...queryOptions.where,
+        creator: {
+          accessLevel: {
+            notIn: ['L0', 'L1'],
+          },
+        },
+      };
+
       const [projects, projectsCount] = await Promise.all([
-        this.prisma.project.findMany(queryOptions),
-        this.prisma.project.count({ where: queryOptions.where }),
+        this.prisma.project.findMany({
+          ...queryOptions,
+          where: whereWithFilter,
+          include: {
+            ...queryOptions.include,
+            creator: true,
+          },
+        }),
+        this.prisma.project.count({ where: whereWithFilter }),
       ]);
-      return { count: projectsCount, projects: projects }
+
+      return { count: projectsCount, projects };
     } catch (err) {
       this.handleErrors(err);
     }
@@ -378,9 +395,9 @@ export class ProjectsService {
    * Constructs a dynamic filter query for retrieving recent projects based on the 'is_recent' query parameter.
    * If 'is_recent' is set to 'true', it creates a 'createdAt' filter to retrieve records created within a
    * specified number of days. The number of days is configured via an environment variable.
-   * 
+   *
    * If a filter array is passed, it pushes the 'createdAt' filter to the existing filters.
-   * 
+   *
    * @param queryParams - HTTP request query parameters object
    * @param filter - Optional existing filter array to which the recent filter will be added if provided
    * @returns The constructed query with a 'createdAt' filter if 'is_recent' is 'true',
@@ -427,7 +444,7 @@ export class ProjectsService {
 
   /**
    * Fetches team names that maintain atleast a single project.
-   * 
+   *
    * @returns Set of team names.
    */
   async getProjectFilters(queryParams) {
@@ -464,7 +481,7 @@ export class ProjectsService {
         },
       })
     ])
-    
+
     return {
       askTags: this.askService.formatAskFilterResponse(askTags),
       tags: this.aggregatePropertyCount(tags,'tags')
@@ -472,7 +489,7 @@ export class ProjectsService {
     // return { maintainedBy: maintainingTeams.map((team) => ({ uid: team.uid, name: team.name, logo: team.logo?.url })) };
   }
 
-  
+
   /**
    * Aggregates the counts of a specified property from an array of objects.
    *

--- a/apps/web-api/src/projects/projects.service.ts
+++ b/apps/web-api/src/projects/projects.service.ts
@@ -100,7 +100,7 @@ export class ProjectsService {
         ...queryOptions.where,
         creator: {
           accessLevel: {
-            notIn: ['L0', 'L1'],
+            notIn: ['L0', 'L1', 'Rejected'],
           },
         },
       };

--- a/apps/web-api/src/recommendations/recommendations.service.ts
+++ b/apps/web-api/src/recommendations/recommendations.service.ts
@@ -582,7 +582,7 @@ export class RecommendationsService {
         where: {
           ...where,
           accessLevel: {
-            notIn: ['L0', 'L1'],
+            notIn: ['L0', 'L1', 'Rejected'],
           },
         },
         skip,
@@ -638,7 +638,7 @@ export class RecommendationsService {
     return this.prisma.member.findMany({
       where: {
         accessLevel: {
-          notIn: ['L0', 'L1'],
+          notIn: ['L0', 'L1', 'Rejected'],
         },
         notificationSetting: {
           subscribed: true,

--- a/apps/web-api/src/recommendations/recommendations.service.ts
+++ b/apps/web-api/src/recommendations/recommendations.service.ts
@@ -579,7 +579,12 @@ export class RecommendationsService {
 
     while (hasMore) {
       const members = await this.prisma.member.findMany({
-        where,
+        where: {
+          ...where,
+          accessLevel: {
+            notIn: ['L0', 'L1'],
+          },
+        },
         skip,
         take: chunkSize,
         include: {
@@ -632,6 +637,9 @@ export class RecommendationsService {
   async getMembersWithEnabledRecommendations() {
     return this.prisma.member.findMany({
       where: {
+        accessLevel: {
+          notIn: ['L0', 'L1'],
+        },
         notificationSetting: {
           subscribed: true,
         },
@@ -666,8 +674,8 @@ export class RecommendationsService {
 
   async getUniqueRoles(): Promise<string[]> {
     const result = await this.prisma.$queryRaw<Array<{ role: string }>>`
-      SELECT DISTINCT role 
-      FROM "TeamMemberRole" 
+      SELECT DISTINCT role
+      FROM "TeamMemberRole"
       WHERE role IS NOT NULL AND role != ''
       ORDER BY role
     `;

--- a/lambda/lambda-opensearch-sync/index.mjs
+++ b/lambda/lambda-opensearch-sync/index.mjs
@@ -129,10 +129,13 @@ function purifyHtml(html) {
 
 async function indexMembers(lastCheckpoint) {
   const res = await pgClient.query(`
-        SELECT m.uid, m.name, m.bio, i.url FROM "Member" m
-        LEFT JOIN "Image" i ON m."imageUid" = i.uid
-        WHERE m."createdAt" > $1 OR m."updatedAt" > $1
-    `, [lastCheckpoint]);
+    SELECT m.uid, m.name, m.bio, i.url
+    FROM "Member" m
+           LEFT JOIN "Image" i ON m."imageUid" = i.uid
+    WHERE
+      (m."createdAt" > $1 OR m."updatedAt" > $1)
+      AND m."accessLevel" NOT IN ('L0', 'L1')
+  `, [lastCheckpoint]);
 
   console.log('Got data from Member table: ' + res.rows.length);
 


### PR DESCRIPTION
Users with L0 and L1 access levels shouldn't be visible across all the endpoints in the results