### PR TITLE
[Team Enrichment] Prevent changing user's data when team force enrichment is triggered

### DIFF
--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -352,6 +352,14 @@ export class TeamEnrichmentService {
           } else if (slotIsEmpty) {
             newFieldsMeta[field] = { status: FieldEnrichmentStatus.CannotEnrich };
           }
+        } else {
+          // Standard mode, field pre-populated by the user (predates enrichment, or
+          // filled in after a failed run). Mark ChangedByUser so a later force run
+          // treats it as user-controlled and won't overwrite it.
+          newFieldsMeta[field] = {
+            ...existingFieldsMeta[field],
+            status: FieldEnrichmentStatus.ChangedByUser,
+          };
         }
       }
 
@@ -392,6 +400,12 @@ export class TeamEnrichmentService {
         } else if (team.industryTags.length === 0) {
           newFieldsMeta.industryTags = { status: FieldEnrichmentStatus.CannotEnrich };
         }
+      } else if (!forceOverwrite && !tagsAlreadyEnriched && !tagsBlockedByUser && team.industryTags.length > 0) {
+        // Team had tags before any enrichment ran. Mark ChangedByUser so force mode won't replace them.
+        newFieldsMeta.industryTags = {
+          ...existingFieldsMeta.industryTags,
+          status: FieldEnrichmentStatus.ChangedByUser,
+        };
       }
 
       // Handle investmentFocus — skip Enriched in standard mode, skip ChangedByUser always.
@@ -428,6 +442,12 @@ export class TeamEnrichmentService {
         } else if (currentFocus.length === 0) {
           newFieldsMeta.investmentFocus = { status: FieldEnrichmentStatus.CannotEnrich };
         }
