### PR TITLE
feat: [Access Control] approval flow

### DIFF
--- a/apps/web-api/prisma/migrations/20260421190000_add_member_approval_module/migration.sql
+++ b/apps/web-api/prisma/migrations/20260421190000_add_member_approval_module/migration.sql
@@ -1,0 +1,107 @@
+-- CreateEnum
+CREATE TYPE "MemberApprovalState" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- CreateTable
+CREATE TABLE "MemberApproval" (
+    "uid" TEXT NOT NULL,
+    "memberUid" TEXT NOT NULL,
+    "state" "MemberApprovalState" NOT NULL DEFAULT 'PENDING',
+    "requestedByUid" TEXT,
+    "reviewedByUid" TEXT,
+    "reason" TEXT,
+    "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reviewedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MemberApproval_pkey" PRIMARY KEY ("uid")
+);
+
+-- CreateTable
+CREATE TABLE "MemberApprovalEvent" (
+    "uid" TEXT NOT NULL,
+    "approvalUid" TEXT NOT NULL,
+    "memberUid" TEXT NOT NULL,
+    "fromState" "MemberApprovalState",
+    "toState" "MemberApprovalState" NOT NULL,
+    "actorUid" TEXT,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MemberApprovalEvent_pkey" PRIMARY KEY ("uid")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemberApproval_memberUid_key" ON "MemberApproval"("memberUid");
+CREATE INDEX "MemberApproval_state_idx" ON "MemberApproval"("state");
+CREATE INDEX "MemberApproval_requestedByUid_idx" ON "MemberApproval"("requestedByUid");
+CREATE INDEX "MemberApproval_reviewedByUid_idx" ON "MemberApproval"("reviewedByUid");
+
+CREATE INDEX "MemberApprovalEvent_approvalUid_idx" ON "MemberApprovalEvent"("approvalUid");
+CREATE INDEX "MemberApprovalEvent_memberUid_idx" ON "MemberApprovalEvent"("memberUid");
+CREATE INDEX "MemberApprovalEvent_actorUid_idx" ON "MemberApprovalEvent"("actorUid");
+
+-- AddForeignKey
+ALTER TABLE "MemberApproval"
+ADD CONSTRAINT "MemberApproval_memberUid_fkey"
+FOREIGN KEY ("memberUid") REFERENCES "Member"("uid")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "MemberApproval"
+ADD CONSTRAINT "MemberApproval_requestedByUid_fkey"
+FOREIGN KEY ("requestedByUid") REFERENCES "Member"("uid")
+ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "MemberApproval"
+ADD CONSTRAINT "MemberApproval_reviewedByUid_fkey"
+FOREIGN KEY ("reviewedByUid") REFERENCES "Member"("uid")
+ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "MemberApprovalEvent"
+ADD CONSTRAINT "MemberApprovalEvent_approvalUid_fkey"
+FOREIGN KEY ("approvalUid") REFERENCES "MemberApproval"("uid")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "MemberApprovalEvent"
+ADD CONSTRAINT "MemberApprovalEvent_memberUid_fkey"
+FOREIGN KEY ("memberUid") REFERENCES "Member"("uid")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "MemberApprovalEvent"
+ADD CONSTRAINT "MemberApprovalEvent_actorUid_fkey"
+FOREIGN KEY ("actorUid") REFERENCES "Member"("uid")
+ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Backfill from legacy accessLevel
+INSERT INTO "MemberApproval" (
+  "uid",
+  "memberUid",
+  "state",
+  "reason",
+  "requestedAt",
+  "reviewedAt",
+  "createdAt",
+  "updatedAt"
+)
+SELECT
+  CONCAT('ma_', "uid"),
+  "uid",
+  CASE
+    WHEN "accessLevel" IN ('L2', 'L3', 'L4') THEN 'APPROVED'::"MemberApprovalState"
+    WHEN "accessLevel" = 'REJECTED' THEN 'REJECTED'::"MemberApprovalState"
+    ELSE 'PENDING'::"MemberApprovalState"
+  END,
+  'Backfilled from legacy accessLevel',
+  COALESCE("createdAt", CURRENT_TIMESTAMP),
+  CASE
+    WHEN "accessLevel" IN ('L2', 'L3', 'L4', 'REJECTED') THEN COALESCE("accessLevelUpdatedAt", "updatedAt", CURRENT_TIMESTAMP)
+    ELSE NULL
+  END,
+  COALESCE("createdAt", CURRENT_TIMESTAMP),
+  COALESCE("updatedAt", CURRENT_TIMESTAMP)
+FROM "Member"
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "MemberApproval" ma
+  WHERE ma."memberUid" = "Member"."uid"
+);

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -215,7 +215,55 @@ model Member {
   roleAssignmentsGiven     RoleAssignment[]     @relation("MemberRoleAssignmentsGiven")
   memberPermissions        MemberPermission[]   @relation("MemberDirectPermissions")
   memberPermissionsGiven   MemberPermission[]   @relation("MemberDirectPermissionsGiven")
+  memberApproval                   MemberApproval?
+  requestedMemberApprovals         MemberApproval[]     @relation("MemberApprovalRequestedBy")
+  reviewedMemberApprovals          MemberApproval[]     @relation("MemberApprovalReviewedBy")
+  memberApprovalEvents             MemberApprovalEvent[] @relation("MemberApprovalEventMember")
+  actedMemberApprovalEvents        MemberApprovalEvent[] @relation("MemberApprovalEventActor")
 }
