### PR TITLE
LAB-691 Update members search roles autocomplete and filtering

### DIFF
--- a/apps/web-api/src/members/members.service.ts
+++ b/apps/web-api/src/members/members.service.ts
@@ -2121,7 +2121,8 @@ export class MembersService {
         }),
       };
 
-      const roles = await this.prisma.teamMemberRole.groupBy({
+      // Search in teamMemberRoles
+      const teamRoles = await this.prisma.teamMemberRole.groupBy({
         by: ['role'],
         where: {
           role: {
@@ -2144,12 +2145,81 @@ export class MembersService {
         },
       });
 
-      const results = roles
+      // Search in experiences (title field)
+      const experiences = await this.prisma.memberExperience.groupBy({
+        by: ['title'],
+        where: {
+          ...(query.trim() && {
+            title: {
+              contains: query,
+              mode: 'insensitive' as const,
+            },
+          }),
+          member: memberFilter,
+        },
+        _count: true,
+        orderBy: {
+          _count: {
+            title: 'desc',
+          },
+        },
+      });
+
+      // Search in projectContributions (role field)
+      const projectRoles = await this.prisma.projectContribution.groupBy({
+        by: ['role'],
+        where: {
+          role: {
+            not: null,
+            ...(query.trim() && {
+              contains: query,
+              mode: 'insensitive' as const,
+            }),
+          },
+          member: memberFilter,
+        },
+        _count: true,
+        orderBy: {
+          _count: {
+            role: 'desc',
+          },
+        },
+      });
+
+      // Combine and deduplicate results
+      const roleMap = new Map<string, number>();
+
+      // Add team roles
+      teamRoles
         .filter((role) => role.role !== null)
-        .map((role) => ({
-          role: role.role as string,
-          count: role._count.memberUid,
-        }));
+        .forEach((role) => {
+          const roleStr = role.role as string;
+          roleMap.set(roleStr, (roleMap.get(roleStr) || 0) + role._count.memberUid);
+        });
+
+      // Add experience titles
+      experiences
+        .filter((exp) => exp.title !== null)
+        .forEach((exp) => {
+          const title = exp.title as string;
+          roleMap.set(title, (roleMap.get(title) || 0) + (exp._count as number));
+        });
+
+      // Add project contribution roles
+      projectRoles
+        .filter((proj) => proj.role !== null)
+        .forEach((proj) => {
+          const role = proj.role as string;
+          roleMap.set(role, (roleMap.get(role) || 0) + (proj._count as number));
+        });
+
+      // Convert map to array and sort by count
+      const results = Array.from(roleMap.entries())
+        .map(([role, count]) => ({
+          role,
+          count,
+        }))
+        .sort((a, b) => b.count - a.count);
 
       const paginatedResults = results.slice(skip, skip + limit);
 

--- a/apps/web-api/src/members/members.service.ts
+++ b/apps/web-api/src/members/members.service.ts
@@ -1813,7 +1813,7 @@ export class MembersService {
 
       // Add OR condition to match any of the three sources
       whereConditions.push({
-        AND: rolesConditions,
+        OR: rolesConditions,
       });
     }
 

--- a/apps/web-api/src/members/members.service.ts
+++ b/apps/web-api/src/members/members.service.ts
@@ -1718,13 +1718,13 @@ export class MembersService {
       if (topicsArray.length > 0) {
         const [ohInterestMemberIds, ohHelpWithMemberIds] = await Promise.all([
           this.prisma.$queryRaw<{ id: number }[]>`
-            SELECT DISTINCT id FROM "Member" 
+            SELECT DISTINCT id FROM "Member"
             WHERE ${Prisma.raw(
               topicsArray
                 .map(
                   (topic) => `
                   EXISTS (
-                    SELECT 1 FROM unnest("ohInterest") AS interest_item 
+                    SELECT 1 FROM unnest("ohInterest") AS interest_item
                     WHERE LOWER(interest_item) LIKE LOWER('%${topic.replace(/'/g, "''")}%')
                   )
                 `
@@ -1733,13 +1733,13 @@ export class MembersService {
             )}
           `,
           this.prisma.$queryRaw<{ id: number }[]>`
-            SELECT DISTINCT id FROM "Member" 
+            SELECT DISTINCT id FROM "Member"
             WHERE ${Prisma.raw(
               topicsArray
                 .map(
                   (topic) => `
                   EXISTS (
-                    SELECT 1 FROM unnest("ohHelpWith") AS help_item 
+                    SELECT 1 FROM unnest("ohHelpWith") AS help_item
                     WHERE LOWER(help_item) LIKE LOWER('%${topic.replace(/'/g, "''")}%')
                   )
                 `
@@ -1768,11 +1768,14 @@ export class MembersService {
       });
     }
 
-    // Roles filter - search in current team roles
+    // Roles filter - search in team roles, experiences, and project contributions
     if (filters.roles && filters.roles.length > 0) {
       // Ensure roles is always an array (query params might come as string)
       const rolesArray = Array.isArray(filters.roles) ? filters.roles : [filters.roles];
-      whereConditions.push({
+      const rolesConditions: Prisma.MemberWhereInput[] = [];
+
+      // Search in team member roles
+      rolesConditions.push({
         teamMemberRoles: {
           some: {
             mainTeam: true,
@@ -1782,6 +1785,35 @@ export class MembersService {
             },
           },
         },
+      });
+
+      // Search in member experiences (title field)
+      rolesConditions.push({
+        experiences: {
+          some: {
+            title: {
+              in: rolesArray,
+              mode: 'insensitive',
+            },
+          },
+        },
+      });
+
+      // Search in project contributions (role field)
+      rolesConditions.push({
+        projectContributions: {
+          some: {
+            role: {
+              in: rolesArray,
+              mode: 'insensitive',
+            },
+          },
+        },
+      });
+
+      // Add OR condition to match any of the three sources
+      whereConditions.push({
+        AND: rolesConditions,
       });
     }
 
@@ -1967,16 +1999,16 @@ export class MembersService {
         // Get member IDs that match the search query in ohInterest or ohHelpWith
         const [ohInterestIds, ohHelpWithIds] = await Promise.all([
           this.prisma.$queryRaw<{ id: number }[]>`
-            SELECT DISTINCT id FROM "Member" 
+            SELECT DISTINCT id FROM "Member"
             WHERE EXISTS (
-              SELECT 1 FROM unnest("ohInterest") AS interest_item 
+              SELECT 1 FROM unnest("ohInterest") AS interest_item
               WHERE LOWER(interest_item) LIKE LOWER(${`%${searchQuery}%`})
             )
           `,
           this.prisma.$queryRaw<{ id: number }[]>`
-            SELECT DISTINCT id FROM "Member" 
+            SELECT DISTINCT id FROM "Member"
             WHERE EXISTS (
-              SELECT 1 FROM unnest("ohHelpWith") AS help_item 
+              SELECT 1 FROM unnest("ohHelpWith") AS help_item
               WHERE LOWER(help_item) LIKE LOWER(${`%${searchQuery}%`})
             )
           `,


### PR DESCRIPTION
## Description

The autocomplete roles and members' search functionality now properly searches across:
  - Team member roles (role field)
  - Member experiences (title field)
  - Project contributions (role field)

## Tickets

- [LAB-691](https://linear.app/plrs-labos/issue/LAB-691/filters-update-members-search-roles-autocomplete-and-filtering)

---

## Checklist before requesting a review

- [x] I've performed a self-review of my code
- [ ] I've added relevant tests for my changes
- [ ] I've confirmed that my code passes linting
- [x] I've confirmed that my code passes all tests
- [x] I've confirmed that my code builds correctly
