### PR TITLE
LAB-841 [Demo Day v2.1] Add investmentTeam field to TeamMemberRole

### DIFF
--- a/apps/back-office/hooks/members/useAddMember.ts
+++ b/apps/back-office/hooks/members/useAddMember.ts
@@ -19,6 +19,7 @@ interface MutationParams {
     teamMemberRoles: {
       teamUid: string;
       role: string;
+      investmentTeam?: boolean;
     }[];
     linkedinHandler: string;
     discordHandler: string;

--- a/apps/back-office/hooks/members/useMember.ts
+++ b/apps/back-office/hooks/members/useMember.ts
@@ -22,6 +22,7 @@ interface IMemberResponse {
     region?: string;
   };
   teamMemberRoles: Array<{
+    investmentTeam?: boolean;
     team: {
       uid: string;
       name: string;
@@ -54,6 +55,7 @@ export const getMemberInfo = async (memberUid: string) => {
       teamTitle: tm.team.name,
       teamUid: tm.teamUid,
       role: tm.role,
+      investmentTeam: tm.investmentTeam || false,
     };
   });
 

--- a/apps/back-office/hooks/members/useUpdateMember.ts
+++ b/apps/back-office/hooks/members/useUpdateMember.ts
@@ -20,6 +20,7 @@ interface MutationParams {
     teamMemberRoles: {
       teamUid: string;
       role: string;
+      investmentTeam?: boolean;
     }[];
     linkedinHandler: string;
     discordHandler: string;

--- a/apps/web-api/prisma/fixtures/team-member-roles.ts
+++ b/apps/web-api/prisma/fixtures/team-member-roles.ts
@@ -37,6 +37,7 @@ export const teamMemberRoles = async () => {
           teamLead: faker.datatype.boolean(),
           startDate: faker.date.past(),
           endDate: faker.date.recent(),
+          investmentTeam: false,
           roleTags: [faker.name.jobType(), faker.name.jobType()],
         };
       })

--- a/apps/web-api/prisma/migrations/20251003154216_add_investment_team_field/migration.sql
+++ b/apps/web-api/prisma/migrations/20251003154216_add_investment_team_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TeamMemberRole" ADD COLUMN "investmentTeam" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -257,17 +257,18 @@ model Location {
 }
 
 model TeamMemberRole {
-  id        Int       @id @default(autoincrement())
-  mainTeam  Boolean   @default(false)
-  teamLead  Boolean   @default(false)
-  startDate DateTime?
-  endDate   DateTime?
-  role      String?
-  member    Member    @relation(fields: [memberUid], references: [uid], onDelete: Cascade)
-  memberUid String
-  team      Team      @relation(fields: [teamUid], references: [uid], onDelete: Cascade)
-  teamUid   String
-  roleTags  String[]
+  id             Int       @id @default(autoincrement())
+  mainTeam       Boolean   @default(false)
+  teamLead       Boolean   @default(false)
+  investmentTeam Boolean   @default(false)
+  startDate      DateTime?
+  endDate        DateTime?
+  role           String?
+  member         Member    @relation(fields: [memberUid], references: [uid], onDelete: Cascade)
+  memberUid      String
+  team           Team      @relation(fields: [teamUid], references: [uid], onDelete: Cascade)
+  teamUid        String
+  roleTags       String[]
 
   // One member can only have one role per team
   @@unique([memberUid, teamUid])

--- a/apps/web-api/src/admin/member.service.ts
+++ b/apps/web-api/src/admin/member.service.ts
@@ -527,7 +527,7 @@ export class MemberService {
           role: t.role,
           mainTeam: false,
           teamLead: false,
-          investmentTeam: t.investmentTeam || false, // Add investmentTeam field
+          investmentTeam: t.investmentTeam || false,
           teamUid: t.teamUid,
           roleTags: t.role?.split(',')?.map((item) => item.trim()),
         })),
@@ -846,6 +846,7 @@ export class MemberService {
         },
         teamMemberRoles: {
           select: {
+            investmentTeam: true,
             team: {
               select: {
                 uid: true,

--- a/apps/web-api/src/admin/member.service.ts
+++ b/apps/web-api/src/admin/member.service.ts
@@ -411,7 +411,8 @@ export class MemberService {
       const foundIndex = existingMember.teamMemberRoles.findIndex((v: any) => v.teamUid === t.teamUid);
       if (foundIndex > -1) {
         const foundValue = existingMember.teamMemberRoles[foundIndex];
-        if (foundValue.role !== t.role) {
+        // Check if a role or investmentTeam has changed
+        if (foundValue.role !== t.role || foundValue.investmentTeam !== t.investmentTeam) {
           let foundDefaultRoleTag = false;
           // Check if there's a default member role tag
           foundValue.roleTags?.some((tag: any) => {
@@ -424,6 +425,10 @@ export class MemberService {
           memberData.teamAndRoles[index].roleTags = foundDefaultRoleTag
             ? foundValue.roleTags
             : t.role?.split(',').map((item: string) => item.trim());
+          // Preserve investmentTeam if not explicitly provided
+          if (t.investmentTeam === undefined) {
+            memberData.teamAndRoles[index].investmentTeam = foundValue.investmentTeam;
+          }
           return true;
         }
       }
@@ -450,6 +455,7 @@ export class MemberService {
         role: t.role,
         mainTeam: false, // Set your default values here if needed
         teamLead: false, // Set your default values here if needed
+        investmentTeam: t.investmentTeam || false,
         teamUid: t.teamUid,
         memberUid,
         roleTags: t.role?.split(',').map((item: string) => item.trim()), // Properly format roleTags
@@ -498,7 +504,11 @@ export class MemberService {
               memberUid,
             },
           },
-          data: { role: roleToUpdate.role, roleTags: roleToUpdate.roleTags },
+          data: {
+            role: roleToUpdate.role,
+            roleTags: roleToUpdate.roleTags,
+            investmentTeam: roleToUpdate.investmentTeam || false,
+          },
         })
       );
       await Promise.all(updatePromises);
@@ -517,6 +527,7 @@ export class MemberService {
           role: t.role,
           mainTeam: false,
           teamLead: false,
+          investmentTeam: t.investmentTeam || false, // Add investmentTeam field
           teamUid: t.teamUid,
           roleTags: t.role?.split(',')?.map((item) => item.trim()),
         })),


### PR DESCRIPTION
## Description

* Add `investmentTeam` to the Prisma schema
* Add migration with the new `investmentTeam` field
* Update PUT endpoint `v1/member/:uid` to handle this new field
* Update GET endpoint `v1/member/:uid` to include this new field. Response example:
```
"teamMemberRoles": [
        {
            "mainTeam": true,
            "teamLead": false,
            "investmentTeam": false,
            "startDate": null,
            "endDate": null,
            "role": "CEO",
            "memberUid": "uid-amir",
            "teamUid": "uid-bailey---beier",
            "roleTags": [
                "CEO"
            ],
```
* Update GET endpoint `/v1/admin/members?accessLevel=L6`. Response example:
```
{
    "data": [
        {
            "uid": "uid-joe",
            "teamMemberRoles": [
                {
                    "investmentTeam": false,
                    "team": {
                        "uid": "uid-bailey---beier",
                        "name": "Bailey - Beier"
                    }
                },
                {
                    "investmentTeam": false,
                    "team": {
                        "uid": "uid-feil-group",
                        "name": "Feil Group"
                    }
                }
            ]
}
```

## Tickets

- [Add investmentTeam field to TeamMemberRole](https://linear.app/plrs-labos/issue/LAB-841/demo-day-v21-add-investmentteam-field-to-teammemberrole)

---