+
+
+model MemberApproval {
+  uid            String              @id @default(cuid())
+  memberUid      String              @unique
+  state          MemberApprovalState @default(PENDING)
+  requestedByUid String?
+  reviewedByUid  String?
+  reason         String?
+  requestedAt    DateTime            @default(now())
+  reviewedAt     DateTime?
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
+
+  member         Member              @relation(fields: [memberUid], references: [uid], onDelete: Cascade)
+  requestedBy    Member?             @relation("MemberApprovalRequestedBy", fields: [requestedByUid], references: [uid], onDelete: SetNull)
+  reviewedBy     Member?             @relation("MemberApprovalReviewedBy", fields: [reviewedByUid], references: [uid], onDelete: SetNull)
+  events         MemberApprovalEvent[]
+
+  @@index([state])
+  @@index([requestedByUid])
+  @@index([reviewedByUid])
+}
+
+model MemberApprovalEvent {
+  uid            String              @id @default(cuid())
+  approvalUid    String
+  memberUid      String
+  fromState      MemberApprovalState?
+  toState        MemberApprovalState
+  actorUid       String?
+  reason         String?
+  createdAt      DateTime            @default(now())
+
+  approval       MemberApproval      @relation(fields: [approvalUid], references: [uid], onDelete: Cascade)
+  member         Member              @relation("MemberApprovalEventMember", fields: [memberUid], references: [uid], onDelete: Cascade)
+  actor          Member?             @relation("MemberApprovalEventActor", fields: [actorUid], references: [uid], onDelete: SetNull)
+
+  @@index([approvalUid])
+  @@index([memberUid])
+  @@index([actorUid])
+}
+
 
 model MemberRole {
   id        Int      @id @default(autoincrement())
@@ -229,6 +277,12 @@ model MemberRole {
 enum ParticipantType {
   MEMBER
   TEAM
+}
+
+enum MemberApprovalState {
+  PENDING
+  APPROVED
+  REJECTED
 }
 
 enum ApprovalStatus {

--- a/apps/web-api/src/access-control-v2/access-control-v2.module.ts
+++ b/apps/web-api/src/access-control-v2/access-control-v2.module.ts
@@ -8,9 +8,10 @@ import { DebugAccessControlV2Controller } from './controllers/debug-access-contr
 import { SelfAccessControlV2Controller } from './controllers/self-access-control-v2.controller';
 import { AdminAccessControlV2MetaController } from './controllers/admin-access-control-v2-meta.controller';
 import { AccessControlV2Service } from './services/access-control-v2.service';
+import { MemberApprovalsModule } from '../member-approvals/member-approvals.module';
 
 @Module({
-  imports: [SharedModule],
+  imports: [SharedModule, MemberApprovalsModule],
   controllers: [
     AdminAccessControlV2Controller,
     DebugAccessControlV2Controller,

--- a/apps/web-api/src/access-control-v2/services/access-control-v2.service.ts
+++ b/apps/web-api/src/access-control-v2/services/access-control-v2.service.ts
@@ -1,9 +1,13 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../shared/prisma.service';
+import { MemberApprovalsService } from '../../member-approvals/member-approvals.service';
 
 @Injectable()
 export class AccessControlV2Service {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly memberApprovalsService: MemberApprovalsService,
+  ) {}
 
   async listPolicies() {
     const policies = await this.prisma.policy.findMany({
@@ -192,6 +196,7 @@ export class AccessControlV2Service {
   }
 
   async assignPolicy(memberUid: string, policyCode: string, assignedByUid?: string) {
+    await this.memberApprovalsService.assertApproved(memberUid);
     const member = await this.ensureMember(memberUid);
     const policy = await this.ensurePolicy(policyCode);
     if (assignedByUid) await this.ensureMember(assignedByUid);
@@ -234,6 +239,7 @@ export class AccessControlV2Service {
   }
 
   async grantDirectPermission(memberUid: string, permissionCode: string, grantedByUid?: string, reason?: string) {
+    await this.memberApprovalsService.assertApproved(memberUid);
     const member = await this.ensureMember(memberUid);
     const permission = await this.ensurePermission(permissionCode);
     if (grantedByUid) await this.ensureMember(grantedByUid);

--- a/apps/web-api/src/app.module.ts
+++ b/apps/web-api/src/app.module.ts
@@ -67,6 +67,7 @@ import { DealRequestsModule } from './deal-requests/deal-requests.module';
 import { ArticleRequestsModule } from './article-requests/article-requests.module';
 import { JobOpeningsModule } from './job-openings/job-openings.module';
 
+import { MemberApprovalsModule } from './member-approvals/member-approvals.module';
 @Module({
   controllers: [AppController, MetricsController],
   imports: [

--- a/apps/web-api/src/demo-days/demo-day-participants.service.ts
+++ b/apps/web-api/src/demo-days/demo-day-participants.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { DemoDayParticipant, Prisma } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
+import { MemberApprovalsService } from '../member-approvals/member-approvals.service';
 import { DemoDaysService } from './demo-days.service';
 import { AnalyticsService } from '../analytics/service/analytics.service';
 import { TeamsService } from '../teams/teams.service';

--- a/apps/web-api/src/demo-days/demo-days.service.ts
+++ b/apps/web-api/src/demo-days/demo-days.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { DemoDay, DemoDayParticipantStatus, DemoDayStatus, PushNotificationCategory } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
+import { MemberApprovalsService } from '../member-approvals/member-approvals.service';
 import { AnalyticsService } from '../analytics/service/analytics.service';
 import { MembersService } from '../members/members.service';
 import { PushNotificationsService } from '../push-notifications/push-notifications.service';

--- a/apps/web-api/src/member-approvals/dto/create-member-approval.dto.ts
+++ b/apps/web-api/src/member-approvals/dto/create-member-approval.dto.ts
@@ -1,0 +1,4 @@
+export class CreateMemberApprovalDto {
+  memberUid: string;
+  reason?: string;
+}

--- a/apps/web-api/src/member-approvals/dto/review-member-approval.dto.ts
+++ b/apps/web-api/src/member-approvals/dto/review-member-approval.dto.ts
@@ -1,0 +1,4 @@
+export class ReviewMemberApprovalDto {
+  state: 'APPROVED' | 'REJECTED' | 'PENDING';
+  reason?: string;
+}

--- a/apps/web-api/src/member-approvals/member-approvals.controller.ts
+++ b/apps/web-api/src/member-approvals/member-approvals.controller.ts
@@ -1,0 +1,42 @@
+import { Body, Controller, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { AdminAuthGuard } from '../guards/admin-auth.guard';
+import { MemberApprovalsService } from './member-approvals.service';
+import { CreateMemberApprovalDto } from './dto/create-member-approval.dto';
+import { ReviewMemberApprovalDto } from './dto/review-member-approval.dto';
+import { NoCache } from '../decorators/no-cache.decorator';
+
+@Controller('v1/admin/member-approvals')
+@UseGuards(AdminAuthGuard)
+export class MemberApprovalsController {
+  constructor(private readonly service: MemberApprovalsService) {}
+
+  @NoCache()
+  @Get()
+  list(@Query('state') state?: 'PENDING' | 'APPROVED' | 'REJECTED') {
+    return this.service.list(state);
+  }
+
+  @NoCache()
+  @Get(':memberUid')
+  get(@Param('memberUid') memberUid: string) {
+    return this.service.get(memberUid);
+  }
+
+  @Post()
+  create(@Req() req: any, @Body() body: CreateMemberApprovalDto) {
+    return this.service.create({
+      memberUid: body.memberUid,
+      reason: body.reason,
+      requestedByUid: req.user?.memberUid ?? null,
+    });
+  }
+
+  @Patch(':memberUid')
+  review(@Req() req: any, @Param('memberUid') memberUid: string, @Body() body: ReviewMemberApprovalDto) {
+    return this.service.review(memberUid, {
+      state: body.state,
+      reason: body.reason,
+      reviewedByUid: req.user?.memberUid ?? null,
+    });
+  }
+}

--- a/apps/web-api/src/member-approvals/member-approvals.e2e.spec.ts
+++ b/apps/web-api/src/member-approvals/member-approvals.e2e.spec.ts
@@ -1,0 +1,5 @@
+describe('MemberApprovals', () => {
+  it('placeholder', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/apps/web-api/src/member-approvals/member-approvals.module.ts
+++ b/apps/web-api/src/member-approvals/member-approvals.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { SharedModule } from '../shared/shared.module';
+import { JwtService } from '../utils/jwt/jwt.service';
+import { AdminAuthGuard } from '../guards/admin-auth.guard';
+import { MemberApprovalsController } from './member-approvals.controller';
+import { MemberApprovalsService } from './member-approvals.service';
+
+@Module({
+  imports: [SharedModule],
+  controllers: [MemberApprovalsController],
+  providers: [MemberApprovalsService, AdminAuthGuard, JwtService],
+  exports: [MemberApprovalsService],
+})
+export class MemberApprovalsModule {}

--- a/apps/web-api/src/member-approvals/member-approvals.service.ts
+++ b/apps/web-api/src/member-approvals/member-approvals.service.ts
@@ -1,0 +1,228 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { PrismaService } from '../shared/prisma.service';
+
+@Injectable()
+export class MemberApprovalsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(state?: 'PENDING' | 'APPROVED' | 'REJECTED') {
+    return this.prisma.memberApproval.findMany({
+      where: state ? { state } : {},
+      include: {
+        member: {
+          select: {
+            uid: true,
+            name: true,
+            email: true,
+            accessLevel: true,
+            role: true,
+            createdAt: true,
+          },
+        },
+        requestedBy: {
+          select: { uid: true, name: true, email: true },
+        },
+        reviewedBy: {
+          select: { uid: true, name: true, email: true },
+        },
+      },
+      orderBy: [
+        { state: 'asc' },
+        { requestedAt: 'desc' },
+      ],
+    });
+  }
+
+  async get(memberUid: string) {
+    const approval = await this.prisma.memberApproval.findUnique({
+      where: { memberUid },
+      include: {
+        member: {
+          select: {
+            uid: true,
+            name: true,
+            email: true,
+            accessLevel: true,
+            role: true,
+            createdAt: true,
+          },
+        },
+        requestedBy: {
+          select: { uid: true, name: true, email: true },
+        },
+        reviewedBy: {
+          select: { uid: true, name: true, email: true },
+        },
+        events: {
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    });
+
+    if (!approval) {
+      throw new NotFoundException(`Member approval not found for memberUid: ${memberUid}`);
+    }
+
+    return approval;
+  }
+
+  async create(body: {
+    memberUid: string;
+    requestedByUid?: string | null;
+    reason?: string;
+  }) {
+    const member = await this.prisma.member.findUnique({
+      where: { uid: body.memberUid },
+      select: { uid: true },
+    });
+
+    if (!member) {
+      throw new NotFoundException(`Member not found: ${body.memberUid}`);
+    }
+
+    if (body.requestedByUid) {
+      const requestedBy = await this.prisma.member.findUnique({
+        where: { uid: body.requestedByUid },
+        select: { uid: true },
+      });
+
+      if (!requestedBy) {
+        throw new NotFoundException(`RequestedBy member not found: ${body.requestedByUid}`);
+      }
+    }
+
+    const existing = await this.prisma.memberApproval.findUnique({
+      where: { memberUid: body.memberUid },
+      select: { uid: true },
+    });
+
+    if (existing) {
+      throw new ConflictException(`Approval already exists for member: ${body.memberUid}`);
+    }
+
+    const approval = await this.prisma.memberApproval.create({
+      data: {
+        memberUid: body.memberUid,
+        requestedByUid: body.requestedByUid ?? null,
+        reason: body.reason ?? null,
+        state: 'PENDING',
+      },
+    });
+
+    await this.prisma.memberApprovalEvent.create({
+      data: {
+        approvalUid: approval.uid,
+        memberUid: body.memberUid,
+        fromState: null,
+        toState: 'PENDING',
+        actorUid: body.requestedByUid ?? null,
+        reason: body.reason ?? 'Approval requested',
+      },
+    });
+
+    return this.get(body.memberUid);
+  }
+
+  async review(
+    memberUid: string,
+    body: {
+      state: 'APPROVED' | 'REJECTED' | 'PENDING';
+      reviewedByUid?: string | null;
+      reason?: string;
+    },
+  ) {
+    const approval = await this.prisma.memberApproval.findUnique({
+      where: { memberUid },
+    });
+
+    if (!approval) {
+      throw new NotFoundException(`Member approval not found for memberUid: ${memberUid}`);
+    }
+
+    if (body.reviewedByUid) {
+      const reviewer = await this.prisma.member.findUnique({
+        where: { uid: body.reviewedByUid },
+        select: { uid: true },
+      });
+
+      if (!reviewer) {
+        throw new NotFoundException(`Reviewer member not found: ${body.reviewedByUid}`);
+      }
+    }
+
+    const updated = await this.prisma.memberApproval.update({
+      where: { memberUid },
+      data: {
+        state: body.state,
+        reviewedByUid: body.reviewedByUid ?? null,
+        reviewedAt: new Date(),
+        reason: body.reason ?? null,
+      },
+    });
+
+    await this.prisma.memberApprovalEvent.create({
+      data: {
+        approvalUid: updated.uid,
+        memberUid,
+        fromState: approval.state,
+        toState: body.state,
+        actorUid: body.reviewedByUid ?? null,
+        reason: body.reason ?? null,
+      },
+    });
+
+    return this.get(memberUid);
+  }
+
+
+  async ensureApprovalExists(memberUid: string, requestedByUid?: string | null) {
+    const existing = await this.prisma.memberApproval.findUnique({
+      where: { memberUid },
+      select: { uid: true },
+    });
+
+    if (existing) {
+      return existing;
+    }
+
+    const approval = await this.prisma.memberApproval.create({
+      data: {
+        memberUid,
+        requestedByUid: requestedByUid ?? null,
+        state: 'PENDING',
+        reason: 'Auto-created on member creation',
+      },
+    });
+
+    await this.prisma.memberApprovalEvent.create({
+      data: {
+        approvalUid: approval.uid,
+        memberUid,
+        fromState: null,
+        toState: 'PENDING',
+        actorUid: requestedByUid ?? null,
+        reason: 'Auto-created on member creation',
+      },
+    });
+
+    return approval;
+  }
+
+  async assertApproved(memberUid: string) {
+    const approval = await this.prisma.memberApproval.findUnique({
+      where: { memberUid },
+      select: { state: true },
+    });
+
+    if (!approval || approval.state !== 'APPROVED') {
+      throw new ForbiddenException(
+        `Member ${memberUid} is not approved. Policies and direct permissions can be assigned only to APPROVED members.`,
+      );
+    }
+  }
+}

--- a/apps/web-api/src/members/members.module.ts
+++ b/apps/web-api/src/members/members.module.ts
@@ -13,6 +13,7 @@ import { NotificationSettingsModule } from '../notification-settings/notificatio
 import { OfficeHoursModule } from '../office-hours/office-hours.module';
 import { TeamsModule } from "../teams/teams.module";
 import { OpenSearchModule } from '../opensearch/opensearch.module';
+import { MemberApprovalsModule } from '../member-approvals/member-approvals.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { OpenSearchModule } from '../opensearch/opensearch.module';
     ParticipantsRequestModule,
     HuskyModule,
     OpenSearchModule,
+    forwardRef(() => MemberApprovalsModule),
     forwardRef(() => NotificationSettingsModule),
     forwardRef(() => OfficeHoursModule),
     forwardRef(() => TeamsModule)

--- a/apps/web-api/src/members/members.service.ts
+++ b/apps/web-api/src/members/members.service.ts
@@ -13,6 +13,7 @@ import axios from 'axios';
 import * as path from 'path';
 import { Member, Prisma } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
+import { MemberApprovalsService } from '../member-approvals/member-approvals.service';
 import { AirtableMemberSchema } from '../utils/airtable/schema/airtable-member.schema';
 import { FileMigrationService } from '../utils/file-migration/file-migration.service';
 import { LocationTransferService } from '../utils/location-transfer/location-transfer.service';
@@ -62,7 +63,8 @@ export class MembersService {
     private notificationSettingsService: NotificationSettingsService,
     @Inject(forwardRef(() => OfficeHoursService))
     private officeHoursService: OfficeHoursService,
-    private openSearchService: OpenSearchService
+    private openSearchService: OpenSearchService,
+    private memberApprovalsService: MemberApprovalsService
   ) {}
 
   /**
@@ -77,9 +79,13 @@ export class MembersService {
     tx: Prisma.TransactionClient = this.prisma
   ): Promise<Member> {
     try {
-      return await tx.member.create({
+      const createdMember = await tx.member.create({
         data: member,
       });
+
+      await this.memberApprovalsService.ensureApprovalExists(createdMember.uid);
+
+      return createdMember;
     } catch (error) {
       return this.handleErrors(error);
     }
@@ -3710,6 +3716,8 @@ export class MembersService {
         accessLevel: 'L0', // default access level for newly created SSO users
       },
     });
+
+    await this.memberApprovalsService.ensureApprovalExists(newMember.uid);
 
     this.logger.info(
       `MembersService.createMemberFromSso → New member created. uid=${newMember.uid}, id=${newMember.id}, email=${newMember.email}`


### PR DESCRIPTION
## Summary

This PR introduces a separate member approval flow and decouples it from `accessLevel`.

## What was done

### 1. Member Approval module
- Added `MemberApproval` and `MemberApprovalEvent` models
- Introduced approval states: `PENDING`, `APPROVED`, `REJECTED`
- Added audit trail for all state transitions

### 2. API
- Added admin endpoints:
  - `GET /v1/admin/member-approvals`
  - `GET /v1/admin/member-approvals/:memberUid`
  - `POST /v1/admin/member-approvals`
  - `PATCH /v1/admin/member-approvals/:memberUid`


### 3. Auto approval creation
- `MemberApproval` is now automatically created with `PENDING` state when a new `Member` is created
- Eliminates need for manual approval request creation

### 4. RBAC integration
- Updated `AccessControlV2Service`:
  - `assignPolicy`
  - `grantDirectPermission`
- Both now require `APPROVED` state

### 5. Backward compatibility
- Existing `accessLevel` remains unchanged
- Approval flow works as a separate layer
- Includes backfill migration from `accessLevel`

