### PR TITLE
Trigger Force Re-Enrichment Teams

### DIFF
--- a/apps/web-api/src/admin/admin-teams.controller.ts
+++ b/apps/web-api/src/admin/admin-teams.controller.ts
@@ -19,7 +19,7 @@ import { NoCache } from '../decorators/no-cache.decorator';
 import { ZodValidationPipe } from '@abitia/zod-dto';
 
 import { AdminTeamsService } from './admin-teams.service';
-import { UploadTeamTiersQueryDto } from './schema/admin-teams';
+import { TriggerForceEnrichmentQueryDto, UploadTeamTiersQueryDto } from './schema/admin-teams';
 import { TeamEnrichmentService } from '../team-enrichment/team-enrichment.service';
 
 @ApiTags('Admin Teams')
@@ -108,5 +108,34 @@ export class AdminTeamsController {
   async triggerEnrichmentAll() {
     const result = await this.teamEnrichmentService.triggerEnrichmentForAllPending('manually');
     return { success: true, ...result, message: 'Enrichment triggered in background' };
+  }
+
+  @Post('/:uid/trigger-force-enrichment')
+  @NoCache()
+  async triggerForceEnrichment(
+    @Param('uid') uid: string,
+    @Query(new ZodValidationPipe()) query: TriggerForceEnrichmentQueryDto
+  ) {
+    const { status } = await this.teamEnrichmentService.forceEnrichTeam(uid, query.mode, 'manually');
+
+    if (status === 'not_found') {
+      throw new BadRequestException(`Team ${uid} not found`);
+    }
+    if (status === 'in_progress') {
+      return { success: false, message: `Enrichment already in progress for team ${uid}` };
+    }
+
+    return { success: true, message: `Force enrichment (mode=${query.mode}) triggered for team ${uid}` };
+  }
+
+  @Post('trigger-force-enrichment')
+  @NoCache()
+  async triggerForceEnrichmentAll(@Query(new ZodValidationPipe()) query: TriggerForceEnrichmentQueryDto) {
+    const result = await this.teamEnrichmentService.forceEnrichAllCompletedTeams(query.mode, 'manually');
+    return {
+      success: true,
+      ...result,
+      message: `Force enrichment (mode=${query.mode}) triggered in background`,
+    };
   }
 }

--- a/apps/web-api/src/admin/schema/admin-teams.ts
+++ b/apps/web-api/src/admin/schema/admin-teams.ts
@@ -59,3 +59,13 @@ export const UploadTeamTiersResultSchema = z.object({
   failedKeys: z.array(z.string()).optional(),
 });
 export class UploadTeamTiersResultDto extends createZodDto(UploadTeamTiersResultSchema) {}
+
+/**
+ * Query parameters for the force-enrichment endpoints.
+ * - `all`: retry every enrichable field except those the user manually edited (overwrites AI-filled values).
+ * - `cannotEnrich`: retry only fields whose prior status was CannotEnrich.
+ */
+export const TriggerForceEnrichmentQuerySchema = z.object({
+  mode: z.enum(['all', 'cannotEnrich']).optional().default('all'),
+});
+export class TriggerForceEnrichmentQueryDto extends createZodDto(TriggerForceEnrichmentQuerySchema) {}

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -16,6 +16,7 @@ import {
   FieldConfidence,
   FieldEnrichmentMeta,
   FieldEnrichmentStatus,
+  ForceEnrichmentMode,
   TeamDataEnrichment,
 } from './team-enrichment.types';
 
@@ -173,7 +174,117 @@ export class TeamEnrichmentService {
     return { status: 'started' };
   }
 
