### PR TITLE
Fix incorrect types for JobOpening

### DIFF
--- a/apps/web-api/src/job-openings/job-openings-enrichment.service.ts
+++ b/apps/web-api/src/job-openings/job-openings-enrichment.service.ts
@@ -112,7 +112,7 @@ export class JobOpeningsEnrichmentService {
         roleTitle: job.roleTitle,
         roleCategory: job.roleCategory ?? null,
         seniority: job.seniority ?? null,
-        location: job.location ?? null,
+        location: job.location ?? [],
         workMode: job.workMode ?? null,
         sourceLink: job.sourceLink ?? null,
         postedDate: job.postedDate?.toISOString() ?? null,

--- a/apps/web-api/src/scripts/import-job-openings.ts
+++ b/apps/web-api/src/scripts/import-job-openings.ts
@@ -147,7 +147,7 @@ async function main() {
         department: row.Department || null,
         seniority: mapSeniority(row.Seniority),
         summary: row.Summary || null,
-        location: row.Location || null,
+        location: row.Location ? [row.Location] : [],
         workMode: null,
         detectionDate,
         sourceType: row['Source Type'] || null,

--- a/libs/contracts/src/schema/team-job-enrichment.ts
+++ b/libs/contracts/src/schema/team-job-enrichment.ts
@@ -79,7 +79,7 @@ export const JobOpeningsPerTeamResponseSchema = z.object({
       roleTitle: z.string(),
       roleCategory: z.string().nullable(),
       seniority: z.string().nullable(),
-      location: z.string().nullable(),
+      location: z.array(z.string()),
       workMode: z.string().nullable(),
       sourceLink: z.string().nullable(),
       postedDate: z.string().nullable(),


### PR DESCRIPTION
Fix for the cb6e31fbae522fb300e9e13b5fa7e67103c65a0b

## Summary 
  - Fix TypeScript build errors after JobOpening.location was changed from String to String[]                                                                                                                                                                            
  - Update response schema, enrichment service, and CSV import script to use string arrays   