### PR TITLE
[Founder Guides] Add in-app and email notifications for guide

### DIFF
--- a/apps/web-api/prisma/migrations/20260409120000_add_guide_notification_categories/migration.sql
+++ b/apps/web-api/prisma/migrations/20260409120000_add_guide_notification_categories/migration.sql
@@ -1,0 +1,3 @@
+-- AlterEnum
+ALTER TYPE "PushNotificationCategory" ADD VALUE 'GUIDE_POST';
+ALTER TYPE "PushNotificationCategory" ADD VALUE 'GUIDE_REPLY';

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -1314,6 +1314,10 @@ enum PushNotificationCategory {
   SYSTEM
 
   IRL_GATHERING
+
+  // Guide comments
+  GUIDE_POST
+  GUIDE_REPLY
 }
 
 // Push notifications for WebSocket delivery

--- a/apps/web-api/src/articles/article-comments.service.ts
+++ b/apps/web-api/src/articles/article-comments.service.ts
@@ -393,9 +393,32 @@ export class ArticleCommentsService {
     const link = `/founder-guides/${article.slugURL}`;
     const recipientUids = new Set<string>();
 
-    // Scenario 1: Top-level comment → notify article author (+ team leads if team-authored)
+    // Scenario 1: Mentions → notify mentioned members (highest priority — a mention is the
+    // most specific signal, so a mentioned user should always get the mention notification
+    // even if they would also be eligible as the article author or parent comment author).
+    const mentionedUids = this.extractMentionUids(comment.content);
+    for (const mentionedUid of mentionedUids) {
+      if (mentionedUid !== commentAuthor.uid && !recipientUids.has(mentionedUid)) {
+        recipientUids.add(mentionedUid);
+        await this.pushNotificationsService.sendGuideCommentNotification({
+          recipientUid: mentionedUid,
+          category: comment.parentUid ? 'GUIDE_REPLY' : 'GUIDE_POST',
+          commentAuthor,
+          articleTitle: article.title,
+          commentContent: comment.content,
+          link,
+          eventType: 'guide_mention',
+        });
+      }
+    }
+
+    // Scenario 2: Top-level comment → notify article author (+ team leads if team-authored)
     if (!comment.parentUid) {
-      if (article.authorMemberUid && article.authorMemberUid !== commentAuthor.uid) {
+      if (
+        article.authorMemberUid &&
+        article.authorMemberUid !== commentAuthor.uid &&
+        !recipientUids.has(article.authorMemberUid)
+      ) {
         recipientUids.add(article.authorMemberUid);
         await this.pushNotificationsService.sendGuideCommentNotification({
           recipientUid: article.authorMemberUid,
@@ -427,7 +450,7 @@ export class ArticleCommentsService {
       }
     }
 
-    // Scenario 2: Reply → notify parent comment author
+    // Scenario 3: Reply → notify parent comment author
     if (comment.parentUid) {
       const parentComment = await this.prisma.articleComment.findUnique({
         where: { uid: comment.parentUid },
@@ -447,23 +470,6 @@ export class ArticleCommentsService {
             eventType: 'guide_reply',
           });
         }
-      }
-    }
-
-    // Scenario 3: Mentions → notify mentioned members
-    const mentionedUids = this.extractMentionUids(comment.content);
-    for (const mentionedUid of mentionedUids) {
-      if (mentionedUid !== commentAuthor.uid && !recipientUids.has(mentionedUid)) {
-        recipientUids.add(mentionedUid);
-        await this.pushNotificationsService.sendGuideCommentNotification({
-          recipientUid: mentionedUid,
-          category: comment.parentUid ? 'GUIDE_REPLY' : 'GUIDE_POST',
-          commentAuthor,
-          articleTitle: article.title,
-          commentContent: comment.content,
-          link,
-          eventType: 'guide_mention',
-        });
       }
     }
   }

--- a/apps/web-api/src/articles/article-comments.service.ts
+++ b/apps/web-api/src/articles/article-comments.service.ts
@@ -2,11 +2,13 @@ import {
   BadRequestException,
   ForbiddenException,
   Injectable,
+  Logger,
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { PrismaService } from '../shared/prisma.service';
 import { CreateArticleCommentDto, UpdateArticleCommentDto } from './article-comments.dto';
+import { PushNotificationsService } from '../push-notifications/push-notifications.service';
 
 type ArticleCommentResponse = {
   uid: string;
@@ -28,7 +30,12 @@ type ArticleCommentResponse = {
 
 @Injectable()
 export class ArticleCommentsService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(ArticleCommentsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly pushNotificationsService: PushNotificationsService
+  ) {}
 
   private async resolveMemberByEmail(userEmail: string) {
     if (!userEmail) {
@@ -145,15 +152,21 @@ export class ArticleCommentsService {
       },
     });
 
+    // Fire-and-forget: send notifications
+    this.sendCommentNotifications(
+      { uid: created.uid, parentUid: created.parentUid, content: created.content, articleUid },
+      { uid: member.uid, name: member.name, image: member.image }
+    ).catch((err) => {
+      this.logger.error(`Failed to send guide comment notifications: ${err?.message}`);
+    });
+
     return this.mapComment(created, false);
   }
 
   async listComments(userEmail: string | undefined, articleUid: string) {
     await this.ensurePublishedArticle(articleUid);
 
-    const member = userEmail
-      ? await this.resolveMemberByEmail(userEmail).catch(() => null)
-      : null;
+    const member = userEmail ? await this.resolveMemberByEmail(userEmail).catch(() => null) : null;
 
     const comments = await this.prisma.articleComment.findMany({
       where: { articleUid },
@@ -177,12 +190,10 @@ export class ArticleCommentsService {
     });
 
     const mapped: ArticleCommentResponse[] = comments.map((comment) =>
-      this.mapComment(comment, Array.isArray(comment.likes) ? comment.likes.length > 0 : false),
+      this.mapComment(comment, Array.isArray(comment.likes) ? comment.likes.length > 0 : false)
     );
 
-    const byUid = new Map<string, ArticleCommentResponse>(
-      mapped.map((comment) => [comment.uid, comment]),
-    );
+    const byUid = new Map<string, ArticleCommentResponse>(mapped.map((comment) => [comment.uid, comment]));
 
     const roots: ArticleCommentResponse[] = [];
 
@@ -360,5 +371,125 @@ export class ArticleCommentsService {
       likesCount: Math.max(updated!.likesCount, 0),
       likedByMe: false,
     };
+  }
+
+  private async sendCommentNotifications(
+    comment: { uid: string; parentUid: string | null; content: string; articleUid: string },
+    commentAuthor: { uid: string; name: string | null; image?: { url: string } | null }
+  ): Promise<void> {
+    const article = await this.prisma.article.findUnique({
+      where: { uid: comment.articleUid },
+      select: {
+        uid: true,
+        title: true,
+        slugURL: true,
+        authorMemberUid: true,
+        authorTeamUid: true,
+      },
+    });
+
+    if (!article) return;
+
+    const link = `/founder-guides/${article.slugURL}`;
+    const recipientUids = new Set<string>();
+
+    // Scenario 1: Top-level comment → notify article author (+ team leads if team-authored)
+    if (!comment.parentUid) {
+      if (article.authorMemberUid && article.authorMemberUid !== commentAuthor.uid) {
+        recipientUids.add(article.authorMemberUid);
+        await this.pushNotificationsService.sendGuideCommentNotification({
+          recipientUid: article.authorMemberUid,
+          category: 'GUIDE_POST',
+          commentAuthor,
+          articleTitle: article.title,
+          commentContent: comment.content,
+          link,
+          eventType: 'guide_comment',
+        });
+      }
+
+      if (article.authorTeamUid) {
+        const teamLeads = await this.resolveTeamLeads(article.authorTeamUid, commentAuthor.uid);
+        for (const lead of teamLeads) {
+          if (!recipientUids.has(lead.uid)) {
+            recipientUids.add(lead.uid);
+            await this.pushNotificationsService.sendGuideCommentNotification({
+              recipientUid: lead.uid,
+              category: 'GUIDE_POST',
+              commentAuthor,
+              articleTitle: article.title,
+              commentContent: comment.content,
+              link,
+              eventType: 'guide_comment',
+            });
+          }
+        }
+      }
+    }
+
+    // Scenario 2: Reply → notify parent comment author
+    if (comment.parentUid) {
+      const parentComment = await this.prisma.articleComment.findUnique({
+        where: { uid: comment.parentUid },
+        select: { authorUid: true },
+      });
+
+      if (parentComment && parentComment.authorUid !== commentAuthor.uid) {
+        if (!recipientUids.has(parentComment.authorUid)) {
+          recipientUids.add(parentComment.authorUid);
+          await this.pushNotificationsService.sendGuideCommentNotification({
+            recipientUid: parentComment.authorUid,
+            category: 'GUIDE_REPLY',
+            commentAuthor,
+            articleTitle: article.title,
+            commentContent: comment.content,
+            link,
+            eventType: 'guide_reply',
+          });
+        }
+      }
+    }
+
+    // Scenario 3: Mentions → notify mentioned members
+    const mentionedUids = this.extractMentionUids(comment.content);
+    for (const mentionedUid of mentionedUids) {
+      if (mentionedUid !== commentAuthor.uid && !recipientUids.has(mentionedUid)) {
+        recipientUids.add(mentionedUid);
+        await this.pushNotificationsService.sendGuideCommentNotification({
+          recipientUid: mentionedUid,
+          category: comment.parentUid ? 'GUIDE_REPLY' : 'GUIDE_POST',
+          commentAuthor,
+          articleTitle: article.title,
+          commentContent: comment.content,
+          link,
+          eventType: 'guide_mention',
+        });
+      }
+    }
+  }
+
+  private async resolveTeamLeads(teamUid: string, excludeUid: string): Promise<Array<{ uid: string }>> {
+    const teamLeadRoles = await this.prisma.teamMemberRole.findMany({
+      where: {
+        teamUid,
+        teamLead: true,
+        memberUid: { not: excludeUid },
+      },
+      select: { memberUid: true },
+    });
+
+    return teamLeadRoles.map((r) => ({ uid: r.memberUid }));
+  }
+
+  private extractMentionUids(content: string): string[] {
+    const regex = /data-uid="([^"]+)"/g;
+    const uids: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(content)) !== null) {
+      if (match[1] && !uids.includes(match[1])) {
+        uids.push(match[1]);
+      }
+    }
+    return uids;
   }
 }

--- a/apps/web-api/src/articles/articles.module.ts
+++ b/apps/web-api/src/articles/articles.module.ts
@@ -7,9 +7,10 @@ import { JwtService } from '../utils/jwt/jwt.service';
 import { RbacModule } from '../rbac/rbac.module';
 import { ArticleCommentsController } from './article-comments.controller';
 import { ArticleCommentsService } from './article-comments.service';
+import { PushNotificationsModule } from '../push-notifications/push-notifications.module';
 
 @Module({
-  imports: [SharedModule, RbacModule],
+  imports: [SharedModule, RbacModule, PushNotificationsModule],
   controllers: [ArticlesController, AdminArticlesController, ArticleCommentsController],
   providers: [ArticlesService, ArticleCommentsService, JwtService],
   exports: [ArticlesService, ArticleCommentsService],

--- a/apps/web-api/src/demo-days/demo-days.module.ts
+++ b/apps/web-api/src/demo-days/demo-days.module.ts
@@ -24,7 +24,7 @@ import { TeamEnrichmentModule } from '../team-enrichment/team-enrichment.module'
     forwardRef(() => MembersModule),
     forwardRef(() => TeamsModule),
     NotificationsModule,
-    PushNotificationsModule,
+    forwardRef(() => PushNotificationsModule),
     TeamEnrichmentModule,
   ],
   controllers: [DemoDaysController, DemoDaySubscriptionsController],

--- a/apps/web-api/src/push-notifications/push-notifications.service.ts
+++ b/apps/web-api/src/push-notifications/push-notifications.service.ts
@@ -25,6 +25,20 @@ export interface ForumMentionEmailDto {
   metadata?: Record<string, unknown>;
 }
 
+export interface GuideCommentNotificationDto {
+  recipientUid: string;
+  category: 'GUIDE_POST' | 'GUIDE_REPLY';
+  commentAuthor: {
+    uid: string;
+    name: string | null;
+    image?: { url: string } | null;
+  };
+  articleTitle: string;
+  commentContent: string;
+  link: string;
+  eventType: 'guide_comment' | 'guide_reply' | 'guide_mention';
+}
+
 interface NotificationWithReadStatus {
   uid: string;
   category: PushNotificationCategory;
@@ -778,5 +792,131 @@ export class PushNotificationsService {
         }`
       );
     }
+  }
+
+  /**
+   * Send push notification + email for guide comment events
+   */
+  async sendGuideCommentNotification(dto: GuideCommentNotificationDto): Promise<void> {
+    const authorName = dto.commentAuthor.name || 'Unknown User';
+    const authorPicture = dto.commentAuthor.image?.url || '';
+
+    let title: string;
+
+    switch (dto.eventType) {
+      case 'guide_comment':
+        title = `${authorName} commented on your Guide "${dto.articleTitle}"`;
+        break;
+      case 'guide_reply':
+        title = `${authorName} replied to your comment on "${dto.articleTitle}"`;
+        break;
+      case 'guide_mention':
+        title = `${authorName} mentioned you in a comment on "${dto.articleTitle}"`;
+        break;
+    }
+
+    // 1. Send push notification (in-app)
+    try {
+      await this.create({
+        category: dto.category as PushNotificationCategory,
+        title,
+        description: dto.commentContent,
+        link: dto.link,
+        recipientUid: dto.recipientUid,
+        isPublic: false,
+        metadata: {
+          authorName,
+          authorUid: dto.commentAuthor.uid,
+          authorPicture,
+          eventType: dto.eventType,
+          articleTitle: dto.articleTitle,
+        },
+      });
+    } catch (error) {
+      this.logger.error(`Failed to send guide push notification: ${error instanceof Error ? error.message : error}`);
+    }
+
+    // 2. Send email notification
+    try {
+      await this.sendGuideCommentEmail({
+        recipientUid: dto.recipientUid,
+        authorName,
+        authorUid: dto.commentAuthor.uid,
+        authorPicture,
+        articleTitle: dto.articleTitle,
+        commentContent: dto.commentContent,
+        link: dto.link,
+        eventType: dto.eventType,
+      });
+    } catch (error) {
+      this.logger.error(`Failed to send guide email notification: ${error instanceof Error ? error.message : error}`);
+    }
+  }
+
+  /**
+   * Send email notification for guide comment events
+   */
+  private async sendGuideCommentEmail(params: {
+    recipientUid: string;
+    authorName: string;
+    authorUid: string;
+    authorPicture: string;
+    articleTitle: string;
+    commentContent: string;
+    link: string;
+    eventType: 'guide_comment' | 'guide_reply' | 'guide_mention';
+  }): Promise<void> {
+    const member = await this.prisma.member.findFirst({
+      where: { uid: params.recipientUid },
+      select: { email: true, name: true, uid: true },
+    });
+
+    if (!member?.email) {
+      this.logger.warn(`Cannot send guide email: member email not found for ${params.recipientUid}`);
+      return;
+    }
+
+    const templateMap: Record<string, { templateName: string; actionType: string }> = {
+      guide_comment: { templateName: 'GUIDE_COMMENT', actionType: 'COMMENT' },
+      guide_reply: { templateName: 'GUIDE_REPLY', actionType: 'REPLY' },
+      guide_mention: { templateName: 'GUIDE_MENTION', actionType: 'MENTION' },
+    };
+
+    const { templateName, actionType } = templateMap[params.eventType];
+    const postLink = `${process.env.WEB_UI_BASE_URL}${params.link}`;
+
+    await this.notificationServiceClient.sendNotification({
+      isPriority: true,
+      deliveryChannel: 'EMAIL',
+      templateName,
+      recipientsInfo: {
+        to: [member.email],
+      },
+      deliveryPayload: {
+        body: {
+          recipientName: member.name || 'there',
+          authorName: params.authorName,
+          authorPicture: params.authorPicture,
+          postContent: params.commentContent,
+          postLink,
+          postTitle: params.articleTitle,
+        },
+      },
+      entityType: 'GUIDE',
+      actionType,
+      sourceMeta: {
+        activityId: '',
+        activityType: `GUIDE_${actionType}`,
+        activityUserId: params.authorUid,
+        activityUserName: params.authorName,
+      },
+      targetMeta: {
+        emailId: member.email,
+        userId: member.uid,
+        userName: member.name || '',
+      },
+    });
+
+    this.logger.log(`Guide ${params.eventType} email sent to ${member.email}`);
   }
 }

--- a/apps/web-api/src/push-notifications/push-notifications.service.ts
+++ b/apps/web-api/src/push-notifications/push-notifications.service.ts
@@ -877,8 +877,8 @@ export class PushNotificationsService {
     }
 
     const templateMap: Record<string, { templateName: string; actionType: string }> = {
-      guide_comment: { templateName: 'GUIDE_COMMENT', actionType: 'COMMENT' },
-      guide_reply: { templateName: 'GUIDE_REPLY', actionType: 'REPLY' },
+      guide_comment: { templateName: 'GUIDE_POST_REPLIED', actionType: 'COMMENT' },
+      guide_reply: { templateName: 'GUIDE_POST_REPLIED', actionType: 'REPLY' },
       guide_mention: { templateName: 'GUIDE_MENTION', actionType: 'MENTION' },
     };
 


### PR DESCRIPTION
## Overview
Added push notifications (in-app) and email notifications for Guide (Article) comments. Follows the same patterns used by Forum notifications.

## New Notification Categories
- `GUIDE_POST` — used for new top-level comments and mentions on comments
- `GUIDE_REPLY` — used for replies to comments and mentions on replies

## Notification Matrix

| Trigger | Recipients | Push | Email |
|---|---|---|---|
| New comment on a Guide | Article author (or team leads if team-authored) | ✅ | ✅ |
| Reply to a comment | Parent comment author | ✅ | ✅ |
| @mention in a comment | Mentioned member | ✅ | ✅ |

## Key Behaviors
- Commenter never receives their own notification
- Deduplication: if a member qualifies for multiple notifications on the same comment (e.g., article author AND mentioned), they only receive one
- Team-authored articles: notifications go to all team leads (via `TeamMemberRole.teamLead`)
- Mentions parsed from Quill editor HTML (`data-uid` attribute)
- Notifications are fire-and-forget (don't block the comment creation response)

## Email Examples

### New comment

<img width="905" height="539" alt="Comment" src="https://github.com/user-attachments/assets/169d8580-c7ae-4619-bc8d-ea407edb29e2" />

### Mention

<img width="906" height="526" alt="Mention" src="https://github.com/user-attachments/assets/94e22711-3441-4c49-a0c6-bae0f6027185" />


## In-App Notification Examples

### UI examples

<img width="514" height="505" alt="Screenshot 2026-04-10 at 3 26 52 PM" src="https://github.com/user-attachments/assets/c1b8ba3b-a54f-4c6c-914a-6fec2bfe3ddb" />


### Scenario 1: New comment on a Guide (article author notification)

> **User "Jane Doe" comments on Guide "How to Build a DAO" authored by "John Smith"**

```json
{
  "category": "GUIDE_POST",
  "title": "Jane Doe commented on your Guide \"How to Build a DAO\"",
  "description": "This is a great guide! I especially liked the section about governance...",
  "link": "/founder-guides/how-to-build-a-dao",
  "recipientUid": "john-smith-uid",
  "isPublic": false,
  "metadata": {
    "authorName": "Jane Doe",
    "authorUid": "jane-doe-uid",
    "authorPicture": "https://pl-directory-images.s3.amazonaws.com/jane.jpg",
    "eventType": "guide_comment",
    "articleTitle": "How to Build a DAO"
  }
}
```

### Scenario 2: New comment on a team-authored Guide (team leads notification)

> **User "Jane Doe" comments on Guide "Protocol Labs Onboarding" authored by team "Protocol Labs". Team leads: "Alice", "Bob"**

Each team lead receives:
```json
{
  "category": "GUIDE_POST",
  "title": "Jane Doe commented on your Guide \"Protocol Labs Onboarding\"",
  "description": "Could you clarify step 3 about setting up the dev environment?",
  "link": "/founder-guides/protocol-labs-onboarding",
  "recipientUid": "alice-uid (or bob-uid)",
  "isPublic": false,
  "metadata": {
    "authorName": "Jane Doe",
    "authorUid": "jane-doe-uid",
    "authorPicture": "https://pl-directory-images.s3.amazonaws.com/jane.jpg",
    "eventType": "guide_comment",
    "articleTitle": "Protocol Labs Onboarding"
  }
}
```

### Scenario 3: Reply to a comment (parent comment author notification)

> **User "Bob" replies to "Jane Doe"'s comment on Guide "How to Build a DAO"**

```json
{
  "category": "GUIDE_REPLY",
  "title": "Bob replied to your comment on \"How to Build a DAO\"",
  "description": "I agree, the governance section was very insightful!",
  "link": "/founder-guides/how-to-build-a-dao",
  "recipientUid": "jane-doe-uid",
  "isPublic": false,
  "metadata": {
    "authorName": "Bob",
    "authorUid": "bob-uid",
    "authorPicture": "https://pl-directory-images.s3.amazonaws.com/bob.jpg",
    "eventType": "guide_reply",
    "articleTitle": "How to Build a DAO"
  }
}
```

### Scenario 4: Mention in a comment (mentioned member notification)

> **User "Jane Doe" mentions "@Alice" in a comment on Guide "How to Build a DAO"**

```json
{
  "category": "GUIDE_POST",
  "title": "Jane Doe mentioned you in a comment on \"How to Build a DAO\"",
  "description": "<p><a class=\"ql-mention\" data-uid=\"alice-uid\">@Alice</a> what do you think about this approach?</p>",
  "link": "/founder-guides/how-to-build-a-dao",
  "recipientUid": "alice-uid",
  "isPublic": false,
  "metadata": {
    "authorName": "Jane Doe",
    "authorUid": "jane-doe-uid",
    "authorPicture": "https://pl-directory-images.s3.amazonaws.com/jane.jpg",
    "eventType": "guide_mention",
    "articleTitle": "How to Build a DAO"
  }
}
```

### Scenario 5: Mention in a reply

> **User "Bob" mentions "@Alice" in a reply on Guide "How to Build a DAO"**

```json
{
  "category": "GUIDE_REPLY",
  "title": "Bob mentioned you in a comment on \"How to Build a DAO\"",
  "description": "<p><a class=\"ql-mention\" data-uid=\"alice-uid\">@Alice</a> check out this reply</p>",
  "link": "/founder-guides/how-to-build-a-dao",
  "recipientUid": "alice-uid",
  "isPublic": false,
  "metadata": {
    "authorName": "Bob",
    "authorUid": "bob-uid",
    "authorPicture": "https://pl-directory-images.s3.amazonaws.com/bob.jpg",
    "eventType": "guide_mention",
    "articleTitle": "How to Build a DAO"
  }
}
```

## Email Templates Required (External Notification Service)
- `GUIDE_COMMENT` (entityType: `GUIDE`, actionType: `COMMENT`)
- `GUIDE_REPLY` (entityType: `GUIDE`, actionType: `REPLY`)
- `GUIDE_MENTION` (entityType: `GUIDE`, actionType: `MENTION`)