-  private async doEnrichTeam(teamUid: string, enrichedBy: string): Promise<void> {
+  async forceEnrichTeam(
+    teamUid: string,
+    mode: ForceEnrichmentMode,
+    enrichedBy = 'manually'
+  ): Promise<{ status: 'started' | 'in_progress' | 'not_found' }> {
+    const team = await this.prisma.team.findUnique({
+      where: { uid: teamUid },
+      select: { dataEnrichment: true },
+    });
+    if (!team) return { status: 'not_found' };
+
+    const existing = this.parseEnrichmentMeta(team.dataEnrichment);
+    if (existing?.status === EnrichmentStatus.InProgress) {
+      this.logger.warn(`Force-enrichment: already in progress for team ${teamUid}, skipping`);
+      return { status: 'in_progress' };
+    }
+
+    const resetFieldsMeta = this.buildForceEnrichmentFieldsMeta(existing?.fieldsMeta ?? {}, mode);
+
+    const enrichment: TeamDataEnrichment = {
+      ...(existing ?? { isAIGenerated: false }),
+      shouldEnrich: true,
+      status: EnrichmentStatus.PendingEnrichment,
+      isAIGenerated: existing?.isAIGenerated ?? false,
+      fieldsMeta: resetFieldsMeta,
+    };
+
+    await this.prisma.team.update({
+      where: { uid: teamUid },
+      data: { dataEnrichment: enrichment as any },
+    });
+
+    this.logger.log(`Force-enrichment queued for team ${teamUid} (mode=${mode})`);
+
+    this.doEnrichTeam(teamUid, enrichedBy, { forceOverwrite: mode === 'all' }).catch((err) => {
+      this.logger.error(`Background force-enrichment failed for team ${teamUid}: ${err.message}`, err.stack);
+    });
+
+    return { status: 'started' };
+  }
+
+  async findCompletedTeams(): Promise<Array<{ uid: string }>> {
+    const completedStatuses = [
+      EnrichmentStatus.Enriched,
+      EnrichmentStatus.Reviewed,
+      EnrichmentStatus.Approved,
+      EnrichmentStatus.FailedToEnrich,
+    ];
+    return this.prisma.team.findMany({
+      where: {
+        OR: completedStatuses.map((status) => ({
+          dataEnrichment: { path: ['status'], equals: status },
+        })),
+      },
+      select: { uid: true },
+    });
+  }
+
+  async forceEnrichAllCompletedTeams(
+    mode: ForceEnrichmentMode,
+    enrichedBy = 'manually'
+  ): Promise<{ total: number; started: number; skipped: number }> {
+    const teams = await this.findCompletedTeams();
+    this.logger.log(`Force-enrich all (mode=${mode}): found ${teams.length} completed teams`);
+
+    let started = 0;
+    let skipped = 0;
+
+    for (const team of teams) {
+      const { status } = await this.forceEnrichTeam(team.uid, mode, enrichedBy);
+      if (status === 'started') {
+        started++;
+      } else {
+        skipped++;
+      }
+    }
+
+    return { total: teams.length, started, skipped };
+  }
+
+  private buildForceEnrichmentFieldsMeta(
+    existing: FieldsMetaMap,
+    mode: ForceEnrichmentMode
+  ): FieldsMetaMap {
+    const reset: FieldsMetaMap = {};
+    for (const [field, meta] of Object.entries(existing) as Array<
+      [EnrichableField | 'logo', FieldEnrichmentMeta | undefined]
+    >) {
+      if (!meta) continue;
+      // User edits are sacrosanct in both modes.
+      if (meta.status === FieldEnrichmentStatus.ChangedByUser) {
+        reset[field] = meta;
+        continue;
+      }
+      if (mode === 'cannotEnrich') {
+        // Keep Enriched so the doEnrichTeam skip-logic leaves them alone; drop CannotEnrich to retry.
+        if (meta.status === FieldEnrichmentStatus.Enriched) {
+          reset[field] = meta;
+        }
+      }
+      // mode === 'all': drop Enriched and CannotEnrich so they get re-processed.
+    }
+    return reset;
+  }
+
+  private async doEnrichTeam(
+    teamUid: string,
+    enrichedBy: string,
+    opts: { forceOverwrite?: boolean } = {}
+  ): Promise<void> {
+    const forceOverwrite = opts.forceOverwrite === true;
     const team = await this.prisma.team.findUnique({
       where: { uid: teamUid },
       select: {
@@ -240,13 +351,20 @@ export class TeamEnrichmentService {
       let fieldsUpdatedCount = 0;
 
       for (const field of ENRICHABLE_TEAM_FIELDS) {
-        // Skip fields already successfully enriched
-        if (existingFieldsMeta[field]?.status === FieldEnrichmentStatus.Enriched) continue;
+        const fieldStatus = existingFieldsMeta[field]?.status;
+
+        // Never overwrite user-edited fields.
+        if (fieldStatus === FieldEnrichmentStatus.ChangedByUser) continue;
+
+        // In standard mode, skip fields already successfully enriched.
+        // In force mode, re-query them and overwrite with fresh AI data.
+        if (!forceOverwrite && fieldStatus === FieldEnrichmentStatus.Enriched) continue;
 
         const currentValue = team[field];
         const newValue = aiResponse[field];
+        const slotIsEmpty = !currentValue || currentValue.trim() === '';
 
-        if (!currentValue || currentValue.trim() === '') {
+        if (slotIsEmpty || forceOverwrite) {
           if (newValue) {
             (updateData as any)[field] = newValue;
             newFieldsMeta[field] = {
@@ -255,14 +373,21 @@ export class TeamEnrichmentService {
               source: EnrichmentSource.AI,
             };
             fieldsUpdatedCount++;
-          } else {
+          } else if (slotIsEmpty) {
             newFieldsMeta[field] = { status: FieldEnrichmentStatus.CannotEnrich };
           }
         }
       }
 
-      // Handle industryTags — skip if already enriched
-      if (existingFieldsMeta.industryTags?.status !== FieldEnrichmentStatus.Enriched && team.industryTags.length === 0) {
+      // Handle industryTags — skip Enriched in standard mode, skip ChangedByUser always.
+      const tagsStatus = existingFieldsMeta.industryTags?.status;
+      const tagsBlockedByUser = tagsStatus === FieldEnrichmentStatus.ChangedByUser;
+      const tagsAlreadyEnriched = tagsStatus === FieldEnrichmentStatus.Enriched;
+      const shouldProcessTags = forceOverwrite
+        ? !tagsBlockedByUser
+        : !tagsAlreadyEnriched && team.industryTags.length === 0;
+
+      if (shouldProcessTags) {
         this.logger.debug(`Team ${teamUid}: AI returned industryTags = [${aiResponse.industryTags.join(', ')}]`);
         if (aiResponse.industryTags.length > 0) {
           const matchedTags = await this.prisma.industryTag.findMany({
@@ -275,24 +400,34 @@ export class TeamEnrichmentService {
             } industryTags: [${matchedTags.map((t) => t.title).join(', ')}]`
           );
           if (matchedTags.length > 0) {
-            updateData.industryTags = { connect: matchedTags.map((t) => ({ uid: t.uid })) };
+            // In force mode, replace the existing tag set; otherwise the team had no tags so connect is equivalent.
+            updateData.industryTags = forceOverwrite
+              ? { set: matchedTags.map((t) => ({ uid: t.uid })) }
+              : { connect: matchedTags.map((t) => ({ uid: t.uid })) };
             newFieldsMeta.industryTags = {
               status: FieldEnrichmentStatus.Enriched,
               confidence: toConfidence(aiResponse.confidence?.industryTags),
               source: EnrichmentSource.AI,
             };
             fieldsUpdatedCount++;
-          } else {
+          } else if (team.industryTags.length === 0) {
             newFieldsMeta.industryTags = { status: FieldEnrichmentStatus.CannotEnrich };
           }
-        } else {
+        } else if (team.industryTags.length === 0) {
           newFieldsMeta.industryTags = { status: FieldEnrichmentStatus.CannotEnrich };
         }
       }
 
-      // Handle investmentFocus — skip if already enriched
+      // Handle investmentFocus — skip Enriched in standard mode, skip ChangedByUser always.
       const currentFocus = team.investorProfile?.investmentFocus || [];
-      if (existingFieldsMeta.investmentFocus?.status !== FieldEnrichmentStatus.Enriched && currentFocus.length === 0) {
+      const focusStatus = existingFieldsMeta.investmentFocus?.status;
+      const focusBlockedByUser = focusStatus === FieldEnrichmentStatus.ChangedByUser;
+      const focusAlreadyEnriched = focusStatus === FieldEnrichmentStatus.Enriched;
+      const shouldProcessFocus = forceOverwrite
+        ? !focusBlockedByUser
+        : !focusAlreadyEnriched && currentFocus.length === 0;
+
+      if (shouldProcessFocus) {
         this.logger.debug(`Team ${teamUid}: AI returned investmentFocus = [${aiResponse.investmentFocus.join(', ')}]`);
         if (aiResponse.investmentFocus.length > 0) {
           if (team.investorProfile) {
@@ -314,7 +449,7 @@ export class TeamEnrichmentService {
             source: EnrichmentSource.AI,
           };
           fieldsUpdatedCount++;
-        } else {
+        } else if (currentFocus.length === 0) {
           newFieldsMeta.investmentFocus = { status: FieldEnrichmentStatus.CannotEnrich };
         }
       }
@@ -437,7 +572,11 @@ export class TeamEnrichmentService {
     return { total: teams.length, started, skipped };
   }
 
-  async handleUserFieldChange(teamUid: string, changedFields: string[], tx?: Prisma.TransactionClient): Promise<void> {
+  async handleUserFieldChange(
+    teamUid: string,
+    changedFieldValues: Record<string, unknown>,
+    tx?: Prisma.TransactionClient
+  ): Promise<void> {
     const db = tx || this.prisma;
 
     const team = await db.team.findUnique({
@@ -447,27 +586,44 @@ export class TeamEnrichmentService {
 
     const meta = this.parseEnrichmentMeta(team?.dataEnrichment);
     if (!meta || !meta.isAIGenerated) return;
+    if (!meta.fieldsMeta) meta.fieldsMeta = {};
 
-    let updated = false;
-    for (const field of changedFields) {
+    const flipped: string[] = [];
+    for (const [field, newValue] of Object.entries(changedFieldValues)) {
+      if (!ENRICHABLE_TEAM_FIELDS.includes(field as EnrichableTeamField)) continue;
+      const currentStatus = meta.fieldsMeta[field as EnrichableTeamField]?.status;
+
+      // AI previously filled this field; user just edited it → flip to ChangedByUser.
+      if (currentStatus === FieldEnrichmentStatus.Enriched) {
+        meta.fieldsMeta[field as EnrichableTeamField] = {
+          ...meta.fieldsMeta[field as EnrichableTeamField],
+          status: FieldEnrichmentStatus.ChangedByUser,
+        };
+        flipped.push(field);
+        continue;
+      }
+
+      // AI couldn't enrich; user is supplying a non-empty value → flip to ChangedByUser
+      // so a later force-enrich run won't overwrite it.
       if (
-        ENRICHABLE_TEAM_FIELDS.includes(field as EnrichableTeamField) &&
-        meta.fieldsMeta?.[field as EnrichableTeamField]?.status === FieldEnrichmentStatus.Enriched
+        currentStatus === FieldEnrichmentStatus.CannotEnrich &&
+        typeof newValue === 'string' &&
+        newValue.trim() !== ''
       ) {
         meta.fieldsMeta[field as EnrichableTeamField] = {
           ...meta.fieldsMeta[field as EnrichableTeamField],
           status: FieldEnrichmentStatus.ChangedByUser,
         };
-        updated = true;
+        flipped.push(field);
       }
     }
 
-    if (updated) {
+    if (flipped.length > 0) {
       await db.team.update({
         where: { uid: teamUid },
         data: { dataEnrichment: meta as any },
       });
-      this.logger.log(`Marked fields as ChangedByUser for team ${teamUid}: ${changedFields.join(', ')}`);
+      this.logger.log(`Marked fields as ChangedByUser for team ${teamUid}: ${flipped.join(', ')}`);
     }
   }
 

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -9,18 +9,18 @@ import {
 } from './team-enrichment-scrapingdog.service';
 import {
   ENRICHABLE_TEAM_FIELDS,
-  EnrichableField,
   EnrichableTeamField,
   EnrichmentSource,
   EnrichmentStatus,
   FieldConfidence,
   FieldEnrichmentMeta,
   FieldEnrichmentStatus,
+  FieldMetaKey,
   ForceEnrichmentMode,
   TeamDataEnrichment,
 } from './team-enrichment.types';
 
-type FieldsMetaMap = Partial<Record<EnrichableField | 'logo', FieldEnrichmentMeta>>;
+type FieldsMetaMap = Partial<Record<FieldMetaKey, FieldEnrichmentMeta>>;
 
 function toConfidence(raw: unknown): FieldConfidence | undefined {
   if (typeof raw !== 'string') return undefined;
@@ -191,14 +191,15 @@ export class TeamEnrichmentService {
       return { status: 'in_progress' };
     }
 
-    const resetFieldsMeta = this.buildForceEnrichmentFieldsMeta(existing?.fieldsMeta ?? {}, mode);
-
+    // Preserve all existing fieldsMeta entries (including Enriched, CannotEnrich, ChangedByUser)
+    // so provenance (confidence, source, prior status) is retained as history.
+    // doEnrichTeam decides per-field whether to skip or overwrite based on forceOverwrite + status.
     const enrichment: TeamDataEnrichment = {
       ...(existing ?? { isAIGenerated: false }),
       shouldEnrich: true,
       status: EnrichmentStatus.PendingEnrichment,
       isAIGenerated: existing?.isAIGenerated ?? false,
-      fieldsMeta: resetFieldsMeta,
+      fieldsMeta: existing?.fieldsMeta ?? {},
     };
 
     await this.prisma.team.update({
@@ -252,31 +253,6 @@ export class TeamEnrichmentService {
     }
 
     return { total: teams.length, started, skipped };
-  }
-
-  private buildForceEnrichmentFieldsMeta(
-    existing: FieldsMetaMap,
-    mode: ForceEnrichmentMode
-  ): FieldsMetaMap {
-    const reset: FieldsMetaMap = {};
-    for (const [field, meta] of Object.entries(existing) as Array<
-      [EnrichableField | 'logo', FieldEnrichmentMeta | undefined]
-    >) {
-      if (!meta) continue;
-      // User edits are sacrosanct in both modes.
-      if (meta.status === FieldEnrichmentStatus.ChangedByUser) {
-        reset[field] = meta;
-        continue;
-      }
-      if (mode === 'cannotEnrich') {
-        // Keep Enriched so the doEnrichTeam skip-logic leaves them alone; drop CannotEnrich to retry.
-        if (meta.status === FieldEnrichmentStatus.Enriched) {
-          reset[field] = meta;
-        }
-      }
-      // mode === 'all': drop Enriched and CannotEnrich so they get re-processed.
-    }
-    return reset;
   }
 
   private async doEnrichTeam(
@@ -517,11 +493,23 @@ export class TeamEnrichmentService {
         newFieldsMeta,
       });
 
-      // Merge field metadata (confidence + source), preserving previous entries
-      const mergedFieldsMeta: FieldsMetaMap = {
-        ...existingFieldsMeta,
-        ...newFieldsMeta,
-      };
+      // Merge field metadata per-field. Undefined keys on the fresh entry don't clobber
+      // prior provenance (confidence, source), so history is preserved when the new AI
+      // run doesn't re-supply them. Entries not touched this run remain as-is.
+      const mergedFieldsMeta: FieldsMetaMap = { ...existingFieldsMeta };
+      for (const [field, fresh] of Object.entries(newFieldsMeta) as Array<
+        [FieldMetaKey, FieldEnrichmentMeta | undefined]
+      >) {
+        if (!fresh) continue;
+        const prior = mergedFieldsMeta[field];
+        const freshDefined = Object.fromEntries(
+          Object.entries(fresh).filter(([, v]) => v !== undefined)
+        ) as Partial<FieldEnrichmentMeta>;
+        mergedFieldsMeta[field] = {
+          ...(prior ?? {}),
+          ...freshDefined,
+        } as FieldEnrichmentMeta;
+      }
 
       // Build enrichment metadata
       const enrichment: TeamDataEnrichment = {
@@ -670,7 +658,7 @@ export class TeamEnrichmentService {
   }): Promise<TeamDataEnrichment['scrapingDog'] | null> {
     const { teamUid, team, existingFieldsMeta, aiLinkedinHandler, updateData, newFieldsMeta } = ctx;
 
-    const markSdField = (field: EnrichableField | 'logo') => {
+    const markSdField = (field: FieldMetaKey) => {
       newFieldsMeta[field] = {
         status: FieldEnrichmentStatus.Enriched,
         confidence: FieldConfidence.High,

--- a/apps/web-api/src/team-enrichment/team-enrichment.types.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.types.ts
@@ -51,6 +51,13 @@ export type EnrichableTeamField = typeof ENRICHABLE_TEAM_FIELDS[number];
 export type EnrichableRelationField = typeof ENRICHABLE_RELATION_FIELDS[number];
 export type EnrichableField = EnrichableTeamField | EnrichableRelationField;
 
+/**
+ * Keys tracked in `dataEnrichment.fieldsMeta`. `logo` is included because the
+ * enrichment pipeline records provenance for it, even though it isn't filled
+ * by the AI text response (it comes from OG scraping or ScrapingDog).
+ */
+export type FieldMetaKey = EnrichableField | 'logo';
+
 export type ForceEnrichmentMode = 'all' | 'cannotEnrich';
 
 export interface TeamDataEnrichment {
@@ -63,7 +70,7 @@ export interface TeamDataEnrichment {
   reviewedBy?: string;
   errorMessage?: string;
   aiModel?: string;
-  fieldsMeta: Partial<Record<EnrichableField | 'logo', FieldEnrichmentMeta>>;
+  fieldsMeta: Partial<Record<FieldMetaKey, FieldEnrichmentMeta>>;
   scrapingDog?: {
     used: boolean;
     fetchedAt: string;

--- a/apps/web-api/src/team-enrichment/team-enrichment.types.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.types.ts
@@ -51,6 +51,8 @@ export type EnrichableTeamField = typeof ENRICHABLE_TEAM_FIELDS[number];
 export type EnrichableRelationField = typeof ENRICHABLE_RELATION_FIELDS[number];
 export type EnrichableField = EnrichableTeamField | EnrichableRelationField;
 
+export type ForceEnrichmentMode = 'all' | 'cannotEnrich';
+
 export interface TeamDataEnrichment {
   shouldEnrich: boolean;
   status: EnrichmentStatus;

--- a/apps/web-api/src/teams/teams.service.ts
+++ b/apps/web-api/src/teams/teams.service.ts
@@ -388,11 +388,14 @@ export class TeamsService {
       result = await this.updateTeamByUid(teamUid, team, tx, requestorEmail);
 
       // Track user changes to AI-enriched fields
-      const changedEnrichableFields = Object.keys(team).filter(
-        (key) => ENRICHABLE_TEAM_FIELDS.includes(key as any) && team[key] !== undefined,
-      );
-      if (changedEnrichableFields.length > 0) {
-        await this.teamEnrichmentService.handleUserFieldChange(teamUid, changedEnrichableFields, tx);
+      const changedEnrichableFieldValues: Record<string, unknown> = {};
+      for (const key of Object.keys(team)) {
+        if (ENRICHABLE_TEAM_FIELDS.includes(key as any) && team[key] !== undefined) {
+          changedEnrichableFieldValues[key] = team[key];
+        }
+      }
+      if (Object.keys(changedEnrichableFieldValues).length > 0) {
+        await this.teamEnrichmentService.handleUserFieldChange(teamUid, changedEnrichableFieldValues, tx);
       }
 
       const toAdd: any[] = [];

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -20,7 +20,7 @@ interface TeamDataEnrichment {
   reviewedAt?: string;             // ISO timestamp
   reviewedBy?: string;             // reviewer email
   errorMessage?: string;           // error details if FailedToEnrich
-  fieldsMeta: Partial<Record<EnrichableField | 'logo', {
+  fieldsMeta: Partial<Record<FieldMetaKey, {
     status: FieldEnrichmentStatus;
     confidence?: 'high' | 'medium' | 'low';
     source?: 'ai' | 'open-graph' | 'scrapingdog';

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -93,8 +93,8 @@ When a user later edits an enriched field, its `fieldsMeta[field].status` is fli
 ## Enrichment Behavior
 
 - Teams without a website are enriched using team name and other available identifiers; the AI will attempt to discover the website
-- Only fills null/empty fields — never overwrites existing data
-- **Re-run safe**: on subsequent runs, only fields with status `CannotEnrich` are retried. Fields already marked `Enriched` or `ChangedByUser` are skipped. Previous field statuses are preserved and merged with new results.
+- **Standard mode** (cron, `trigger-enrichment`): only fills null/empty fields — never overwrites existing data. On subsequent runs, only fields with status `CannotEnrich` are retried. Fields already marked `Enriched` or `ChangedByUser` are skipped. Previous field statuses are preserved and merged with new results.
+- **Force mode** (`trigger-force-enrichment`): re-queries every field except those marked `ChangedByUser`. Overwrites existing scalar values, replaces `industryTags` with the new set, and replaces `investmentFocus`. Logo is NOT re-fetched when the team already has one, because user-uploaded logos are indistinguishable from AI-set logos.
 - **Concurrency guard**: if enrichment is already `InProgress` for a team, duplicate requests are rejected immediately
 - **`enrichedBy`**: set to `'system-cron'` for cron jobs, `'manually'` for admin-triggered enrichment
 
@@ -168,6 +168,29 @@ Guard: AdminAuthGuard
 Finds all pending teams and enriches them. Teams already in progress are skipped.
 Returns `{ success, total, started, skipped, message }`.
 
+### Force Re-Enrichment for a Single Team
+```
+POST /v1/admin/teams/:uid/trigger-force-enrichment?mode=all|cannotEnrich
+Guard: AdminAuthGuard
+```
+Re-queues an already-enriched team for re-processing. Use when a team's data is stale
+(e.g. they changed their website, pivoted focus) or when a new AI model has been rolled out.
+
+- `mode=all` (default) — re-queries every enrichable field except those with status `ChangedByUser`. Overwrites existing AI-filled values with fresh results.
+- `mode=cannotEnrich` — retries only fields whose prior status was `CannotEnrich`. Leaves `Enriched` fields untouched.
+
+User-edited fields (`ChangedByUser`) are never overwritten in either mode.
+Returns `{ success, message }` on success, or `{ success: false, message }` if enrichment is already in progress. Does NOT require `IS_TEAM_ENRICHMENT_ENABLED`.
+
+### Force Re-Enrichment for All Completed Teams
+```
+POST /v1/admin/teams/trigger-force-enrichment?mode=all|cannotEnrich
+Guard: AdminAuthGuard
+```
+Finds all teams with `status ∈ { Enriched, Reviewed, Approved, FailedToEnrich }` and re-queues them using the same `mode` semantics as the single-team variant.
+Teams currently `InProgress` or `PendingEnrichment` are skipped.
+Returns `{ success, total, started, skipped, message }`.
+
 ### Team Lead Review
 ```
 PATCH /v1/teams/:uid/enrichment-review
@@ -179,7 +202,13 @@ Validates requestor is team lead of the team
 ## User Change Tracking
 
 When a team is updated via `updateTeamFromParticipantsRequest()`, if the team has `isAIGenerated=true`,
-any modified enrichable fields are marked as `ChangedByUser` in `fieldsMeta` (status is flipped but `confidence` and `source` are preserved as provenance).
+modified enrichable fields are marked as `ChangedByUser` in `fieldsMeta` (status is flipped but `confidence` and `source` are preserved as provenance).
+
+Two cases trigger the flip:
+- The field's prior status was `Enriched` (AI had filled it, user is now editing it).
+- The field's prior status was `CannotEnrich` and the user supplies a non-empty value (user is filling in what AI couldn't find).
+
+Marking these fields protects them from being overwritten by a later force re-enrichment run.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Description                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                         
### Force Re-Enrichment for a Single Team
```
POST /v1/admin/teams/:uid/trigger-force-enrichment?mode=all|cannotEnrich
Guard: AdminAuthGuard
```
Re-queues an already-enriched team for re-processing. Use when a team's data is stale
(e.g. they changed their website, pivoted focus) or when a new AI model has been rolled out.

- `mode=all` (default) — re-queries every enrichable field except those with status `ChangedByUser`. Overwrites existing AI-filled values with fresh results.
- `mode=cannotEnrich` — retries only fields whose prior status was `CannotEnrich`. Leaves `Enriched` fields untouched.

User-edited fields (`ChangedByUser`) are never overwritten in either mode.
Returns `{ success, message }` on success, or `{ success: false, message }` if enrichment is already in progress. Does NOT require `IS_TEAM_ENRICHMENT_ENABLED`.

### Force Re-Enrichment for All Completed Teams
```
POST /v1/admin/teams/trigger-force-enrichment?mode=all|cannotEnrich
Guard: AdminAuthGuard
```
Finds all teams with `status ∈ { Enriched, Reviewed, Approved, FailedToEnrich }` and re-queues them using the same `mode` semantics as the single-team variant.
Teams currently `InProgress` or `PendingEnrichment` are skipped.
Returns `{ success, total, started, skipped, message }`.                                  
  
