### PR TITLE
LAB-1675 [Founder Guides] [RBAC] Implement permission scopes (PLVS/PLCC)

### DIFF
--- a/apps/back-office/hooks/access-control/useUpdateMemberPermissionScopes.ts
+++ b/apps/back-office/hooks/access-control/useUpdateMemberPermissionScopes.ts
@@ -7,25 +7,19 @@ interface MutationParams {
   authToken: string | undefined;
   memberUid: string;
   permissionCode: string;
-  grantedByMemberUid?: string;
-  scopes?: string[];
+  scopes: string[];
 }
 
-export function useGrantPermission() {
+export function useUpdateMemberPermissionScopes() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (params: MutationParams) => {
-      const { authToken, memberUid, permissionCode, grantedByMemberUid, scopes } = params;
+      const { authToken, memberUid, permissionCode, scopes } = params;
 
       const { data } = await api.post(
-        `${API_ROUTE.ADMIN_RBAC_PERMISSIONS}/grant`,
-        {
-          memberUid,
-          permissionCode,
-          grantedByMemberUid,
-          scopes,
-        },
+        `${API_ROUTE.ADMIN_RBAC_PERMISSIONS}/scopes`,
+        { memberUid, permissionCode, scopes },
         {
           headers: {
             authorization: `Bearer ${authToken}`,

--- a/apps/back-office/hooks/access-control/useUpdateRolePermissionScopes.ts
+++ b/apps/back-office/hooks/access-control/useUpdateRolePermissionScopes.ts
@@ -5,27 +5,21 @@ import { RbacQueryKeys } from './constants/queryKeys';
 
 interface MutationParams {
   authToken: string | undefined;
-  memberUid: string;
+  roleCode: string;
   permissionCode: string;
-  grantedByMemberUid?: string;
-  scopes?: string[];
+  scopes: string[];
 }
 
-export function useGrantPermission() {
+export function useUpdateRolePermissionScopes() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (params: MutationParams) => {
-      const { authToken, memberUid, permissionCode, grantedByMemberUid, scopes } = params;
+      const { authToken, roleCode, permissionCode, scopes } = params;
 
       const { data } = await api.post(
-        `${API_ROUTE.ADMIN_RBAC_PERMISSIONS}/grant`,
-        {
-          memberUid,
-          permissionCode,
-          grantedByMemberUid,
-          scopes,
-        },
+        `${API_ROUTE.ADMIN_RBAC_ROLES}/permission-scopes`,
+        { roleCode, permissionCode, scopes },
         {
           headers: {
             authorization: `Bearer ${authToken}`,
@@ -37,10 +31,10 @@ export function useGrantPermission() {
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: [RbacQueryKeys.MEMBER_DETAILS, variables.authToken, variables.memberUid],
+        queryKey: [RbacQueryKeys.ROLE_DETAILS, variables.authToken, variables.roleCode],
       });
       queryClient.invalidateQueries({
-        queryKey: [RbacQueryKeys.MEMBERS_LIST, variables.authToken],
+        queryKey: [RbacQueryKeys.ROLES_LIST, variables.authToken],
       });
       queryClient.invalidateQueries({
         queryKey: [RbacQueryKeys.PERMISSION_DETAILS, variables.authToken, variables.permissionCode],

--- a/apps/back-office/pages/access-control/members/[uid].tsx
+++ b/apps/back-office/pages/access-control/members/[uid].tsx
@@ -34,14 +34,16 @@ import AddRoleModal from '../../../screens/access-control/components/AddRoleModa
 import AddPermissionModal from '../../../screens/access-control/components/AddPermissionModal';
 import ConfirmDeleteModal from '../../../screens/access-control/components/ConfirmDeleteModal';
 import InfoModal from '../../../screens/access-control/components/InfoModal';
+import EditScopesModal from '../../../screens/access-control/components/EditScopesModal';
 import { RoleBasic, PermissionBasic } from '../../../screens/access-control/types';
+import { useUpdateMemberPermissionScopes } from '../../../hooks/access-control/useUpdateMemberPermissionScopes';
 
 import s from './styles.module.scss';
 
 type Tab = 'roles' | 'permissions';
 type PermissionFilter = 'all' | 'direct' | 'viaRoles';
 
-type MemberPermissionRow = PermissionBasic & { viaRoles: string[]; isDirect: boolean };
+type MemberPermissionRow = PermissionBasic & { viaRoles: string[]; isDirect: boolean; scopes: string[] };
 
 const REMOVE_DIRECT_AND_ROLE_WARNING =
   'This permission is also granted through assigned role(s). Removing the direct grant will not remove access from those roles—you can still have this permission until you change or remove those role assignments.';
@@ -63,6 +65,7 @@ const MemberEditPage = () => {
   const [confirmRemovePermission, setConfirmRemovePermission] = useState<PermissionBasic | null>(null);
   const [removePermissionWarningNote, setRemovePermissionWarningNote] = useState<string | null>(null);
   const [infoPermission, setInfoPermission] = useState<(PermissionBasic & { viaRoles: string[] }) | null>(null);
+  const [editScopesPerm, setEditScopesPerm] = useState<MemberPermissionRow | null>(null);
 
   // Fetch data
   const { data: memberData, isLoading: memberLoading } = useRbacMember({
@@ -78,6 +81,7 @@ const MemberEditPage = () => {
   const revokeRole = useRevokeRole();
   const grantPermission = useGrantPermission();
   const revokePermission = useRevokePermission();
+  const updateMemberPermissionScopes = useUpdateMemberPermissionScopes();
 
   // Redirects
   useEffect(() => {
@@ -155,13 +159,14 @@ const MemberEditPage = () => {
     }
   };
 
-  const handleAddPermission = async (permission: PermissionBasic) => {
+  const handleAddPermission = async (permission: PermissionBasic, scopes: string[]) => {
     try {
       await grantPermission.mutateAsync({
         authToken,
         memberUid: uid as string,
         permissionCode: permission.code,
         grantedByMemberUid: user?.uid,
+        scopes,
       });
       toast.success(`Granted permission "${permission.code}" to ${member?.name}`);
       setShowAddPermissionModal(false);
@@ -189,6 +194,22 @@ const MemberEditPage = () => {
   const closeRemovePermissionModal = () => {
     setConfirmRemovePermission(null);
     setRemovePermissionWarningNote(null);
+  };
+
+  const handleSaveScopes = async (scopes: string[]) => {
+    if (!editScopesPerm) return;
+    try {
+      await updateMemberPermissionScopes.mutateAsync({
+        authToken,
+        memberUid: uid as string,
+        permissionCode: editScopesPerm.code,
+        scopes,
+      });
+      toast.success(`Updated scopes for "${editScopesPerm.code}"`);
+      setEditScopesPerm(null);
+    } catch (error) {
+      toast.error('Failed to update scopes');
+    }
   };
 
   /** Direct + via roles → confirm with warning. Direct only → confirm. Role-only → cannot delete info. */
@@ -373,6 +394,7 @@ const MemberEditPage = () => {
                   <div className={clsx(s.headerCell, s.flexible)}>Description</div>
                   <div className={clsx(s.headerCell, s.fixed)}>Via Roles</div>
                   <div className={clsx(s.headerCell, s.fixed)}>Direct</div>
+                  <div className={clsx(s.headerCell, s.fixed)}>Scopes</div>
                   <div className={clsx(s.headerCell, s.fixed)}>Action</div>
                 </div>
               </div>
@@ -393,6 +415,29 @@ const MemberEditPage = () => {
                       </div>
                       <div className={clsx(s.bodyCell, s.fixed)}>
                         <PermissionStatusCell viaRoles={perm.viaRoles} isDirect={perm.isDirect} variant="badges" />
+                      </div>
+                      <div className={clsx(s.bodyCell, s.fixed)}>
+                        <div className={s.scopesCell}>
+                          {perm.scopes?.length > 0 ? (
+                            perm.scopes.map((scope) => (
+                              <span key={scope} className={s.scopeTag}>{scope}</span>
+                            ))
+                          ) : (
+                            <span className={s.scopeEmpty}>--</span>
+                          )}
+                          {perm.isDirect && (
+                            <button
+                              type="button"
+                              onClick={() => setEditScopesPerm(perm)}
+                              className={s.scopeEditButton}
+                              title="Edit scopes"
+                            >
+                              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                              </svg>
+                            </button>
+                          )}
+                        </div>
                       </div>
                       <div className={clsx(s.bodyCell, s.fixed)}>
                         {perm.isDirect ? (
@@ -490,6 +535,18 @@ const MemberEditPage = () => {
             title="Cannot Delete Permission"
             message={`This permission is inherited from the following role(s):`}
             items={infoPermission.viaRoles}
+          />
+        )}
+
+        {/* Edit Scopes Modal */}
+        {editScopesPerm && (
+          <EditScopesModal
+            isOpen={!!editScopesPerm}
+            onClose={() => setEditScopesPerm(null)}
+            onSave={handleSaveScopes}
+            title={`Edit Scopes for ${editScopesPerm.code}`}
+            currentScopes={editScopesPerm.scopes ?? []}
+            isLoading={updateMemberPermissionScopes.isPending}
           />
         )}
       </div>

--- a/apps/back-office/pages/access-control/members/styles.module.scss
+++ b/apps/back-office/pages/access-control/members/styles.module.scss
@@ -395,6 +395,52 @@
   }
 }
 
+// Scopes
+.scopesCell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.scopeTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #1e40af;
+  background: #dbeafe;
+  border-radius: 4px;
+  letter-spacing: 0.3px;
+}
+
+.scopeEmpty {
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.scopeEditButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  background: #fff;
+  color: #64748b;
+  cursor: pointer;
+  margin-left: 4px;
+  flex-shrink: 0;
+
+  &:hover {
+    background: #f1f5f9;
+    color: #334155;
+    border-color: #cbd5e1;
+  }
+}
+
 .deleteButtonMuted {
   display: flex;
   align-items: center;

--- a/apps/back-office/pages/access-control/roles/[code].tsx
+++ b/apps/back-office/pages/access-control/roles/[code].tsx
@@ -9,12 +9,14 @@ import { useAuth } from '../../../context/auth-context';
 import { useRbacRole } from '../../../hooks/access-control/useRbacRole';
 import { useAssignRole } from '../../../hooks/access-control/useAssignRole';
 import { useRevokeRole } from '../../../hooks/access-control/useRevokeRole';
+import { useUpdateRolePermissionScopes } from '../../../hooks/access-control/useUpdateRolePermissionScopes';
 
 import MemberCell from '../../../screens/access-control/components/MemberCell';
 import TeamCell from '../../../screens/access-control/components/TeamCell';
 import AddMemberModal from '../../../screens/access-control/components/AddMemberModal';
 import ConfirmDeleteModal from '../../../screens/access-control/components/ConfirmDeleteModal';
-import { MemberBasic } from '../../../screens/access-control/types';
+import EditScopesModal from '../../../screens/access-control/components/EditScopesModal';
+import { MemberBasic, PermissionBasic } from '../../../screens/access-control/types';
 
 import s from './styles.module.scss';
 
@@ -34,6 +36,7 @@ const RoleEditPage = () => {
   // Modal states
   const [showAddMemberModal, setShowAddMemberModal] = useState(false);
   const [confirmRemoveMember, setConfirmRemoveMember] = useState<MemberBasic | null>(null);
+  const [editScopesPerm, setEditScopesPerm] = useState<PermissionBasic | null>(null);
 
   // Fetch data
   const { data: roleData, isLoading: roleLoading } = useRbacRole({
@@ -47,6 +50,7 @@ const RoleEditPage = () => {
   // Mutations
   const assignRole = useAssignRole();
   const revokeRole = useRevokeRole();
+  const updateRolePermissionScopes = useUpdateRolePermissionScopes();
 
   // Redirects
   useEffect(() => {
@@ -97,6 +101,22 @@ const RoleEditPage = () => {
       setConfirmRemoveMember(null);
     } catch (error) {
       toast.error('Failed to remove member from role');
+    }
+  };
+
+  const handleSaveRoleScopes = async (scopes: string[]) => {
+    if (!editScopesPerm) return;
+    try {
+      await updateRolePermissionScopes.mutateAsync({
+        authToken,
+        roleCode: code as string,
+        permissionCode: editScopesPerm.code,
+        scopes,
+      });
+      toast.success(`Updated scopes for "${editScopesPerm.code}"`);
+      setEditScopesPerm(null);
+    } catch (error) {
+      toast.error('Failed to update scopes');
     }
   };
 
@@ -287,6 +307,7 @@ const RoleEditPage = () => {
                 <div className={s.tableRow}>
                   <div className={clsx(s.headerCell, s.permissionCode)}>Permission</div>
                   <div className={clsx(s.headerCell, s.flexible)}>Description</div>
+                  <div className={clsx(s.headerCell, s.fixed)}>Scopes</div>
                 </div>
               </div>
               <div className={s.tableBody}>
@@ -299,6 +320,27 @@ const RoleEditPage = () => {
                         <span className={s.codeText}>{permission.code}</span>
                       </div>
                       <div className={clsx(s.bodyCell, s.flexible)}>{permission.description || '-'}</div>
+                      <div className={clsx(s.bodyCell, s.fixed)}>
+                        <div className={s.scopesCell}>
+                          {permission.scopes?.length ? (
+                            permission.scopes.map((scope) => (
+                              <span key={scope} className={s.scopeTag}>{scope}</span>
+                            ))
+                          ) : (
+                            <span className={s.scopeEmpty}>--</span>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => setEditScopesPerm(permission)}
+                            className={s.scopeEditButton}
+                            title="Edit scopes"
+                          >
+                            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
                     </div>
                   ))
                 )}
@@ -326,6 +368,18 @@ const RoleEditPage = () => {
             title="Remove Member from Role"
             message={`Are you sure you want to remove "${confirmRemoveMember.name}" from the role "${roleData?.name}"?`}
             isLoading={revokeRole.isPending}
+          />
+        )}
+
+        {/* Edit Scopes Modal */}
+        {editScopesPerm && (
+          <EditScopesModal
+            isOpen={!!editScopesPerm}
+            onClose={() => setEditScopesPerm(null)}
+            onSave={handleSaveRoleScopes}
+            title={`Edit Scopes for ${editScopesPerm.code}`}
+            currentScopes={editScopesPerm.scopes ?? []}
+            isLoading={updateRolePermissionScopes.isPending}
           />
         )}
       </div>

--- a/apps/back-office/pages/access-control/roles/styles.module.scss
+++ b/apps/back-office/pages/access-control/roles/styles.module.scss
@@ -298,6 +298,52 @@
   color: #0f172a;
 }
 
+// Scopes
+.scopesCell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.scopeTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #1e40af;
+  background: #dbeafe;
+  border-radius: 4px;
+  letter-spacing: 0.3px;
+}
+
+.scopeEmpty {
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.scopeEditButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  background: #fff;
+  color: #64748b;
+  cursor: pointer;
+  margin-left: 4px;
+  flex-shrink: 0;
+
+  &:hover {
+    background: #f1f5f9;
+    color: #334155;
+    border-color: #cbd5e1;
+  }
+}
+
 .removeButton {
   display: inline-flex;
   align-items: center;

--- a/apps/back-office/screens/access-control/components/AddPermissionModal.tsx
+++ b/apps/back-office/screens/access-control/components/AddPermissionModal.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Modal from '../../../components/modal/modal';
 import clsx from 'clsx';
-import { PermissionBasic } from '../types';
+import { PermissionBasic, AVAILABLE_SCOPES } from '../types';
 import { AccessControlSelect } from './AccessControlSelect';
 
 interface AddPermissionModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAdd: (permission: PermissionBasic) => void;
+  onAdd: (permission: PermissionBasic, scopes: string[]) => void;
   title: string;
   permissions: PermissionBasic[];
   isLoading?: boolean;
@@ -22,24 +22,42 @@ export const AddPermissionModal: React.FC<AddPermissionModalProps> = ({
   isLoading = false,
 }) => {
   const [selectedCode, setSelectedCode] = useState('');
+  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    if (!isOpen) setSelectedCode('');
+    if (!isOpen) {
+      setSelectedCode('');
+      setSelectedScopes(new Set());
+    }
   }, [isOpen]);
 
   const selectedPermission = permissions.find((p) => p.code === selectedCode) ?? null;
   const submitDisabled = isLoading || !selectedPermission;
 
+  const toggleScope = (scope: string) => {
+    setSelectedScopes((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) {
+        next.delete(scope);
+      } else {
+        next.add(scope);
+      }
+      return next;
+    });
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!selectedPermission) return;
-    onAdd(selectedPermission);
+    onAdd(selectedPermission, [...selectedScopes].sort());
     setSelectedCode('');
+    setSelectedScopes(new Set());
     onClose();
   };
 
   const handleClose = () => {
     setSelectedCode('');
+    setSelectedScopes(new Set());
     onClose();
   };
 
@@ -81,6 +99,33 @@ export const AddPermissionModal: React.FC<AddPermissionModalProps> = ({
             />
             {permissions.length === 0 && (
               <p className="text-sm text-gray-500">This member already has every permission granted directly.</p>
+            )}
+
+            {selectedPermission && (
+              <div className="mt-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">Scopes (optional)</label>
+                <div className="flex gap-3">
+                  {AVAILABLE_SCOPES.map((scope) => (
+                    <label
+                      key={scope}
+                      className={clsx(
+                        'flex items-center gap-2 rounded-lg border px-3 py-2 cursor-pointer transition-colors text-sm',
+                        selectedScopes.has(scope)
+                          ? 'border-blue-300 bg-blue-50'
+                          : 'border-gray-200 hover:border-gray-300'
+                      )}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedScopes.has(scope)}
+                        onChange={() => toggleScope(scope)}
+                        className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                      />
+                      {scope}
+                    </label>
+                  ))}
+                </div>
+              </div>
             )}
           </form>
         </div>

--- a/apps/back-office/screens/access-control/components/EditScopesModal.tsx
+++ b/apps/back-office/screens/access-control/components/EditScopesModal.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import Modal from '../../../components/modal/modal';
+import clsx from 'clsx';
+import { AVAILABLE_SCOPES } from '../types';
+
+interface EditScopesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (scopes: string[]) => void;
+  title: string;
+  currentScopes: string[];
+  isLoading?: boolean;
+}
+
+export const EditScopesModal: React.FC<EditScopesModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  title,
+  currentScopes,
+  isLoading = false,
+}) => {
+  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set(currentScopes));
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedScopes(new Set(currentScopes));
+    }
+  }, [isOpen, currentScopes]);
+
+  const toggleScope = (scope: string) => {
+    setSelectedScopes((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) {
+        next.delete(scope);
+      } else {
+        next.add(scope);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave([...selectedScopes].sort());
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="w-full min-w-[400px] max-w-lg rounded-lg bg-white shadow-xl">
+        <div className="border-b border-gray-200 px-6 py-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+            <button type="button" onClick={onClose} className="text-gray-400 transition-colors hover:text-gray-600">
+              <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div className="px-6 py-6">
+          <form id="edit-scopes-form" onSubmit={handleSubmit} className="space-y-3">
+            <p className="text-sm text-gray-500 mb-4">
+              Select which scopes this permission should have access to:
+            </p>
+            {AVAILABLE_SCOPES.map((scope) => (
+              <label
+                key={scope}
+                className={clsx(
+                  'flex items-center gap-3 rounded-lg border p-3 cursor-pointer transition-colors',
+                  selectedScopes.has(scope)
+                    ? 'border-blue-300 bg-blue-50'
+                    : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                )}
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedScopes.has(scope)}
+                  onChange={() => toggleScope(scope)}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="text-sm font-medium text-gray-900">{scope}</span>
+              </label>
+            ))}
+          </form>
+        </div>
+
+        <div className="rounded-b-lg border-t border-gray-200 bg-gray-50 px-6 py-4">
+          <div className="flex justify-end space-x-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              form="edit-scopes-form"
+              disabled={isLoading}
+              className={clsx(
+                'inline-flex items-center rounded-lg border border-transparent px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+                isLoading ? 'cursor-not-allowed bg-gray-400' : 'bg-blue-600 hover:bg-blue-700'
+              )}
+            >
+              {isLoading ? 'Saving...' : 'Save Scopes'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default EditScopesModal;

--- a/apps/back-office/screens/access-control/types.ts
+++ b/apps/back-office/screens/access-control/types.ts
@@ -24,7 +24,11 @@ export interface PermissionBasic {
   uid: string;
   code: string;
   description?: string | null;
+  scopes?: string[];
 }
+
+// Keep in sync with apps/web-api/src/rbac/rbac.constants.ts RBAC_SCOPES
+export const AVAILABLE_SCOPES = ['PLVS', 'PLCC'] as const;
 
 export interface MemberWithRoles extends MemberBasic {
   projectContributions: TeamInfo[];
@@ -71,7 +75,7 @@ export interface MemberAccessDetails {
   };
   roles: Array<RoleBasic & { permissions: PermissionBasic[] }>;
   directPermissions: PermissionBasic[];
-  allPermissions: Array<PermissionBasic & { viaRoles: string[]; isDirect: boolean }>;
+  allPermissions: Array<PermissionBasic & { viaRoles: string[]; isDirect: boolean; scopes: string[] }>;
 }
 
 export interface PaginationInfo {

--- a/apps/web-api/prisma/fixtures/articles.ts
+++ b/apps/web-api/prisma/fixtures/articles.ts
@@ -40,6 +40,7 @@ Talk to a qualified startup attorney before making this decision. The cost of re
       authorMemberUid: author.uid,
       authorTeamUid: null,
       status: ArticleStatus.PUBLISHED,
+      scope: 'PLVS',
       publishedAt: new Date('2026-01-15T10:00:00.000Z'),
     },
     {
@@ -68,6 +69,7 @@ Keep your cap table updated after every transaction — SAFEs, options grants, a
       authorMemberUid: null,
       authorTeamUid: team?.uid ?? null,
       status: ArticleStatus.PUBLISHED,
+      scope: 'PLCC',
       publishedAt: new Date('2026-01-22T10:00:00.000Z'),
     },
     {
@@ -116,6 +118,7 @@ The best fundraising advice: build something people want, and the money will fol
       authorMemberUid: author.uid,
       authorTeamUid: null,
       status: ArticleStatus.PUBLISHED,
+      scope: null,
       publishedAt: new Date('2026-03-01T10:00:00.000Z'),
     },
     {
@@ -139,6 +142,7 @@ Check back soon for the full guide.`,
       authorMemberUid: author.uid,
       authorTeamUid: null,
       status: ArticleStatus.DRAFT,
+      scope: 'PLVS',
       publishedAt: null,
     },
     {
@@ -163,6 +167,7 @@ Draft notes: Most Series A rounds in 2026 require $1-2M ARR with 15-20% month-ov
       authorMemberUid: null,
       authorTeamUid: team?.uid ?? null,
       status: ArticleStatus.DRAFT,
+      scope: null,
       publishedAt: null,
     },
   ];

--- a/apps/web-api/prisma/migrations/20260408120000_add_permission_scopes/migration.sql
+++ b/apps/web-api/prisma/migrations/20260408120000_add_permission_scopes/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "RolePermission" ADD COLUMN "scopes" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+-- AlterTable
+ALTER TABLE "MemberPermission" ADD COLUMN "scopes" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+-- AlterTable
+ALTER TABLE "Article" ADD COLUMN "scope" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Article_scope_idx" ON "Article"("scope");

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -1639,6 +1639,7 @@ model Article {
   createdBy       String?
   updatedBy       String?
   status          ArticleStatus      @default(DRAFT)
+  scope           String?
   publishedAt     DateTime?
   isDeleted       Boolean            @default(false)
   deletedAt       DateTime?
@@ -1654,6 +1655,7 @@ model Article {
   @@index([isDeleted])
   @@index([createdBy])
   @@index([updatedBy])
+  @@index([scope])
 }
 
 model ArticleStatistic {
@@ -1707,6 +1709,7 @@ model Permission {
 model RolePermission {
   roleUid       String
   permissionUid String
+  scopes        String[] @default([])
   createdAt     DateTime @default(now())
 
   role       Role       @relation(fields: [roleUid], references: [uid], onDelete: Restrict, onUpdate: Cascade)
@@ -1743,6 +1746,7 @@ model MemberPermission {
   grantedByMemberUid String?
   revokedAt          DateTime?
   status             String    @default("ACTIVE")
+  scopes             String[]  @default([])
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
 

--- a/apps/web-api/src/articles/articles.dto.ts
+++ b/apps/web-api/src/articles/articles.dto.ts
@@ -23,6 +23,7 @@ export class CreateArticleDto {
   authorMemberUid?: string;
   authorTeamUid?: string;
   status?: ArticleStatus;
+  scope?: string | null;
   officeHours?: string | null;
 }
 
@@ -37,6 +38,7 @@ export class UpdateArticleDto {
   authorMemberUid?: string;
   authorTeamUid?: string;
   status?: ArticleStatus;
+  scope?: string | null;
   officeHours?: string | null;
 }
 

--- a/apps/web-api/src/articles/articles.service.ts
+++ b/apps/web-api/src/articles/articles.service.ts
@@ -5,10 +5,15 @@ import { CreateArticleDto, ListArticlesQueryDto, UpdateArticleDto } from './arti
 import type { ArticleCategory } from './articles.constants';
 import { ARTICLE_CATEGORY_DESCRIPTIONS, WORDS_PER_MINUTE } from './articles.constants';
 import { MemberRole } from "../utils/constants";
+import { RbacService } from '../rbac/rbac.service';
+import { RBAC_PERMISSION_CODES, AVAILABLE_SCOPES } from '../rbac/rbac.constants';
 
 @Injectable()
 export class ArticlesService {
-  constructor(private readonly prisma: PrismaService) { }
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly rbacService: RbacService,
+  ) { }
 
   // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -74,6 +79,32 @@ export class ArticlesService {
     }
 
     return article;
+  }
+
+  private validateArticleScope(scope: string | null | undefined): void {
+    if (scope && !AVAILABLE_SCOPES.includes(scope as any)) {
+      throw new BadRequestException(`Invalid article scope: ${scope}. Allowed: ${AVAILABLE_SCOPES.join(', ')}`);
+    }
+  }
+
+  private async resolveUserScopes(userEmail?: string): Promise<string[]> {
+    if (!userEmail) return [];
+    try {
+      const member = await this.rbacService.findMemberByEmail(userEmail);
+      if (!member) return [];
+      return this.rbacService.getScopesForPermission(member.uid, RBAC_PERMISSION_CODES.FOUNDER_GUIDES_VIEW);
+    } catch {
+      return [];
+    }
+  }
+
+  private buildScopeFilter(userScopes: string[]): Prisma.ArticleWhereInput {
+    return {
+      OR: [
+        { scope: null },
+        ...(userScopes.length > 0 ? [{ scope: { in: userScopes } }] : []),
+      ],
+    };
   }
 
   private buildArticleWhere(query: ListArticlesQueryDto, status?: ArticleStatus): Prisma.ArticleWhereInput {
@@ -160,7 +191,11 @@ export class ArticlesService {
     const limit = Number(query.limit) || 20;
     const skip = (page - 1) * limit;
 
-    const where = this.buildArticleWhere(query, ArticleStatus.PUBLISHED);
+    const userScopes = await this.resolveUserScopes(userEmail);
+    const where: Prisma.ArticleWhereInput = {
+      ...this.buildArticleWhere(query, ArticleStatus.PUBLISHED),
+      ...this.buildScopeFilter(userScopes),
+    };
 
     let orderBy: Prisma.ArticleOrderByWithRelationInput;
     switch (query.sort) {
@@ -266,6 +301,14 @@ export class ArticlesService {
       throw new NotFoundException('Article not found');
     }
 
+    // Scope check: if the article has a scope, verify user has access (authors bypass)
+    if (article.scope && !isAuthor) {
+      const userScopes = await this.resolveUserScopes(userEmail);
+      if (!userScopes.includes(article.scope)) {
+        throw new ForbiddenException('You do not have access to this article');
+      }
+    }
+
     // Aggregate stats
     const [viewAgg, likeCount, userStat] = await Promise.all([
       this.prisma.articleStatistic.aggregate({
@@ -337,6 +380,19 @@ export class ArticlesService {
     };
   }
 
+  private async assertArticleScopeAccess(articleUid: string, userEmail: string): Promise<void> {
+    const article = await this.prisma.article.findFirst({
+      where: { uid: articleUid, isDeleted: false },
+      select: { scope: true },
+    });
+    if (article?.scope) {
+      const userScopes = await this.resolveUserScopes(userEmail);
+      if (!userScopes.includes(article.scope)) {
+        throw new ForbiddenException('You do not have access to this article');
+      }
+    }
+  }
+
   async likeArticle(userEmail: string, articleUid: string) {
     const { memberUid } = await this.resolveMemberByEmail(userEmail);
 
@@ -349,6 +405,8 @@ export class ArticlesService {
       throw new NotFoundException('Article not found');
     }
 
+    await this.assertArticleScopeAccess(articleUid, userEmail);
+
     return this.prisma.articleStatistic.upsert({
       where: { articleUid_memberUid: { articleUid, memberUid } },
       update: { likeCount: 1 },
@@ -358,6 +416,8 @@ export class ArticlesService {
 
   async unlikeArticle(userEmail: string, articleUid: string) {
     const { memberUid } = await this.resolveMemberByEmail(userEmail);
+
+    await this.assertArticleScopeAccess(articleUid, userEmail);
 
     const stat = await this.prisma.articleStatistic.findUnique({
       where: { articleUid_memberUid: { articleUid, memberUid } },
@@ -384,6 +444,8 @@ export class ArticlesService {
     if (!article) {
       throw new NotFoundException('Article not found');
     }
+
+    await this.assertArticleScopeAccess(articleUid, userEmail);
 
     return this.prisma.articleStatistic.upsert({
       where: { articleUid_memberUid: { articleUid, memberUid } },
@@ -434,6 +496,7 @@ export class ArticlesService {
   }
 
   async createArticle(body: CreateArticleDto, userEmail?: string) {
+    this.validateArticleScope(body.scope);
     if (body.authorMemberUid && body.authorTeamUid) {
       throw new BadRequestException('Provide either authorMemberUid or authorTeamUid, not both');
     }
@@ -480,6 +543,7 @@ export class ArticlesService {
           createdBy,
           updatedBy: createdBy,
           status,
+          scope: body.scope ?? null,
           publishedAt: status === ArticleStatus.PUBLISHED ? new Date() : null,
         },
         include: this.articleInclude,
@@ -488,6 +552,7 @@ export class ArticlesService {
   }
 
   async updateOwnArticle(userEmail: string, uid: string, body: UpdateArticleDto) {
+    if (body.scope !== undefined) this.validateArticleScope(body.scope);
     const { memberUid, teamUid, isDirectoryAdmin } = await this.resolveMemberByEmail(userEmail);
     await this.ensureArticleOwnership(uid, memberUid, teamUid, isDirectoryAdmin);
 
@@ -508,6 +573,7 @@ export class ArticlesService {
       data.readingTime = this.calculateReadingTime(body.content);
     }
     if (body.coverImageUid !== undefined) data.coverImageUid = body.coverImageUid;
+    if (body.scope !== undefined) data.scope = body.scope;
     if (body.status !== undefined) {
       data.status = body.status;
       if (body.status === ArticleStatus.PUBLISHED && existing.status !== ArticleStatus.PUBLISHED) {
@@ -543,6 +609,8 @@ export class ArticlesService {
     const limit = Number(query.limit) || 20;
     const skip = (page - 1) * limit;
 
+    // My articles only shows user's own articles -- no scope restriction needed
+    // (authors always see their own articles regardless of scope)
     const where: Prisma.ArticleWhereInput = {
       isDeleted: false,
       OR: [{ authorMemberUid: memberUid }, ...(teamUid ? [{ authorTeamUid: teamUid }] : [])],
@@ -650,6 +718,7 @@ export class ArticlesService {
   }
 
   async adminCreate(body: CreateArticleDto, userEmail?: string) {
+    this.validateArticleScope(body.scope);
     const slugURL = body.slugURL || (await this.generateSlug(body.title));
     const readingTime = this.calculateReadingTime(body.content);
     const status = body.status ?? ArticleStatus.DRAFT;
@@ -689,6 +758,7 @@ export class ArticlesService {
           createdBy,
           updatedBy: createdBy,
           status,
+          scope: body.scope ?? null,
           publishedAt: status === ArticleStatus.PUBLISHED ? new Date() : null,
         },
         include: this.articleInclude,
@@ -697,6 +767,7 @@ export class ArticlesService {
   }
 
   async adminUpdate(uid: string, body: UpdateArticleDto, userEmail?: string) {
+    if (body.scope !== undefined) this.validateArticleScope(body.scope);
     const existing = await this.prisma.article.findUnique({ where: { uid } });
 
     if (!existing) {
@@ -717,6 +788,7 @@ export class ArticlesService {
     if (body.coverImageUid !== undefined) data.coverImageUid = body.coverImageUid;
     if (body.authorMemberUid !== undefined) data.authorMemberUid = body.authorMemberUid;
     if (body.authorTeamUid !== undefined) data.authorTeamUid = body.authorTeamUid;
+    if (body.scope !== undefined) data.scope = body.scope;
     if (body.status !== undefined) {
       data.status = body.status;
       if (body.status === ArticleStatus.PUBLISHED && existing.status !== ArticleStatus.PUBLISHED) {

--- a/apps/web-api/src/rbac/admin-rbac.controller.ts
+++ b/apps/web-api/src/rbac/admin-rbac.controller.ts
@@ -4,6 +4,7 @@ import { AssignRoleDto } from './dto/assign-role.dto';
 import { GrantPermissionDto } from './dto/grant-permission.dto';
 import { RevokePermissionDto } from './dto/revoke-permission.dto';
 import { RevokeRoleDto } from './dto/revoke-role.dto';
+import { UpdateMemberPermissionScopesDto, UpdateRolePermissionScopesDto } from './dto/update-scopes.dto';
 import { RbacService } from './rbac.service';
 import { NoCache } from '../decorators/no-cache.decorator';
 
@@ -98,11 +99,21 @@ export class AdminRbacController {
 
   @Post('permissions/grant')
   async grantPermission(@Body() body: GrantPermissionDto) {
-    return this.rbacService.grantPermission(body.memberUid, body.permissionCode, body.grantedByMemberUid);
+    return this.rbacService.grantPermission(body.memberUid, body.permissionCode, body.grantedByMemberUid, body.scopes);
   }
 
   @Post('permissions/revoke')
   async revokePermission(@Body() body: RevokePermissionDto) {
     return this.rbacService.revokePermission(body.memberUid, body.permissionCode);
+  }
+
+  @Post('permissions/scopes')
+  async updateMemberPermissionScopes(@Body() body: UpdateMemberPermissionScopesDto) {
+    return this.rbacService.updateMemberPermissionScopes(body.memberUid, body.permissionCode, body.scopes);
+  }
+
+  @Post('roles/permission-scopes')
+  async updateRolePermissionScopes(@Body() body: UpdateRolePermissionScopesDto) {
+    return this.rbacService.updateRolePermissionScopes(body.roleCode, body.permissionCode, body.scopes);
   }
 }

--- a/apps/web-api/src/rbac/dto/grant-permission.dto.ts
+++ b/apps/web-api/src/rbac/dto/grant-permission.dto.ts
@@ -4,4 +4,6 @@ export class GrantPermissionDto {
   permissionCode: string;
 
   grantedByMemberUid?: string;
+
+  scopes?: string[];
 }

--- a/apps/web-api/src/rbac/dto/update-scopes.dto.ts
+++ b/apps/web-api/src/rbac/dto/update-scopes.dto.ts
@@ -1,0 +1,11 @@
+export class UpdateMemberPermissionScopesDto {
+  memberUid: string;
+  permissionCode: string;
+  scopes: string[];
+}
+
+export class UpdateRolePermissionScopesDto {
+  roleCode: string;
+  permissionCode: string;
+  scopes: string[];
+}

--- a/apps/web-api/src/rbac/rbac.constants.ts
+++ b/apps/web-api/src/rbac/rbac.constants.ts
@@ -7,3 +7,10 @@ export const RBAC_PERMISSION_CODES = {
   FOUNDER_GUIDES_VIEW: 'founder_guides.view',
   FOUNDER_GUIDES_CREATE: 'founder_guides.create',
 } as const;
+
+export const RBAC_SCOPES = {
+  PLVS: 'PLVS',
+  PLCC: 'PLCC',
+} as const;
+
+export const AVAILABLE_SCOPES = Object.values(RBAC_SCOPES);

--- a/apps/web-api/src/rbac/rbac.service.ts
+++ b/apps/web-api/src/rbac/rbac.service.ts
@@ -1,14 +1,23 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from "../shared/prisma.service";
 import { CurrentUserAccessDto } from './rbac.types';
+import { AVAILABLE_SCOPES } from './rbac.constants';
 
 @Injectable()
 export class RbacService {
   constructor(private readonly prisma: PrismaService) {}
+
+  private validateScopes(scopes: string[]): void {
+    const invalid = scopes.filter((s) => !AVAILABLE_SCOPES.includes(s as any));
+    if (invalid.length > 0) {
+      throw new BadRequestException(`Invalid scope(s): ${invalid.join(', ')}. Allowed: ${AVAILABLE_SCOPES.join(', ')}`);
+    }
+  }
 
   async getAccessForMember(memberUid: string): Promise<CurrentUserAccessDto> {
     const [roleAssignments, directPermissions] = await Promise.all([
@@ -44,20 +53,36 @@ export class RbacService {
 
     const roleCodes = [...new Set(roleAssignments.map((x) => x.role.code))];
 
-    const permissionCodes = new Set<string>();
+    const permissionScopesMap = new Map<string, Set<string>>();
     for (const ra of roleAssignments) {
       for (const rp of ra.role.rolePermissions) {
-        permissionCodes.add(rp.permission.code);
+        const code = rp.permission.code;
+        if (!permissionScopesMap.has(code)) {
+          permissionScopesMap.set(code, new Set());
+        }
+        for (const s of rp.scopes) {
+          permissionScopesMap.get(code)!.add(s);
+        }
       }
     }
     for (const mp of directPermissions) {
-      permissionCodes.add(mp.permission.code);
+      const code = mp.permission.code;
+      if (!permissionScopesMap.has(code)) {
+        permissionScopesMap.set(code, new Set());
+      }
+      for (const s of mp.scopes) {
+        permissionScopesMap.get(code)!.add(s);
+      }
     }
+
+    const permissions = [...permissionScopesMap.entries()]
+      .map(([name, scopes]) => ({ name, scopes: [...scopes].sort() }))
+      .sort((a, b) => a.name.localeCompare(b.name));
 
     return {
       memberUid,
       roles: roleCodes.sort(),
-      permissions: [...permissionCodes].sort(),
+      permissions,
     };
   }
 
@@ -172,7 +197,9 @@ export class RbacService {
     });
   }
 
-  async grantPermission(memberUid: string, permissionCode: string, grantedByMemberUid?: string) {
+  async grantPermission(memberUid: string, permissionCode: string, grantedByMemberUid?: string, scopes?: string[]) {
+    if (scopes?.length) this.validateScopes(scopes);
+
     const permission = await this.prisma.permission.findUnique({
       where: { code: permissionCode },
     });
@@ -201,6 +228,7 @@ export class RbacService {
         permissionUid: permission.uid,
         grantedByMemberUid: grantedByMemberUid ?? null,
         status: 'ACTIVE',
+        scopes: scopes ?? [],
       },
     });
   }
@@ -225,6 +253,106 @@ export class RbacService {
         status: 'REVOKED',
         revokedAt: new Date(),
       },
+    });
+  }
+
+  async getScopesForPermission(memberUid: string, permissionCode: string): Promise<string[]> {
+    const [roleAssignments, directPermissions] = await Promise.all([
+      this.prisma.roleAssignment.findMany({
+        where: {
+          memberUid,
+          status: 'ACTIVE',
+          revokedAt: null,
+          role: {
+            rolePermissions: {
+              some: {
+                permission: { code: permissionCode },
+              },
+            },
+          },
+        },
+        include: {
+          role: {
+            include: {
+              rolePermissions: {
+                where: { permission: { code: permissionCode } },
+              },
+            },
+          },
+        },
+      }),
+      this.prisma.memberPermission.findMany({
+        where: {
+          memberUid,
+          status: 'ACTIVE',
+          revokedAt: null,
+          permission: { code: permissionCode },
+        },
+      }),
+    ]);
+
+    const allScopes = new Set<string>();
+    for (const ra of roleAssignments) {
+      for (const rp of ra.role.rolePermissions) {
+        for (const s of rp.scopes) allScopes.add(s);
+      }
+    }
+    for (const mp of directPermissions) {
+      for (const s of mp.scopes) allScopes.add(s);
+    }
+
+    return [...allScopes].sort();
+  }
+
+  async updateMemberPermissionScopes(memberUid: string, permissionCode: string, scopes: string[]) {
+    this.validateScopes(scopes);
+
+    const permission = await this.prisma.permission.findUnique({
+      where: { code: permissionCode },
+    });
+
+    if (!permission) {
+      throw new NotFoundException(`Permission not found: ${permissionCode}`);
+    }
+
+    const result = await this.prisma.memberPermission.updateMany({
+      where: {
+        memberUid,
+        permissionUid: permission.uid,
+        status: 'ACTIVE',
+        revokedAt: null,
+      },
+      data: { scopes },
+    });
+
+    if (result.count === 0) {
+      throw new NotFoundException(`Active permission grant not found for member`);
+    }
+
+    return { updated: result.count };
+  }
+
+  async updateRolePermissionScopes(roleCode: string, permissionCode: string, scopes: string[]) {
+    this.validateScopes(scopes);
+
+    const role = await this.prisma.role.findUnique({ where: { code: roleCode } });
+    if (!role) {
+      throw new NotFoundException(`Role not found: ${roleCode}`);
+    }
+
+    const permission = await this.prisma.permission.findUnique({ where: { code: permissionCode } });
+    if (!permission) {
+      throw new NotFoundException(`Permission not found: ${permissionCode}`);
+    }
+
+    return this.prisma.rolePermission.update({
+      where: {
+        roleUid_permissionUid: {
+          roleUid: role.uid,
+          permissionUid: permission.uid,
+        },
+      },
+      data: { scopes },
     });
   }
 
@@ -300,6 +428,7 @@ export class RbacService {
         uid: rp.permission.uid,
         code: rp.permission.code,
         description: rp.permission.description,
+        scopes: rp.scopes,
       })),
     }));
 
@@ -308,10 +437,11 @@ export class RbacService {
       uid: mp.permission.uid,
       code: mp.permission.code,
       description: mp.permission.description,
+      scopes: mp.scopes,
     }));
 
     // Build all permissions with source info
-    const permissionMap = new Map<string, { permission: any; viaRoles: string[]; isDirect: boolean }>();
+    const permissionMap = new Map<string, { permission: any; viaRoles: string[]; isDirect: boolean; scopes: Set<string> }>();
 
     // Add role-based permissions
     for (const role of roles) {
@@ -319,11 +449,13 @@ export class RbacService {
         const existing = permissionMap.get(perm.code);
         if (existing) {
           existing.viaRoles.push(role.name);
+          for (const s of perm.scopes) existing.scopes.add(s);
         } else {
           permissionMap.set(perm.code, {
             permission: perm,
             viaRoles: [role.name],
             isDirect: false,
+            scopes: new Set(perm.scopes),
           });
         }
       }
@@ -334,11 +466,13 @@ export class RbacService {
       const existing = permissionMap.get(perm.code);
       if (existing) {
         existing.isDirect = true;
+        for (const s of perm.scopes) existing.scopes.add(s);
       } else {
         permissionMap.set(perm.code, {
           permission: perm,
           viaRoles: [],
           isDirect: true,
+          scopes: new Set(perm.scopes),
         });
       }
     }
@@ -357,6 +491,7 @@ export class RbacService {
         ...p.permission,
         viaRoles: p.viaRoles,
         isDirect: p.isDirect,
+        scopes: [...p.scopes].sort(),
       })),
     };
   }
@@ -569,6 +704,7 @@ export class RbacService {
         uid: rp.permission.uid,
         code: rp.permission.code,
         description: rp.permission.description,
+        scopes: rp.scopes,
       })),
     }));
   }
@@ -654,6 +790,7 @@ export class RbacService {
         uid: rp.permission.uid,
         code: rp.permission.code,
         description: rp.permission.description,
+        scopes: rp.scopes,
       })),
       members: assignments.map((ra: any) => ({
         uid: ra.member.uid,
@@ -753,6 +890,7 @@ export class RbacService {
         code: rp.role.code,
         name: rp.role.name,
         memberCount: roleMemberCountMap.get(rp.role.uid) || 0,
+        scopes: rp.scopes,
       }));
 
       // Get unique members with direct permission
@@ -828,6 +966,7 @@ export class RbacService {
           name: rp.role.name,
           description: rp.role.description,
           memberCount,
+          scopes: rp.scopes,
         };
       })
     );

--- a/apps/web-api/src/rbac/rbac.types.ts
+++ b/apps/web-api/src/rbac/rbac.types.ts
@@ -1,5 +1,10 @@
+export type PermissionWithScopes = {
+  name: string;
+  scopes: string[];
+};
+
 export type CurrentUserAccessDto = {
   memberUid: string;
   roles: string[];
-  permissions: string[];
+  permissions: PermissionWithScopes[];
 };


### PR DESCRIPTION
## Description

Extends the existing RBAC system with permission scopes — a fine-grained access layer that controls which articles users can see based on their assigned scopes (e.g., PLVS, PLCC). Articles with scope = null remain visible to all users with the base permission.


## Back Office
* Add scopes to permissions
<img width="490" height="371" alt="Screenshot 2026-04-08 at 7 05 51 PM" src="https://github.com/user-attachments/assets/a2c5dd89-a7c2-4fbf-883d-8cdf13914c3e" />

* Add/Edit/View scoped for a member
<img width="1432" height="503" alt="Screenshot 2026-04-08 at 6 07 53 PM" src="https://github.com/user-attachments/assets/4f049ae8-24ce-47e8-9991-81257c02d6d7" />

## Dependencies
Goes with https://github.com/memser-spaceport/pln-directory-portal-v2/pull/2295

## Tickets

[LAB-1675](https://linear.app/plrs-labos/issue/LAB-1675/founder-guides-rbac-implement-permission-scopes-plvsplcc)

