### PR TITLE
feat: add scope to direct permissions

### DIFF
--- a/apps/back-office/pages/access-control/permissions/[code].tsx
+++ b/apps/back-office/pages/access-control/permissions/[code].tsx
@@ -9,11 +9,13 @@ import { useAuth } from '../../../context/auth-context';
 import { useRbacPermission } from '../../../hooks/access-control/useRbacPermission';
 import { useGrantPermission } from '../../../hooks/access-control/useGrantPermission';
 import { useRevokePermission } from '../../../hooks/access-control/useRevokePermission';
+import { useUpdateMemberPermissionScopes } from '../../../hooks/access-control/useUpdateMemberPermissionScopes';
 
 import MemberCell from '../../../screens/access-control/components/MemberCell';
 import TeamCell from '../../../screens/access-control/components/TeamCell';
 import PermissionStatusCell from '../../../screens/access-control/components/PermissionStatusCell';
 import AddMemberModal from '../../../screens/access-control/components/AddMemberModal';
+import EditScopesModal from '../../../screens/access-control/components/EditScopesModal';
 import ConfirmDeleteModal from '../../../screens/access-control/components/ConfirmDeleteModal';
 import InfoModal from '../../../screens/access-control/components/InfoModal';
 import { MemberBasic, TeamInfo } from '../../../screens/access-control/types';
@@ -23,7 +25,7 @@ import s from './styles.module.scss';
 type Tab = 'roles' | 'members';
 type MemberFilter = 'all' | 'direct' | 'viaRoles';
 
-type PermissionMemberRow = MemberBasic & { viaRoles: string[]; isDirect: boolean; projectContributions: TeamInfo[] };
+type PermissionMemberRow = MemberBasic & { viaRoles: string[]; isDirect: boolean; projectContributions: TeamInfo[]; scopes: string[] };
 
 const REMOVE_DIRECT_AND_ROLE_WARNING =
   'This member also has this permission through assigned role(s). Removing the direct grant will not remove access from those roles—the member will still have this permission until you change or remove those role assignments.';