+      } else if (!forceOverwrite && !focusAlreadyEnriched && !focusBlockedByUser && currentFocus.length > 0) {
+        // Team had investmentFocus before any enrichment ran. Mark ChangedByUser so force mode won't replace it.
+        newFieldsMeta.investmentFocus = {
+          ...existingFieldsMeta.investmentFocus,
+          status: FieldEnrichmentStatus.ChangedByUser,
+        };
       }
 
       // Handle logo via OG tag scraping — only from a verified website

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -329,7 +329,7 @@ export class TeamEnrichmentService {
       for (const field of ENRICHABLE_TEAM_FIELDS) {
         const fieldStatus = existingFieldsMeta[field]?.status;
 
-        // User-controlled fields are never touched.
+        // Never overwrite user-edited fields.
         if (fieldStatus === FieldEnrichmentStatus.ChangedByUser) continue;
 
         const currentValue = team[field];

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -329,49 +329,57 @@ export class TeamEnrichmentService {
       for (const field of ENRICHABLE_TEAM_FIELDS) {
         const fieldStatus = existingFieldsMeta[field]?.status;
 
-        // Never overwrite user-edited fields.
+        // User-controlled fields are never touched.
         if (fieldStatus === FieldEnrichmentStatus.ChangedByUser) continue;
 
-        // In standard mode, skip fields already successfully enriched.
-        // In force mode, re-query them and overwrite with fresh AI data.
-        if (!forceOverwrite && fieldStatus === FieldEnrichmentStatus.Enriched) continue;
-
         const currentValue = team[field];
-        const newValue = aiResponse[field];
         const slotIsEmpty = !currentValue || currentValue.trim() === '';
 
-        if (slotIsEmpty || forceOverwrite) {
-          if (newValue) {
-            (updateData as any)[field] = newValue;
-            newFieldsMeta[field] = {
-              status: FieldEnrichmentStatus.Enriched,
-              confidence: toConfidence(aiResponse.confidence?.[field]),
-              source: EnrichmentSource.AI,
-            };
-            fieldsUpdatedCount++;
-          } else if (slotIsEmpty) {
-            newFieldsMeta[field] = { status: FieldEnrichmentStatus.CannotEnrich };
-          }
-        } else {
-          // Standard mode, field pre-populated by the user (predates enrichment, or
-          // filled in after a failed run). Mark ChangedByUser so a later force run
-          // treats it as user-controlled and won't overwrite it.
+        // User-owned: non-empty value with no prior AI enrichment. Applies in BOTH
+        // standard and force modes — force mode must NEVER overwrite user data whose
+        // only "crime" is that dataEnrichment was null on a team's first enrichment.
+        if (!slotIsEmpty && fieldStatus !== FieldEnrichmentStatus.Enriched) {
           newFieldsMeta[field] = {
             ...existingFieldsMeta[field],
             status: FieldEnrichmentStatus.ChangedByUser,
           };
+          continue;
         }
+
+        // Standard mode skips already-enriched fields; force mode re-queries them.
+        if (!forceOverwrite && fieldStatus === FieldEnrichmentStatus.Enriched) continue;
+
+        // Remaining shapes: slot empty, OR (slot non-empty && Enriched && forceOverwrite).
+        const newValue = aiResponse[field];
+        if (newValue) {
+          (updateData as any)[field] = newValue;
+          newFieldsMeta[field] = {
+            status: FieldEnrichmentStatus.Enriched,
+            confidence: toConfidence(aiResponse.confidence?.[field]),
+            source: EnrichmentSource.AI,
+          };
+          fieldsUpdatedCount++;
+        } else if (slotIsEmpty) {
+          newFieldsMeta[field] = { status: FieldEnrichmentStatus.CannotEnrich };
+        }
+        // Force mode + non-empty slot + AI returned null: preserve existing value + meta.
       }
 
-      // Handle industryTags — skip Enriched in standard mode, skip ChangedByUser always.
+      // Handle industryTags — same four-layer check as the scalar loop.
       const tagsStatus = existingFieldsMeta.industryTags?.status;
-      const tagsBlockedByUser = tagsStatus === FieldEnrichmentStatus.ChangedByUser;
-      const tagsAlreadyEnriched = tagsStatus === FieldEnrichmentStatus.Enriched;
-      const shouldProcessTags = forceOverwrite
-        ? !tagsBlockedByUser
-        : !tagsAlreadyEnriched && team.industryTags.length === 0;
 
-      if (shouldProcessTags) {
+      if (tagsStatus === FieldEnrichmentStatus.ChangedByUser) {
+        // User-controlled — skip entirely.
+      } else if (team.industryTags.length > 0 && tagsStatus !== FieldEnrichmentStatus.Enriched) {
+        // User-owned: team has tags with no prior AI enrichment. Protect in both modes.
+        newFieldsMeta.industryTags = {
+          ...existingFieldsMeta.industryTags,
+          status: FieldEnrichmentStatus.ChangedByUser,
+        };
+      } else if (!forceOverwrite && tagsStatus === FieldEnrichmentStatus.Enriched) {
+        // Standard mode, already enriched — skip.
+      } else {
+        // Either team has no tags, or force mode + Enriched — run AI matching.
         this.logger.debug(`Team ${teamUid}: AI returned industryTags = [${aiResponse.industryTags.join(', ')}]`);
         if (aiResponse.industryTags.length > 0) {
           const matchedTags = await this.prisma.industryTag.findMany({
@@ -384,7 +392,7 @@ export class TeamEnrichmentService {
             } industryTags: [${matchedTags.map((t) => t.title).join(', ')}]`
           );
           if (matchedTags.length > 0) {
-            // In force mode, replace the existing tag set; otherwise the team had no tags so connect is equivalent.
+            // Force mode: replace existing tag set; fresh-field mode: team had none, connect is equivalent.
             updateData.industryTags = forceOverwrite
               ? { set: matchedTags.map((t) => ({ uid: t.uid })) }
               : { connect: matchedTags.map((t) => ({ uid: t.uid })) };
@@ -400,24 +408,24 @@ export class TeamEnrichmentService {
         } else if (team.industryTags.length === 0) {
           newFieldsMeta.industryTags = { status: FieldEnrichmentStatus.CannotEnrich };
         }
-      } else if (!forceOverwrite && !tagsAlreadyEnriched && !tagsBlockedByUser && team.industryTags.length > 0) {
-        // Team had tags before any enrichment ran. Mark ChangedByUser so force mode won't replace them.
-        newFieldsMeta.industryTags = {
-          ...existingFieldsMeta.industryTags,
-          status: FieldEnrichmentStatus.ChangedByUser,
-        };
       }
 
-      // Handle investmentFocus — skip Enriched in standard mode, skip ChangedByUser always.
+      // Handle investmentFocus — same four-layer check.
       const currentFocus = team.investorProfile?.investmentFocus || [];
       const focusStatus = existingFieldsMeta.investmentFocus?.status;
-      const focusBlockedByUser = focusStatus === FieldEnrichmentStatus.ChangedByUser;
-      const focusAlreadyEnriched = focusStatus === FieldEnrichmentStatus.Enriched;
-      const shouldProcessFocus = forceOverwrite
-        ? !focusBlockedByUser
-        : !focusAlreadyEnriched && currentFocus.length === 0;
 
-      if (shouldProcessFocus) {
+      if (focusStatus === FieldEnrichmentStatus.ChangedByUser) {
+        // User-controlled — skip entirely.
+      } else if (currentFocus.length > 0 && focusStatus !== FieldEnrichmentStatus.Enriched) {
+        // User-owned: team has focus tags with no prior AI enrichment. Protect in both modes.
+        newFieldsMeta.investmentFocus = {
+          ...existingFieldsMeta.investmentFocus,
+          status: FieldEnrichmentStatus.ChangedByUser,
+        };
+      } else if (!forceOverwrite && focusStatus === FieldEnrichmentStatus.Enriched) {
+        // Standard mode, already enriched — skip.
+      } else {
+        // Either team has no focus, or force mode + Enriched — run AI matching.
         this.logger.debug(`Team ${teamUid}: AI returned investmentFocus = [${aiResponse.investmentFocus.join(', ')}]`);
         if (aiResponse.investmentFocus.length > 0) {
           if (team.investorProfile) {
@@ -442,12 +450,6 @@ export class TeamEnrichmentService {
         } else if (currentFocus.length === 0) {
           newFieldsMeta.investmentFocus = { status: FieldEnrichmentStatus.CannotEnrich };
         }
-      } else if (!forceOverwrite && !focusAlreadyEnriched && !focusBlockedByUser && currentFocus.length > 0) {
-        // Team had investmentFocus before any enrichment ran. Mark ChangedByUser so force mode won't replace it.
-        newFieldsMeta.investmentFocus = {
-          ...existingFieldsMeta.investmentFocus,
-          status: FieldEnrichmentStatus.ChangedByUser,
-        };
       }
 
       // Handle logo via OG tag scraping — only from a verified website
@@ -498,6 +500,10 @@ export class TeamEnrichmentService {
         }
       } else if (team.logoUid) {
         this.logger.log(`Team ${teamUid} (${team.name}) already has a logo, skipping logo fetch`);
+        // Logo predates enrichment and has no meta entry — treat as user-owned.
+        if (!existingFieldsMeta.logo) {
+          newFieldsMeta.logo = { status: FieldEnrichmentStatus.ChangedByUser };
+        }
       } else {
         this.logger.log(`Team ${teamUid} (${team.name}): no verified website available, skipping logo fetch`);
         newFieldsMeta.logo = { status: FieldEnrichmentStatus.CannotEnrich };

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -53,7 +53,7 @@ interface TeamDataEnrichment {
 Each enrichable field is tracked in `dataEnrichment.fieldsMeta[<field>].status`:
 - `Enriched` — field was empty and successfully filled by AI
 - `CannotEnrich` — field was empty but AI could not find a value
-- `ChangedByUser` — field was enriched by AI but later modified by a user
+- `ChangedByUser` — field is user-controlled: either (a) it was enriched by AI and later modified by a user, (b) it was already populated before enrichment ever ran, or (c) the user filled in a previously `CannotEnrich` field. In all three cases, future enrichment runs (including force mode) will not overwrite the field.
 
 ### Field Confidence & Source
 
@@ -201,14 +201,13 @@ Validates requestor is team lead of the team
 
 ## User Change Tracking
 
-When a team is updated via `updateTeamFromParticipantsRequest()`, if the team has `isAIGenerated=true`,
-modified enrichable fields are marked as `ChangedByUser` in `fieldsMeta` (status is flipped but `confidence` and `source` are preserved as provenance).
+`ChangedByUser` is the "user-controlled, don't touch" marker. It is set in three places so that a later force re-enrichment cannot overwrite user data:
 
-Two cases trigger the flip:
-- The field's prior status was `Enriched` (AI had filled it, user is now editing it).
-- The field's prior status was `CannotEnrich` and the user supplies a non-empty value (user is filling in what AI couldn't find).
+1. **During the first (or any non-force) enrichment run** — when the enrichment loop encounters a scalar field / `industryTags` / `investmentFocus` that is already non-empty, it writes `fieldsMeta[field] = { ..., status: ChangedByUser }`. This protects values the user had populated before enrichment ever ran.
+2. **When a user edits an AI-filled field** — `handleUserFieldChange()` flips `Enriched → ChangedByUser` for modified fields (called from `updateTeamFromParticipantsRequest()` when the team has `isAIGenerated=true`).
+3. **When a user fills in a `CannotEnrich` field** — `handleUserFieldChange()` also flips `CannotEnrich → ChangedByUser` when the user supplies a non-empty value for a field that AI had previously given up on.
 
-Marking these fields protects them from being overwritten by a later force re-enrichment run.
+In all cases, `confidence` and `source` from any prior status are preserved as provenance.
 
 ## Environment Variables
 

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -201,13 +201,19 @@ Validates requestor is team lead of the team
 
 ## User Change Tracking
 
-`ChangedByUser` is the "user-controlled, don't touch" marker. It is set in three places so that a later force re-enrichment cannot overwrite user data:
+### Governing invariant
 
-1. **During the first (or any non-force) enrichment run** — when the enrichment loop encounters a scalar field / `industryTags` / `investmentFocus` that is already non-empty, it writes `fieldsMeta[field] = { ..., status: ChangedByUser }`. This protects values the user had populated before enrichment ever ran.
+**If a field has a value and its prior `fieldsMeta[field].status` is not `Enriched`, it is user-owned. Enrichment never overwrites it and marks it `ChangedByUser`.**
+
+This rule applies in both standard and force modes. Force mode can re-query fields marked `Enriched` (AI-owned), but it will not touch anything the user has populated — including on a team's very first enrichment where `dataEnrichment` is `null`.
+
+### Where `ChangedByUser` is written
+
+1. **During any enrichment run** — when the loop encounters a scalar field / `industryTags` / `investmentFocus` / `logo` that is non-empty and has no prior `Enriched` status, it writes `fieldsMeta[field] = { ..., status: ChangedByUser }`. Covers pre-existing user data on a first-ever run (whether triggered by cron or by force-enrichment) and any orphan user-supplied values that bypassed the team-update flow.
 2. **When a user edits an AI-filled field** — `handleUserFieldChange()` flips `Enriched → ChangedByUser` for modified fields (called from `updateTeamFromParticipantsRequest()` when the team has `isAIGenerated=true`).
-3. **When a user fills in a `CannotEnrich` field** — `handleUserFieldChange()` also flips `CannotEnrich → ChangedByUser` when the user supplies a non-empty value for a field that AI had previously given up on.
+3. **When a user fills in a `CannotEnrich` field** — `handleUserFieldChange()` also flips `CannotEnrich → ChangedByUser` when the user supplies a non-empty value for a field AI had previously given up on.
 
-In all cases, `confidence` and `source` from any prior status are preserved as provenance.
+`confidence` and `source` from any prior status are preserved as provenance across the status flip.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Description

 `ChangedByUser` — field is user-controlled: 
*  It was enriched by AI and later modified by a user
* **new** It was already populated before enrichment ever ran
* The user filled in a previously `CannotEnrich` field. In all three cases, future enrichment runs (including force mode) will not overwrite the field.

