### PR TITLE
LAB-848 [Demo Day v2.1] Add field for “Company paragraph for fundraise” for TeamFundraisingProfile

### DIFF
--- a/apps/web-api/prisma/migrations/20251006151811_add_description_to_team_fundraising_profile/migration.sql
+++ b/apps/web-api/prisma/migrations/20251006151811_add_description_to_team_fundraising_profile/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TeamFundraisingProfile" ADD COLUMN "description" TEXT;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -838,6 +838,8 @@ model TeamFundraisingProfile {
   videoUploadUid String?
   videoUpload    Upload? @relation("TFP_videoUpload", fields: [videoUploadUid], references: [uid])
 
+  description String?
+
   status TeamFundraisingProfileStatus @default(DRAFT)
 
   createdAt      DateTime @default(now())

--- a/apps/web-api/src/demo-days/demo-day-fundraising-profiles.service.ts
+++ b/apps/web-api/src/demo-days/demo-day-fundraising-profiles.service.ts
@@ -171,6 +171,7 @@ export class DemoDayFundraisingProfilesService {
       onePagerUpload: fundraisingProfile.onePagerUpload,
       videoUploadUid: fundraisingProfile.videoUploadUid,
       videoUpload: fundraisingProfile.videoUpload,
+      description: fundraisingProfile.description,
     };
   }
 
@@ -409,6 +410,32 @@ export class DemoDayFundraisingProfilesService {
         teamUid: team.uid,
         demoDayUid: demoDay.uid,
         videoUploadUid,
+        status: 'DRAFT',
+      },
+    });
+
+    await this.updateFundraisingProfileStatus(team.uid, demoDay.uid);
+    return this.getCurrentDemoDayFundraisingProfile(memberEmail);
+  }
+
+  async updateFundraisingDescription(memberEmail: string, description: string): Promise<any> {
+    const { team, demoDay } = await this.validateDemoDayFounderAccess(memberEmail);
+
+    // Update or create profile
+    await this.prisma.teamFundraisingProfile.upsert({
+      where: {
+        teamUid_demoDayUid: {
+          teamUid: team.uid,
+          demoDayUid: demoDay.uid,
+        },
+      },
+      update: {
+        description,
+      },
+      create: {
+        teamUid: team.uid,
+        demoDayUid: demoDay.uid,
+        description,
         status: 'DRAFT',
       },
     });

--- a/apps/web-api/src/demo-days/demo-days.controller.ts
+++ b/apps/web-api/src/demo-days/demo-days.controller.ts
@@ -22,7 +22,7 @@ import { UserTokenValidation } from '../guards/user-token-validation.guard';
 import { UploadsService } from '../uploads/uploads.service';
 import { UploadKind, UploadScopeType } from '@prisma/client';
 import { NoCache } from '../decorators/no-cache.decorator';
-import { UpdateFundraisingTeamDto } from 'libs/contracts/src/schema';
+import { UpdateFundraisingTeamDto, UpdateFundraisingDescriptionDto } from 'libs/contracts/src/schema';
 
 @ApiTags('Demo Days')
 @Controller('v1/demo-days')
@@ -108,6 +108,17 @@ export class DemoDaysController {
     });
 
     return this.demoDayFundraisingProfilesService.updateFundraisingVideo(req.userEmail, upload.uid);
+  }
+
+  @Put('current/fundraising-profile/description')
+  @UseGuards(UserTokenValidation)
+  @NoCache()
+  async updateDescription(@Req() req, @Body() body: UpdateFundraisingDescriptionDto) {
+    if (!body.description || body.description.trim() === '') {
+      throw new Error('description is required');
+    }
+
+    return this.demoDayFundraisingProfilesService.updateFundraisingDescription(req.userEmail, body.description);
   }
 
   @Delete('current/fundraising-profile/video')

--- a/libs/contracts/src/schema/demo-day.ts
+++ b/libs/contracts/src/schema/demo-day.ts
@@ -10,3 +10,9 @@ export const UpdateFundraisingTeamSchema = z.object({
 });
 
 export class UpdateFundraisingTeamDto extends createZodDto(UpdateFundraisingTeamSchema) {}
+
+export const UpdateFundraisingDescriptionSchema = z.object({
+  description: z.string(),
+});
+
+export class UpdateFundraisingDescriptionDto extends createZodDto(UpdateFundraisingDescriptionSchema) {}


### PR DESCRIPTION
## Description

* Add migration with the new field
* Update GET `/v1/demo-days/current/fundraising-profile` - Now includes description field
* Update GET `/v1/demo-days/current/fundraising-profiles` - Now includes description field for all profiles
* Add PUT `/v1/demo-days/current/fundraising-profile/description` - New endpoint to update description (similar to `current/fundraising-profile/video`):
```
curl --location --request PUT 'localhost:3000/v1/demo-days/current/fundraising-profile/description' \
--header 'Content-Type: application/json' \
--data '{
    "description": "Test description"
}'
```

## Ticket

- [LAB-848](https://linear.app/plrs-labos/issue/LAB-848/demo-day-v21-add-field-for-company-paragraph-for-fundraise-for)