@@ -45,6 +47,7 @@ const PermissionEditPage = () => {
   const [confirmRemoveMember, setConfirmRemoveMember] = useState<PermissionMemberRow | null>(null);
   const [removePermissionWarningNote, setRemovePermissionWarningNote] = useState<string | null>(null);
   const [infoMember, setInfoMember] = useState<PermissionMemberRow | null>(null);
+  const [editScopesMember, setEditScopesMember] = useState<PermissionMemberRow | null>(null);
 
   // Fetch data
   const { data: permissionData, isLoading: permissionLoading } = useRbacPermission({
@@ -59,6 +62,7 @@ const PermissionEditPage = () => {
   // Mutations
   const grantPermission = useGrantPermission();
   const revokePermission = useRevokePermission();
+  const updateMemberPermissionScopes = useUpdateMemberPermissionScopes();
 
   // Redirects
   useEffect(() => {
@@ -98,13 +102,14 @@ const PermissionEditPage = () => {
     return []; // Will be populated by search
   }, [members]);
 
-  const handleAddMember = async (member: MemberBasic) => {
+  const handleAddMember = async (member: MemberBasic, scopes: string[]) => {
     try {
       await grantPermission.mutateAsync({
         authToken,
         memberUid: member.uid,
         permissionCode: code as string,
         grantedByMemberUid: user?.uid,
+        scopes,
       });
       toast.success(`Granted "${permission?.code}" to ${member.name}`);
       setShowAddMemberModal(false);
@@ -126,6 +131,22 @@ const PermissionEditPage = () => {
       setRemovePermissionWarningNote(null);
     } catch (error) {
       toast.error('Failed to revoke permission');
+    }
+  };
+
+  const handleSaveScopes = async (scopes: string[]) => {
+    if (!editScopesMember) return;
+    try {
+      await updateMemberPermissionScopes.mutateAsync({
+        authToken,
+        memberUid: editScopesMember.uid,
+        permissionCode: code as string,
+        scopes,
+      });
+      toast.success(`Updated scopes for "${editScopesMember.name}"`);
+      setEditScopesMember(null);
+    } catch (error) {
+      toast.error('Failed to update scopes');
     }
   };
 
@@ -262,6 +283,7 @@ const PermissionEditPage = () => {
                   <div className={clsx(s.headerCell, s.teamCell)}>Team</div>
                   <div className={clsx(s.headerCell, s.viaRolesCell)}>Via Roles</div>
                   <div className={clsx(s.headerCell, s.directCell)}>Direct</div>
+                  <div className={clsx(s.headerCell, s.scopesCol)}>Scopes</div>
                   <div className={clsx(s.headerCell, s.actionCell)}>Action</div>
                 </div>
               </div>
@@ -286,6 +308,29 @@ const PermissionEditPage = () => {
                       </div>
                       <div className={clsx(s.bodyCell, s.directCell)}>
                         <PermissionStatusCell viaRoles={member.viaRoles} isDirect={member.isDirect} variant="badges" />
+                      </div>
+                      <div className={clsx(s.bodyCell, s.scopesCol)}>
+                        <div className={s.scopesCell}>
+                          {member.scopes?.length > 0 ? (
+                            member.scopes.map((scope) => (
+                              <span key={scope} className={s.scopeTag}>{scope}</span>
+                            ))
+                          ) : (
+                            <span className={s.scopeEmpty}>--</span>
+                          )}
+                          {member.isDirect && (
+                            <button
+                              type="button"
+                              onClick={() => setEditScopesMember(member)}
+                              className={s.scopeEditButton}
+                              title="Edit scopes"
+                            >
+                              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                              </svg>
+                            </button>
+                          )}
+                        </div>
                       </div>
                       <div className={clsx(s.bodyCell, s.actionCell)}>
                         {member.isDirect ? (
@@ -392,10 +437,11 @@ const PermissionEditPage = () => {
         <AddMemberModal
           isOpen={showAddMemberModal}
           onClose={() => setShowAddMemberModal(false)}
-          onAdd={handleAddMember as any}
+          onAdd={handleAddMember}
           title={`Grant "${permission?.code}" to Member`}
           existingMemberUids={members.filter((m) => m.isDirect).map((m) => m.uid)}
           isLoading={grantPermission.isPending}
+          showScopes
         />
 
         {/* Confirm Remove Member Modal */}
@@ -419,6 +465,18 @@ const PermissionEditPage = () => {
             title="Cannot Remove Permission"
             message={`This member has this permission via the following role(s):`}
             items={infoMember.viaRoles}
+          />
+        )}
+
+        {/* Edit Scopes Modal */}
+        {editScopesMember && (
+          <EditScopesModal
+            isOpen={!!editScopesMember}
+            onClose={() => setEditScopesMember(null)}
+            onSave={handleSaveScopes}
+            title={`Edit Scopes for ${editScopesMember.name}`}
+            currentScopes={editScopesMember.scopes ?? []}
+            isLoading={updateMemberPermissionScopes.isPending}
           />
         )}
       </div>

--- a/apps/back-office/pages/access-control/permissions/styles.module.scss
+++ b/apps/back-office/pages/access-control/permissions/styles.module.scss
@@ -310,15 +310,65 @@
 }
 
 .viaRolesCell {
-  width: 400px;
+  width: 280px;
 }
 
 .directCell {
   width: 100px;
 }
 
+.scopesCol {
+  width: 160px;
+}
+
 .actionCell {
   width: 80px;
+}
+
+// Scopes
+.scopesCell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.scopeTag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #1e40af;
+  background: #dbeafe;
+  border-radius: 4px;
+  letter-spacing: 0.3px;
+}
+
+.scopeEmpty {
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.scopeEditButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  background: #fff;
+  color: #64748b;
+  cursor: pointer;
+  margin-left: 4px;
+  flex-shrink: 0;
+
+  &:hover {
+    background: #f1f5f9;
+    color: #334155;
+    border-color: #cbd5e1;
+  }
 }
 
 .fixed {

--- a/apps/back-office/pages/access-control/roles/[code].tsx
+++ b/apps/back-office/pages/access-control/roles/[code].tsx
@@ -74,7 +74,7 @@ const RoleEditPage = () => {
     setPage(1); // Reset to first page on search
   };
 
-  const handleAddMember = async (member: MemberBasic) => {
+  const handleAddMember = async (member: MemberBasic, _scopes: string[]) => {
     try {
       await assignRole.mutateAsync({
         authToken,

--- a/apps/back-office/screens/access-control/components/AddMemberModal.tsx
+++ b/apps/back-office/screens/access-control/components/AddMemberModal.tsx
@@ -4,16 +4,17 @@ import { useSearchMembers } from '../../../hooks/access-control/useSearchMembers
 import { useRbacMembers } from '../../../hooks/access-control/useRbacMembers';
 import { useCookie } from 'react-use';
 import clsx from 'clsx';
-import { MemberBasic } from '../types';
+import { MemberBasic, AVAILABLE_SCOPES } from '../types';
 
 interface AddMemberModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAdd: (member: MemberBasic) => void;
+  onAdd: (member: MemberBasic, scopes: string[]) => void;
   title: string;
   existingMemberUids?: string[];
   excludeRoleCode?: string;
   isLoading?: boolean;
+  showScopes?: boolean;
 }
 
 export const AddMemberModal: React.FC<AddMemberModalProps> = ({
@@ -24,10 +25,12 @@ export const AddMemberModal: React.FC<AddMemberModalProps> = ({
   existingMemberUids = [],
   excludeRoleCode,
   isLoading = false,
+  showScopes = false,
 }) => {
   const [authToken] = useCookie('plnadmin');
   const [selectedMember, setSelectedMember] = useState<MemberBasic | null>(null);
   const [memberSearch, setMemberSearch] = useState('');
+  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
 
   const searchActive = memberSearch.trim().length >= 2;
 
@@ -63,9 +66,22 @@ export const AddMemberModal: React.FC<AddMemberModalProps> = ({
 
   const submitDisabled = isLoading || !selectedMember;
 
+  const toggleScope = (scope: string) => {
+    setSelectedScopes((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) {
+        next.delete(scope);
+      } else {
+        next.add(scope);
+      }
+      return next;
+    });
+  };
+
   const resetAll = () => {
     setSelectedMember(null);
     setMemberSearch('');
+    setSelectedScopes(new Set());
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -73,7 +89,7 @@ export const AddMemberModal: React.FC<AddMemberModalProps> = ({
 
     if (!selectedMember) return;
 
-    onAdd(selectedMember);
+    onAdd(selectedMember, [...selectedScopes].sort());
     resetAll();
     onClose();
   };
@@ -218,6 +234,33 @@ export const AddMemberModal: React.FC<AddMemberModalProps> = ({
                 )}
               </div>
             </div>
+
+            {showScopes && selectedMember && (
+              <div className="mt-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">Scopes (optional)</label>
+                <div className="flex gap-3">
+                  {AVAILABLE_SCOPES.map((scope) => (
+                    <label
+                      key={scope}
+                      className={clsx(
+                        'flex items-center gap-2 rounded-lg border px-3 py-2 cursor-pointer transition-colors text-sm',
+                        selectedScopes.has(scope)
+                          ? 'border-blue-300 bg-blue-50'
+                          : 'border-gray-200 hover:border-gray-300'
+                      )}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedScopes.has(scope)}
+                        onChange={() => toggleScope(scope)}
+                        className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                      />
+                      {scope}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
           </form>
         </div>
 

--- a/apps/back-office/screens/access-control/types.ts
+++ b/apps/back-office/screens/access-control/types.ts
@@ -65,7 +65,7 @@ export interface PermissionWithCounts extends PermissionBasic {
 
 export interface PermissionDetails extends PermissionBasic {
   roles: Array<RoleBasic & { memberCount: number }>;
-  members: Array<MemberBasic & { viaRoles: string[]; isDirect: boolean; projectContributions: TeamInfo[] }>;
+  members: Array<MemberBasic & { viaRoles: string[]; isDirect: boolean; projectContributions: TeamInfo[]; scopes: string[] }>;
   pagination: PaginationInfo;
 }
 

--- a/apps/web-api/src/rbac/rbac.service.ts
+++ b/apps/web-api/src/rbac/rbac.service.ts
@@ -1045,6 +1045,7 @@ export class RbacService {
           projectContributions: assignment.member.projectContributions,
           viaRoles: [assignment.role.name],
           isDirect: false,
+          scopes: [],
         });
       }
     }
@@ -1054,6 +1055,7 @@ export class RbacService {
       const existing = memberMap.get(mp.member.uid);
       if (existing) {
         existing.isDirect = true;
+        existing.scopes = mp.scopes ?? [];
       } else {
         memberMap.set(mp.member.uid, {
           uid: mp.member.uid,
@@ -1063,6 +1065,7 @@ export class RbacService {
           projectContributions: mp.member.projectContributions,
           viaRoles: [],
           isDirect: true,
+          scopes: mp.scopes ?? [],
         });
       }
     }


### PR DESCRIPTION
## Description

On the permission detail page (/access-control/permissions/[code]), admins can grant permissions to members via "Add Direct Permission" but cannot select scopes (PLVS/PLCC). The member detail page (/access-control/members/[uid]) already has full scope support, scope selection when adding permissions, scope badges in the table, and inline edit. We need to bring this same capability to the permission detail page.

## Back Office

<img width="1390" height="603" alt="Screenshot 2026-04-09 at 6 32 47 PM" src="https://github.com/user-attachments/assets/7538f242-0929-4ad5-8eb1-f646c66c49d6" />

<img width="1492" height="941" alt="Screenshot 2026-04-09 at 6 33 03 PM" src="https://github.com/user-attachments/assets/b4d99ce0-5a51-48da-be6e-18fa34bef2e3" />


## Tickets

[LAB-1675](https://linear.app/plrs-labos/issue/LAB-1675/founder-guides-rbac-implement-permission-scopes-plvsplcc)