### PR TITLE
feat: job alerts v1 (backend)

### DIFF
--- a/apps/web-api/prisma/migrations/20260428033129_add_job_alerts/migration.sql
+++ b/apps/web-api/prisma/migrations/20260428033129_add_job_alerts/migration.sql
@@ -1,0 +1,56 @@
+-- CreateTable
+CREATE TABLE "JobAlert" (
+    "id" SERIAL NOT NULL,
+    "uid" TEXT NOT NULL,
+    "memberUid" TEXT NOT NULL,
+    "name" VARCHAR(120) NOT NULL,
+    "filterState" JSONB NOT NULL,
+    "filterStateHash" TEXT NOT NULL,
+    "isPaused" BOOLEAN NOT NULL DEFAULT false,
+    "lastSentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "JobAlert_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "JobAlertSendRun" (
+    "id" SERIAL NOT NULL,
+    "uid" TEXT NOT NULL,
+    "alertUid" TEXT NOT NULL,
+    "ingestRunId" TEXT NOT NULL,
+    "matchCount" INTEGER NOT NULL,
+    "emailType" TEXT NOT NULL,
+    "sentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "JobAlertSendRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "JobAlert_uid_key" ON "JobAlert"("uid");
+
+-- CreateIndex
+CREATE INDEX "JobAlert_memberUid_createdAt_idx" ON "JobAlert"("memberUid", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "JobAlert_isPaused_deletedAt_idx" ON "JobAlert"("isPaused", "deletedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "JobAlert_memberUid_filterStateHash_key" ON "JobAlert"("memberUid", "filterStateHash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "JobAlertSendRun_uid_key" ON "JobAlertSendRun"("uid");
+
+-- CreateIndex
+CREATE INDEX "JobAlertSendRun_ingestRunId_idx" ON "JobAlertSendRun"("ingestRunId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "JobAlertSendRun_alertUid_ingestRunId_key" ON "JobAlertSendRun"("alertUid", "ingestRunId");
+
+-- AddForeignKey
+ALTER TABLE "JobAlert" ADD CONSTRAINT "JobAlert_memberUid_fkey" FOREIGN KEY ("memberUid") REFERENCES "Member"("uid") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "JobAlertSendRun" ADD CONSTRAINT "JobAlertSendRun_alertUid_fkey" FOREIGN KEY ("alertUid") REFERENCES "JobAlert"("uid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web-api/prisma/migrations/20260428180000_job_alert_drop_is_paused_and_active_unique/migration.sql
+++ b/apps/web-api/prisma/migrations/20260428180000_job_alert_drop_is_paused_and_active_unique/migration.sql
@@ -1,0 +1,11 @@
+-- Drop the now-unused isPaused column and its composite index
+DROP INDEX IF EXISTS "JobAlert_isPaused_deletedAt_idx";
+ALTER TABLE "JobAlert" DROP COLUMN IF EXISTS "isPaused";
+
+-- Replace it with a deletedAt index (used by the active-alert lookup)
+CREATE INDEX IF NOT EXISTS "JobAlert_deletedAt_idx" ON "JobAlert"("deletedAt");
+
+-- Enforce single active alert per member at the DB level
+CREATE UNIQUE INDEX IF NOT EXISTS "JobAlert_active_per_member"
+  ON "JobAlert"("memberUid")
+  WHERE "deletedAt" IS NULL;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -222,6 +222,7 @@ model Member {
   reviewedMemberApprovals   MemberApproval[]      @relation("MemberApprovalReviewedBy")
   memberApprovalEvents      MemberApprovalEvent[] @relation("MemberApprovalEventMember")
   actedMemberApprovalEvents MemberApprovalEvent[] @relation("MemberApprovalEventActor")
+  jobAlerts                 JobAlert[]            @relation("MemberJobAlerts")
 }
 
 model MemberApproval {
@@ -2055,4 +2056,37 @@ model TeamJobEnrichment {
   @@index([teamUid])
   @@index([needsReview])
   @@index([dataDiscrepancyFlag])
+}
+
+model JobAlert {
+  id              Int               @id @default(autoincrement())
+  uid             String            @unique @default(cuid())
+  memberUid       String
+  member          Member            @relation("MemberJobAlerts", fields: [memberUid], references: [uid], onDelete: Cascade)
+  name            String            @db.VarChar(120)
+  filterState     Json
+  filterStateHash String
+  lastSentAt      DateTime?
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
+  deletedAt       DateTime?
+  sendRuns        JobAlertSendRun[] @relation("JobAlertSendRuns")
+
+  @@unique([memberUid, filterStateHash])
+  @@index([memberUid, createdAt(sort: Desc)])
+  @@index([deletedAt])
+}
+
+model JobAlertSendRun {
+  id          Int      @id @default(autoincrement())
+  uid         String   @unique @default(cuid())
+  alertUid    String
+  alert       JobAlert @relation("JobAlertSendRuns", fields: [alertUid], references: [uid], onDelete: Cascade)
+  ingestRunId String
+  matchCount  Int
+  emailType   String
+  sentAt      DateTime @default(now())
+
+  @@unique([alertUid, ingestRunId])
+  @@index([ingestRunId])
 }

--- a/apps/web-api/project.json
+++ b/apps/web-api/project.json
@@ -23,7 +23,9 @@
           "apps/web-api/src/shared/linkedinVerifiedAdmin.hbs",
           "apps/web-api/src/shared/memberApproved.hbs",
           "apps/web-api/src/shared/memberRejected.hbs",
-          "apps/web-api/src/shared/contactSupport.hbs"
+          "apps/web-api/src/shared/contactSupport.hbs",
+          "apps/web-api/src/shared/jobAlertConfirmation.hbs",
+          "apps/web-api/src/shared/jobAlertDigest.hbs"
         ]
       },
       "configurations": {
@@ -47,6 +49,17 @@
         "outputPath": "dist/apps/web-api/cli",
         "main": "apps/web-api/src/cli.ts",
         "outputFileName": "cli.js",
+        "tsConfig": "apps/web-api/tsconfig.build.json",
+        "tsPlugins": ["@nestjs/swagger/plugin"]
+      }
+    },
+    "build-jobs-seed": {
+      "executor": "@nrwl/node:webpack",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/web-api/jobs-seed",
+        "main": "apps/web-api/src/jobs-seed.ts",
+        "outputFileName": "jobs-seed.js",
         "tsConfig": "apps/web-api/tsconfig.build.json",
         "tsPlugins": ["@nestjs/swagger/plugin"]
       }

--- a/apps/web-api/src/app.module.ts
+++ b/apps/web-api/src/app.module.ts
@@ -6,6 +6,7 @@ import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { InternalServiceThrottlerGuard } from './guards/internal-service-throttler.guard';
 import { ScheduleModule } from '@nestjs/schedule';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import * as redisStore from 'cache-manager-redis-store';
 import { AppController } from './app.controller';
 import { FundingStagesModule } from './funding-stages/funding-stages.module';
@@ -67,6 +68,7 @@ import { DealsModule } from './deals/deals.module';
 import { DealRequestsModule } from './deal-requests/deal-requests.module';
 import { ArticleRequestsModule } from './article-requests/article-requests.module';
 import { JobOpeningsModule } from './job-openings/job-openings.module';
+import { JobAlertsModule } from './job-alerts/job-alerts.module';
 
 @Module({
   controllers: [AppController, MetricsController],
@@ -104,6 +106,7 @@ import { JobOpeningsModule } from './job-openings/job-openings.module';
       },
     }),
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot(),
     MembersModule,
     HealthModule,
     TeamsModule,
@@ -154,6 +157,7 @@ import { JobOpeningsModule } from './job-openings/job-openings.module';
     DealRequestsModule,
     ArticleRequestsModule,
     JobOpeningsModule,
+    JobAlertsModule,
   ],
   providers: [
     {

--- a/apps/web-api/src/events/events.module.ts
+++ b/apps/web-api/src/events/events.module.ts
@@ -17,14 +17,16 @@ import { TeamsModule } from '../teams/teams.module';
   providers: [EventsService, EventsToolingService, EventsConsumer, EventConsumerHelper, EventGuestSyncHelper],
   imports: [
     SqsModule.register({
-      consumers: [
-        {
-          name: 'events',
-          queueUrl: process.env.EVENTS_QUEUE_URL || '',
-          region: process.env.AWS_REGION,
-          pollingWaitTimeMs: (process.env.POLLING_INTERVAL as unknown as number) || 5000
-        },
-      ],
+      consumers: process.env.EVENTS_QUEUE_URL
+        ? [
+            {
+              name: 'events',
+              queueUrl: process.env.EVENTS_QUEUE_URL,
+              region: process.env.AWS_REGION,
+              pollingWaitTimeMs: (process.env.POLLING_INTERVAL as unknown as number) || 5000,
+            },
+          ]
+        : [],
       producers: [],
     }),
     forwardRef(() => PLEventsModule),

--- a/apps/web-api/src/job-alerts/job-alerts-dispatch.service.ts
+++ b/apps/web-api/src/job-alerts/job-alerts-dispatch.service.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import Handlebars from 'handlebars';
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import pLimit from 'p-limit';
 import type { JobAlertFilterState } from 'libs/contracts/src/schema/job-alert';
 import { JobOpeningsQueryService } from '../job-openings/job-openings-query.service';
 import { PrismaService } from '../shared/prisma.service';
@@ -15,6 +16,8 @@ import { seniorityLabel } from './job-alerts.utils';
 const DIGEST_TEMPLATE = path.join(__dirname, 'shared', 'jobAlertDigest.hbs');
 const CONFIRMATION_TEMPLATE = path.join(__dirname, 'shared', 'jobAlertConfirmation.hbs');
 const MAX_ROLES_IN_EMAIL = 10;
+const BATCH_SIZE = 50;
+const EMAIL_CONCURRENCY = 5;
 
 const buildAppUrl = (pathname: string) => {
   const base = process.env.WEB_UI_BASE_URL || process.env.APPLICATION_BASE_URL || 'https://www.plnetwork.io';
@@ -28,13 +31,13 @@ export class JobAlertsDispatchService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly jobOpeningsQueryService: JobOpeningsQueryService,
-    private readonly awsService: AwsService,
+    private readonly awsService: AwsService
   ) {}
 
   @OnEvent(JOB_INGEST_COMPLETED)
   async onJobIngestCompleted(payload: JobIngestCompletedPayload) {
     this.logger.log(
-      `Received ${JOB_INGEST_COMPLETED} runId=${payload.runId} created=${payload.created} updated=${payload.updated}`,
+      `Received ${JOB_INGEST_COMPLETED} runId=${payload.runId} created=${payload.created} updated=${payload.updated}`
     );
     if (payload.created === 0 && payload.updated === 0) {
       this.logger.log('Skipping dispatch: no new or updated jobs in this run');
@@ -44,81 +47,134 @@ export class JobAlertsDispatchService {
   }
 
   async dispatch(payload: JobIngestCompletedPayload): Promise<{ sent: number; skipped: number }> {
-    const activeAlerts = await this.prisma.jobAlert.findMany({
-      where: { deletedAt: null },
-      select: {
-        uid: true,
-        memberUid: true,
-        name: true,
-        filterState: true,
-        lastSentAt: true,
-        createdAt: true,
-        member: { select: { uid: true, email: true, name: true, deletedAt: true } },
-      },
-    });
-
     let sent = 0;
     let skipped = 0;
+    let cursor: string | undefined;
 
-    for (const alert of activeAlerts) {
-      if (!alert.member?.email || alert.member.deletedAt) {
-        skipped++;
-        continue;
-      }
-
-      const existingRun = await this.prisma.jobAlertSendRun.findUnique({
-        where: { alertUid_ingestRunId: { alertUid: alert.uid, ingestRunId: payload.runId } },
-        select: { uid: true },
+    do {
+      const batch = await this.prisma.jobAlert.findMany({
+        where: { deletedAt: null },
+        select: {
+          uid: true,
+          memberUid: true,
+          name: true,
+          filterState: true,
+          lastSentAt: true,
+          createdAt: true,
+          member: { select: { uid: true, email: true, name: true, deletedAt: true } },
+        },
+        take: BATCH_SIZE,
+        skip: cursor ? 1 : 0,
+        cursor: cursor ? { uid: cursor } : undefined,
+        orderBy: { uid: 'asc' },
       });
-      if (existingRun) {
-        this.logger.log(`Idempotency: alert ${alert.uid} already dispatched for run ${payload.runId}`);
-        skipped++;
-        continue;
-      }
 
-      const filterState = alert.filterState as unknown as JobAlertFilterState;
-      const sinceTs = alert.lastSentAt ?? alert.createdAt;
-      const matches = await this.jobOpeningsQueryService.findNewMatchesSince(
-        { ...filterState, page: 1, limit: 50, sort: 'newest' },
-        sinceTs,
+      if (batch.length === 0) break;
+
+      const validAlerts = batch.filter(
+        (alert): alert is typeof alert & { member: NonNullable<typeof alert.member> & { email: string } } =>
+          Boolean(alert.member?.email && !alert.member.deletedAt)
+      );
+      skipped += batch.length - validAlerts.length;
+
+      const alreadySent = await this.getAlreadySentAlerts(
+        validAlerts.map((a) => a.uid),
+        payload.runId
       );
 
-      if (matches.length === 0) {
-        this.logger.log(`Alert ${alert.uid}: no new matches since ${sinceTs.toISOString()}`);
-        skipped++;
-        continue;
+      const alertsToProcess = validAlerts.filter((alert) => !alreadySent.has(alert.uid));
+      skipped += validAlerts.length - alertsToProcess.length;
+
+      if (alertsToProcess.length > 0) {
+        const batchResults = await this.processBatch(alertsToProcess, payload.runId);
+        sent += batchResults.sent;
+        skipped += batchResults.skipped;
       }
 
-      try {
-        await this.sendDigestEmail({
-          alertUid: alert.uid,
-          alertName: alert.name,
-          memberEmail: alert.member.email,
-          matches,
-          filterState,
-        });
-        await this.prisma.jobAlertSendRun.create({
-          data: {
+      cursor = batch.length === BATCH_SIZE ? batch[batch.length - 1].uid : undefined;
+      this.logger.log(`Processed batch of ${batch.length} alerts, cursor: ${cursor ?? 'end'}`);
+    } while (cursor);
+
+    this.logger.log(`Dispatch complete for runId=${payload.runId}: ${sent} alerts had matches, ${skipped} skipped`);
+    return { sent, skipped };
+  }
+
+  private async getAlreadySentAlerts(alertUids: string[], runId: string): Promise<Set<string>> {
+    const existing = await this.prisma.jobAlertSendRun.findMany({
+      where: {
+        alertUid: { in: alertUids },
+        ingestRunId: runId,
+      },
+      select: { alertUid: true },
+    });
+    return new Set(existing.map((r) => r.alertUid));
+  }
+
+  private async processBatch(
+    alerts: Array<{
+      uid: string;
+      memberUid: string;
+      name: string;
+      filterState: unknown;
+      lastSentAt: Date | null;
+      createdAt: Date;
+      member: { uid: string; email: string; name: string | null; deletedAt: Date | null };
+    }>,
+    runId: string
+  ): Promise<{ sent: number; skipped: number }> {
+    let sent = 0;
+    let skipped = 0;
+    const limit = pLimit(EMAIL_CONCURRENCY);
+
+    const tasks = alerts.map((alert) =>
+      limit(async () => {
+        const filterState = alert.filterState as unknown as JobAlertFilterState;
+        const sinceTs = alert.lastSentAt ?? alert.createdAt;
+
+        try {
+          const matches = await this.jobOpeningsQueryService.findNewMatchesSince(
+            { ...filterState, page: 1, limit: 50, sort: 'newest' },
+            sinceTs
+          );
+
+          if (matches.length === 0) {
+            this.logger.log(`Alert ${alert.uid}: no new matches since ${sinceTs.toISOString()}`);
+            skipped++;
+            return;
+          }
+
+          await this.sendDigestEmail({
             alertUid: alert.uid,
-            ingestRunId: payload.runId,
-            matchCount: matches.length,
-            emailType: 'digest',
-          },
-        });
-        await this.prisma.jobAlert.update({
-          where: { uid: alert.uid },
-          data: { lastSentAt: new Date() },
-        });
-        sent++;
-      } catch (err) {
-        this.logger.error(`Failed to dispatch alert ${alert.uid}: ${(err as Error).message}`);
-        skipped++;
-      }
-    }
+            alertName: alert.name,
+            memberEmail: alert.member.email,
+            matches,
+            filterState,
+          });
 
-    this.logger.log(
-      `Dispatch complete for runId=${payload.runId}: ${sent} alerts had matches, ${skipped} skipped`,
+          await this.prisma.jobAlertSendRun.create({
+            data: {
+              alertUid: alert.uid,
+              ingestRunId: runId,
+              matchCount: matches.length,
+              emailType: 'digest',
+            },
+          });
+
+          await this.prisma.jobAlert.update({
+            where: { uid: alert.uid },
+            data: { lastSentAt: new Date() },
+          });
+
+          sent++;
+        } catch (err) {
+          this.logger.error(`Failed to dispatch alert ${alert.uid}: ${(err as Error).message}`);
+          skipped++;
+        }
+      })
     );
+
+    await Promise.all(tasks);
+
     return { sent, skipped };
   }
 
@@ -130,9 +186,7 @@ export class JobAlertsDispatchService {
     filterState: JobAlertFilterState;
   }) {
     const { alertUid, alertName, memberEmail, matches, filterState } = args;
-    const subject = `${matches.length} role${
-      matches.length === 1 ? '' : 's'
-    } match from PL network: ${alertName}`;
+    const subject = `${matches.length} role${matches.length === 1 ? '' : 's'} match from PL network: ${alertName}`;
     const data = this.buildEmailData({ alertUid, alertName, matches, filterState });
     await this.send({ template: CONFIRMATION_TEMPLATE, subject, data, to: memberEmail });
     await this.prisma.jobAlertSendRun.create({
@@ -153,9 +207,7 @@ export class JobAlertsDispatchService {
     filterState: JobAlertFilterState;
   }) {
     const { alertUid, alertName, memberEmail, matches, filterState } = args;
-    const subject = `${matches.length} new role${
-      matches.length === 1 ? '' : 's'
-    } match from PL network: ${alertName}`;
+    const subject = `${matches.length} new role${matches.length === 1 ? '' : 's'} match from PL network: ${alertName}`;
     const data = this.buildEmailData({ alertUid, alertName, matches, filterState });
     await this.send({ template: DIGEST_TEMPLATE, subject, data, to: memberEmail });
   }
@@ -173,10 +225,10 @@ export class JobAlertsDispatchService {
       const applyUrl = role.sourceLink
         ? buildAppUrl(
             `/jobs/redirect?token=${encodeURIComponent(
-              issueJobAlertToken({ purpose: 'redirect', alertUid, jobUid: role.uid, applyUrl: role.sourceLink }),
+              issueJobAlertToken({ purpose: 'redirect', alertUid, jobUid: role.uid, applyUrl: role.sourceLink })
             )}&utm_source=job_alerts&utm_medium=email&utm_code=${utmCode}&alert_uid=${alertUid}&job_uid=${
               role.uid
-            }&position=${idx + 1}`,
+            }&position=${idx + 1}`
           )
         : null;
       return {
@@ -232,7 +284,7 @@ export class JobAlertsDispatchService {
       args.subject,
       fromAddress,
       [args.to],
-      [],
+      []
     );
   }
 
@@ -251,7 +303,7 @@ export class JobAlertsDispatchService {
           `  To:      ${args.to}\n` +
           `  Subject: ${args.subject}\n` +
           `  Preview: file://${previewPath}\n` +
-          '─────────────────────────────────────────────────────────',
+          '─────────────────────────────────────────────────────────'
       );
     } catch (err) {
       this.logger.error(`Failed to render email preview: ${(err as Error).message}`);

--- a/apps/web-api/src/job-alerts/job-alerts-dispatch.service.ts
+++ b/apps/web-api/src/job-alerts/job-alerts-dispatch.service.ts
@@ -1,0 +1,260 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import Handlebars from 'handlebars';
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import type { JobAlertFilterState } from 'libs/contracts/src/schema/job-alert';
+import { JobOpeningsQueryService } from '../job-openings/job-openings-query.service';
+import { PrismaService } from '../shared/prisma.service';
+import { AwsService } from '../utils/aws/aws.service';
+import { JOB_INGEST_COMPLETED, JobIngestCompletedPayload } from './job-alerts.events';
+import { issueJobAlertToken } from './job-alerts-token.util';
+import { seniorityLabel } from './job-alerts.utils';
+
+const DIGEST_TEMPLATE = path.join(__dirname, 'shared', 'jobAlertDigest.hbs');
+const CONFIRMATION_TEMPLATE = path.join(__dirname, 'shared', 'jobAlertConfirmation.hbs');
+const MAX_ROLES_IN_EMAIL = 10;
+
+const buildAppUrl = (pathname: string) => {
+  const base = process.env.WEB_UI_BASE_URL || process.env.APPLICATION_BASE_URL || 'https://www.plnetwork.io';
+  return `${base.replace(/\/$/, '')}${pathname}`;
+};
+
+@Injectable()
+export class JobAlertsDispatchService {
+  private readonly logger = new Logger(JobAlertsDispatchService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly jobOpeningsQueryService: JobOpeningsQueryService,
+    private readonly awsService: AwsService,
+  ) {}
+
+  @OnEvent(JOB_INGEST_COMPLETED)
+  async onJobIngestCompleted(payload: JobIngestCompletedPayload) {
+    this.logger.log(
+      `Received ${JOB_INGEST_COMPLETED} runId=${payload.runId} created=${payload.created} updated=${payload.updated}`,
+    );
+    if (payload.created === 0 && payload.updated === 0) {
+      this.logger.log('Skipping dispatch: no new or updated jobs in this run');
+      return;
+    }
+    await this.dispatch(payload);
+  }
+
+  async dispatch(payload: JobIngestCompletedPayload): Promise<{ sent: number; skipped: number }> {
+    const activeAlerts = await this.prisma.jobAlert.findMany({
+      where: { deletedAt: null },
+      select: {
+        uid: true,
+        memberUid: true,
+        name: true,
+        filterState: true,
+        lastSentAt: true,
+        createdAt: true,
+        member: { select: { uid: true, email: true, name: true, deletedAt: true } },
+      },
+    });
+
+    let sent = 0;
+    let skipped = 0;
+
+    for (const alert of activeAlerts) {
+      if (!alert.member?.email || alert.member.deletedAt) {
+        skipped++;
+        continue;
+      }
+
+      const existingRun = await this.prisma.jobAlertSendRun.findUnique({
+        where: { alertUid_ingestRunId: { alertUid: alert.uid, ingestRunId: payload.runId } },
+        select: { uid: true },
+      });
+      if (existingRun) {
+        this.logger.log(`Idempotency: alert ${alert.uid} already dispatched for run ${payload.runId}`);
+        skipped++;
+        continue;
+      }
+
+      const filterState = alert.filterState as unknown as JobAlertFilterState;
+      const sinceTs = alert.lastSentAt ?? alert.createdAt;
+      const matches = await this.jobOpeningsQueryService.findNewMatchesSince(
+        { ...filterState, page: 1, limit: 50, sort: 'newest' },
+        sinceTs,
+      );
+
+      if (matches.length === 0) {
+        this.logger.log(`Alert ${alert.uid}: no new matches since ${sinceTs.toISOString()}`);
+        skipped++;
+        continue;
+      }
+
+      try {
+        await this.sendDigestEmail({
+          alertUid: alert.uid,
+          alertName: alert.name,
+          memberEmail: alert.member.email,
+          matches,
+          filterState,
+        });
+        await this.prisma.jobAlertSendRun.create({
+          data: {
+            alertUid: alert.uid,
+            ingestRunId: payload.runId,
+            matchCount: matches.length,
+            emailType: 'digest',
+          },
+        });
+        await this.prisma.jobAlert.update({
+          where: { uid: alert.uid },
+          data: { lastSentAt: new Date() },
+        });
+        sent++;
+      } catch (err) {
+        this.logger.error(`Failed to dispatch alert ${alert.uid}: ${(err as Error).message}`);
+        skipped++;
+      }
+    }
+
+    this.logger.log(
+      `Dispatch complete for runId=${payload.runId}: ${sent} alerts had matches, ${skipped} skipped`,
+    );
+    return { sent, skipped };
+  }
+
+  async sendConfirmationEmail(args: {
+    alertUid: string;
+    alertName: string;
+    memberEmail: string;
+    matches: Awaited<ReturnType<JobOpeningsQueryService['findNewMatchesSince']>>;
+    filterState: JobAlertFilterState;
+  }) {
+    const { alertUid, alertName, memberEmail, matches, filterState } = args;
+    const subject = `${matches.length} role${
+      matches.length === 1 ? '' : 's'
+    } match from PL network: ${alertName}`;
+    const data = this.buildEmailData({ alertUid, alertName, matches, filterState });
+    await this.send({ template: CONFIRMATION_TEMPLATE, subject, data, to: memberEmail });
+    await this.prisma.jobAlertSendRun.create({
+      data: {
+        alertUid,
+        ingestRunId: `confirmation-${alertUid}`,
+        matchCount: matches.length,
+        emailType: 'confirmation',
+      },
+    });
+  }
+
+  private async sendDigestEmail(args: {
+    alertUid: string;
+    alertName: string;
+    memberEmail: string;
+    matches: Awaited<ReturnType<JobOpeningsQueryService['findNewMatchesSince']>>;
+    filterState: JobAlertFilterState;
+  }) {
+    const { alertUid, alertName, memberEmail, matches, filterState } = args;
+    const subject = `${matches.length} new role${
+      matches.length === 1 ? '' : 's'
+    } match from PL network: ${alertName}`;
+    const data = this.buildEmailData({ alertUid, alertName, matches, filterState });
+    await this.send({ template: DIGEST_TEMPLATE, subject, data, to: memberEmail });
+  }
+
+  private buildEmailData(args: {
+    alertUid: string;
+    alertName: string;
+    matches: Awaited<ReturnType<JobOpeningsQueryService['findNewMatchesSince']>>;
+    filterState: JobAlertFilterState;
+  }) {
+    const { alertUid, alertName, matches, filterState } = args;
+    const utmCode = Math.random().toString(36).slice(2, 10);
+    const trimmed = matches.slice(0, MAX_ROLES_IN_EMAIL);
+    const rolesData = trimmed.map((role, idx) => {
+      const applyUrl = role.sourceLink
+        ? buildAppUrl(
+            `/jobs/redirect?token=${encodeURIComponent(
+              issueJobAlertToken({ purpose: 'redirect', alertUid, jobUid: role.uid, applyUrl: role.sourceLink }),
+            )}&utm_source=job_alerts&utm_medium=email&utm_code=${utmCode}&alert_uid=${alertUid}&job_uid=${
+              role.uid
+            }&position=${idx + 1}`,
+          )
+        : null;
+      return {
+        roleTitle: role.roleTitle,
+        teamName: role.team?.name ?? '',
+        location: (role.location ?? []).join(' · '),
+        seniority: role.seniority ? seniorityLabel(role.seniority) : null,
+        applyUrl,
+      };
+    });
+
+    const filterQuery = this.filterStateToQueryString(filterState);
+    const unsubToken = issueJobAlertToken({ purpose: 'unsubscribe', alertUid });
+
+    return {
+      matchCount: matches.length,
+      matchCountIsOne: matches.length === 1,
+      alertName,
+      roles: rolesData,
+      hasMore: matches.length > MAX_ROLES_IN_EMAIL,
+      viewAllUrl: buildAppUrl(`/jobs${filterQuery ? `?${filterQuery}` : ''}`),
+      unsubscribeUrl: buildAppUrl(`/jobs/unsubscribed?token=${encodeURIComponent(unsubToken)}`),
+    };
+  }
+
+  private filterStateToQueryString(filterState: JobAlertFilterState): string {
+    const params = new URLSearchParams();
+    if (filterState.q) params.set('q', filterState.q);
+    for (const key of ['roleCategory', 'seniority', 'focus', 'location'] as const) {
+      for (const value of filterState[key] ?? []) params.append(key, value);
+    }
+    const workplaceTypes = new Set<string>();
+    for (const m of filterState.workMode ?? []) {
+      if (m === 'remote' || m === 'distributed') workplaceTypes.add('remote');
+      else if (m === 'hybrid' || m === 'in-office') workplaceTypes.add(m);
+    }
+    for (const wt of workplaceTypes) params.append('workplaceType', wt);
+    return params.toString();
+  }
+
+  private async send(args: { template: string; subject: string; data: unknown; to: string }) {
+    const fromAddress = process.env.SES_SOURCE_EMAIL || 'no-reply@plnetwork.io';
+
+    if (!this.awsService.isEmailServiceEnabled()) {
+      this.previewToConsole(args, fromAddress);
+      return null;
+    }
+
+    return this.awsService.sendEmailWithTemplate(
+      args.template,
+      args.data,
+      args.subject,
+      args.subject,
+      fromAddress,
+      [args.to],
+      [],
+    );
+  }
+
+  private previewToConsole(args: { template: string; subject: string; data: unknown; to: string }, from: string) {
+    try {
+      const tpl = fs.readFileSync(args.template, 'utf-8');
+      Handlebars.registerHelper('eq', (a, b) => a === b);
+      Handlebars.registerHelper('and', (...rest) => rest.every(Boolean));
+      const html = Handlebars.compile(tpl)(args.data);
+      const filename = `job-alert-${path.basename(args.template).replace('.hbs', '')}-${Date.now()}.html`;
+      const previewPath = path.join(os.tmpdir(), filename);
+      fs.writeFileSync(previewPath, html, 'utf-8');
+      this.logger.log(
+        '\n────── EMAIL PREVIEW (IS_EMAIL_ENABLED is not true) ──────\n' +
+          `  From:    ${from}\n` +
+          `  To:      ${args.to}\n` +
+          `  Subject: ${args.subject}\n` +
+          `  Preview: file://${previewPath}\n` +
+          '─────────────────────────────────────────────────────────',
+      );
+    } catch (err) {
+      this.logger.error(`Failed to render email preview: ${(err as Error).message}`);
+    }
+  }
+}

--- a/apps/web-api/src/job-alerts/job-alerts-public.controller.ts
+++ b/apps/web-api/src/job-alerts/job-alerts-public.controller.ts
@@ -1,0 +1,60 @@
+import { BadRequestException, Body, Controller, NotFoundException, Post } from '@nestjs/common';
+import {
+  UnsubscribeRequestSchema,
+  VerifyRedirectRequestSchema,
+} from 'libs/contracts/src/schema/job-alert';
+import { NoCache } from '../decorators/no-cache.decorator';
+import { PrismaService } from '../shared/prisma.service';
+import { verifyJobAlertToken } from './job-alerts-token.util';
+
+@Controller('v1/job-alerts')
+export class JobAlertsPublicController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Post('verify-redirect')
+  @NoCache()
+  async verifyRedirect(@Body() body: unknown) {
+    const parsed = VerifyRedirectRequestSchema.parse(body);
+    let payload;
+    try {
+      payload = verifyJobAlertToken(parsed.token, 'redirect');
+    } catch (err) {
+      throw new BadRequestException((err as Error).message);
+    }
+    if (!payload.applyUrl || !payload.jobUid) {
+      throw new BadRequestException('Token missing required fields');
+    }
+    return {
+      applyUrl: payload.applyUrl,
+      alertUid: payload.alertUid,
+      jobUid: payload.jobUid,
+    };
+  }
+
+  @Post('unsubscribe')
+  @NoCache()
+  async unsubscribe(@Body() body: unknown) {
+    const parsed = UnsubscribeRequestSchema.parse(body);
+    let payload;
+    try {
+      payload = verifyJobAlertToken(parsed.token, 'unsubscribe');
+    } catch (err) {
+      throw new BadRequestException((err as Error).message);
+    }
+    const alert = await this.prisma.jobAlert.findFirst({
+      where: { uid: payload.alertUid, deletedAt: null },
+      select: { uid: true, name: true, filterStateHash: true },
+    });
+    if (!alert) {
+      throw new NotFoundException('Job alert not found');
+    }
+    await this.prisma.jobAlert.update({
+      where: { uid: alert.uid },
+      data: {
+        deletedAt: new Date(),
+        filterStateHash: `${alert.filterStateHash}#deleted:${alert.uid}`,
+      },
+    });
+    return { alertUid: alert.uid, alertName: alert.name };
+  }
+}

--- a/apps/web-api/src/job-alerts/job-alerts-public.controller.ts
+++ b/apps/web-api/src/job-alerts/job-alerts-public.controller.ts
@@ -1,15 +1,12 @@
-import { BadRequestException, Body, Controller, NotFoundException, Post } from '@nestjs/common';
-import {
-  UnsubscribeRequestSchema,
-  VerifyRedirectRequestSchema,
-} from 'libs/contracts/src/schema/job-alert';
+import { BadRequestException, Body, Controller, Post } from '@nestjs/common';
+import { UnsubscribeRequestSchema, VerifyRedirectRequestSchema } from 'libs/contracts/src/schema/job-alert';
 import { NoCache } from '../decorators/no-cache.decorator';
-import { PrismaService } from '../shared/prisma.service';
+import { JobAlertsService } from './job-alerts.service';
 import { verifyJobAlertToken } from './job-alerts-token.util';
 
 @Controller('v1/job-alerts')
 export class JobAlertsPublicController {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly service: JobAlertsService) {}
 
   @Post('verify-redirect')
   @NoCache()
@@ -35,26 +32,6 @@ export class JobAlertsPublicController {
   @NoCache()
   async unsubscribe(@Body() body: unknown) {
     const parsed = UnsubscribeRequestSchema.parse(body);
-    let payload;
-    try {
-      payload = verifyJobAlertToken(parsed.token, 'unsubscribe');
-    } catch (err) {
-      throw new BadRequestException((err as Error).message);
-    }
-    const alert = await this.prisma.jobAlert.findFirst({
-      where: { uid: payload.alertUid, deletedAt: null },
-      select: { uid: true, name: true, filterStateHash: true },
-    });
-    if (!alert) {
-      throw new NotFoundException('Job alert not found');
-    }
-    await this.prisma.jobAlert.update({
-      where: { uid: alert.uid },
-      data: {
-        deletedAt: new Date(),
-        filterStateHash: `${alert.filterStateHash}#deleted:${alert.uid}`,
-      },
-    });
-    return { alertUid: alert.uid, alertName: alert.name };
+    return this.service.unsubscribeByToken(parsed.token);
   }
 }

--- a/apps/web-api/src/job-alerts/job-alerts-token.util.spec.ts
+++ b/apps/web-api/src/job-alerts/job-alerts-token.util.spec.ts
@@ -1,0 +1,72 @@
+import { issueJobAlertToken, verifyJobAlertToken } from './job-alerts-token.util';
+
+describe('job-alerts-token.util', () => {
+  const ORIGINAL_SECRET = process.env.JOB_ALERTS_TOKEN_SECRET;
+
+  beforeAll(() => {
+    process.env.JOB_ALERTS_TOKEN_SECRET = 'test-secret-must-be-long-enough-32chars';
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_SECRET === undefined) delete process.env.JOB_ALERTS_TOKEN_SECRET;
+    else process.env.JOB_ALERTS_TOKEN_SECRET = ORIGINAL_SECRET;
+  });
+
+  it('round-trips a valid unsubscribe token', () => {
+    const token = issueJobAlertToken({ purpose: 'unsubscribe', alertUid: 'alert-1' });
+    const payload = verifyJobAlertToken(token, 'unsubscribe');
+    expect(payload.alertUid).toBe('alert-1');
+    expect(payload.purpose).toBe('unsubscribe');
+  });
+
+  it('round-trips a redirect token with jobUid + applyUrl', () => {
+    const token = issueJobAlertToken({
+      purpose: 'redirect',
+      alertUid: 'alert-1',
+      jobUid: 'job-2',
+      applyUrl: 'https://example.com/apply',
+    });
+    const payload = verifyJobAlertToken(token, 'redirect');
+    expect(payload.jobUid).toBe('job-2');
+    expect(payload.applyUrl).toBe('https://example.com/apply');
+  });
+
+  it('rejects a wrong-purpose token', () => {
+    const token = issueJobAlertToken({ purpose: 'unsubscribe', alertUid: 'alert-1' });
+    expect(() => verifyJobAlertToken(token, 'redirect')).toThrow(/purpose/i);
+  });
+
+  it('rejects a tampered signature', () => {
+    const token = issueJobAlertToken({ purpose: 'unsubscribe', alertUid: 'alert-1' });
+    const parts = token.split('.');
+    parts[2] = parts[2].slice(0, -1) + (parts[2].slice(-1) === 'a' ? 'b' : 'a');
+    const tampered = parts.join('.');
+    expect(() => verifyJobAlertToken(tampered, 'unsubscribe')).toThrow(/signature/i);
+  });
+
+  it('rejects a tampered body', () => {
+    const original = issueJobAlertToken({ purpose: 'unsubscribe', alertUid: 'alert-1' });
+    const otherToken = issueJobAlertToken({ purpose: 'unsubscribe', alertUid: 'alert-evil' });
+    const [v, , sig] = original.split('.');
+    const [, otherBody] = otherToken.split('.');
+    const swapped = `${v}.${otherBody}.${sig}`;
+    expect(() => verifyJobAlertToken(swapped, 'unsubscribe')).toThrow(/signature/i);
+  });
+
+  it('rejects an expired token', () => {
+    const token = issueJobAlertToken({ purpose: 'unsubscribe', alertUid: 'alert-1' });
+    expect(() => verifyJobAlertToken(token, 'unsubscribe', -1)).toThrow(/expired/i);
+  });
+
+  it('rejects a malformed token', () => {
+    expect(() => verifyJobAlertToken('not-a-token', 'unsubscribe')).toThrow(/malformed/i);
+    expect(() => verifyJobAlertToken('a.b', 'unsubscribe')).toThrow(/malformed/i);
+  });
+
+  it('rejects an unsupported version', () => {
+    const token = issueJobAlertToken({ purpose: 'unsubscribe', alertUid: 'alert-1' });
+    const parts = token.split('.');
+    parts[0] = 'v999';
+    expect(() => verifyJobAlertToken(parts.join('.'), 'unsubscribe')).toThrow(/version/i);
+  });
+});

--- a/apps/web-api/src/job-alerts/job-alerts-token.util.ts
+++ b/apps/web-api/src/job-alerts/job-alerts-token.util.ts
@@ -1,0 +1,68 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export type JobAlertTokenPurpose = 'redirect' | 'unsubscribe';
+
+export interface JobAlertTokenPayload {
+  purpose: JobAlertTokenPurpose;
+  alertUid: string;
+  jobUid?: string;
+  applyUrl?: string;
+  iat: number;
+}
+
+const VERSION = 'v1';
+
+const getSecret = (): string => {
+  const secret = process.env.JOB_ALERTS_TOKEN_SECRET;
+  if (!secret) {
+    throw new Error('JOB_ALERTS_TOKEN_SECRET environment variable is not set');
+  }
+  return secret;
+};
+
+const base64UrlEncode = (input: Buffer | string): string => {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf-8') : input;
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+};
+
+const base64UrlDecode = (input: string): Buffer => {
+  const pad = input.length % 4 === 0 ? '' : '='.repeat(4 - (input.length % 4));
+  return Buffer.from(input.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64');
+};
+
+const sign = (data: string): string => {
+  return base64UrlEncode(createHmac('sha256', getSecret()).update(data).digest());
+};
+
+export const issueJobAlertToken = (payload: Omit<JobAlertTokenPayload, 'iat'>): string => {
+  const full: JobAlertTokenPayload = { ...payload, iat: Math.floor(Date.now() / 1000) };
+  const body = base64UrlEncode(JSON.stringify(full));
+  const signature = sign(`${VERSION}.${body}`);
+  return `${VERSION}.${body}.${signature}`;
+};
+
+export const verifyJobAlertToken = (
+  token: string,
+  expectedPurpose: JobAlertTokenPurpose,
+  maxAgeSeconds = 60 * 60 * 24 * 60,
+): JobAlertTokenPayload => {
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new Error('Malformed token');
+  const [version, body, providedSig] = parts;
+  if (version !== VERSION) throw new Error('Unsupported token version');
+
+  const expectedSig = sign(`${version}.${body}`);
+  const a = Buffer.from(providedSig, 'utf-8');
+  const b = Buffer.from(expectedSig, 'utf-8');
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    throw new Error('Invalid token signature');
+  }
+
+  const decoded = JSON.parse(base64UrlDecode(body).toString('utf-8')) as JobAlertTokenPayload;
+  if (decoded.purpose !== expectedPurpose) throw new Error('Wrong token purpose');
+
+  const ageSeconds = Math.floor(Date.now() / 1000) - decoded.iat;
+  if (ageSeconds > maxAgeSeconds) throw new Error('Token expired');
+
+  return decoded;
+};

--- a/apps/web-api/src/job-alerts/job-alerts.controller.ts
+++ b/apps/web-api/src/job-alerts/job-alerts.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  CreateJobAlertSchema,
+  UpdateJobAlertSchema,
+} from 'libs/contracts/src/schema/job-alert';
+import { NoCache } from '../decorators/no-cache.decorator';
+import { UserAuthValidateGuard } from '../guards/user-auth-validate.guard';
+import { JobAlertsService } from './job-alerts.service';
+
+@Controller('v1/job-alerts')
+@UseGuards(UserAuthValidateGuard)
+export class JobAlertsController {
+  constructor(private readonly service: JobAlertsService) {}
+
+  @Get()
+  @NoCache()
+  async list(@Req() req: any) {
+    const memberUid = await this.service.resolveMemberUidByEmail(req.userEmail);
+    return this.service.list(memberUid);
+  }
+
+  @Post()
+  @NoCache()
+  async create(@Req() req: any, @Body() body: unknown) {
+    const memberUid = await this.service.resolveMemberUidByEmail(req.userEmail);
+    const parsed = CreateJobAlertSchema.parse(body);
+    return this.service.create(memberUid, parsed);
+  }
+
+  @Patch(':uid')
+  @NoCache()
+  async update(@Req() req: any, @Param('uid') uid: string, @Body() body: unknown) {
+    const memberUid = await this.service.resolveMemberUidByEmail(req.userEmail);
+    const parsed = UpdateJobAlertSchema.parse(body);
+    return this.service.update(memberUid, uid, parsed);
+  }
+
+  @Delete(':uid')
+  @HttpCode(204)
+  @NoCache()
+  async delete(@Req() req: any, @Param('uid') uid: string): Promise<void> {
+    const memberUid = await this.service.resolveMemberUidByEmail(req.userEmail);
+    await this.service.delete(memberUid, uid);
+  }
+}

--- a/apps/web-api/src/job-alerts/job-alerts.events.ts
+++ b/apps/web-api/src/job-alerts/job-alerts.events.ts
@@ -1,0 +1,11 @@
+export const JOB_INGEST_COMPLETED = 'job-ingest.completed';
+
+export interface JobIngestCompletedPayload {
+  runId: string;
+  source: string | null;
+  received: number;
+  created: number;
+  updated: number;
+  failed: number;
+  completedAt: string;
+}

--- a/apps/web-api/src/job-alerts/job-alerts.module.ts
+++ b/apps/web-api/src/job-alerts/job-alerts.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { JobOpeningsModule } from '../job-openings/job-openings.module';
+import { SharedModule } from '../shared/shared.module';
+import { AwsService } from '../utils/aws/aws.service';
+import { JobAlertsController } from './job-alerts.controller';
+import { JobAlertsDispatchService } from './job-alerts-dispatch.service';
+import { JobAlertsPublicController } from './job-alerts-public.controller';
+import { JobAlertsService } from './job-alerts.service';
+
+@Module({
+  imports: [SharedModule, JobOpeningsModule],
+  controllers: [JobAlertsController, JobAlertsPublicController],
+  providers: [JobAlertsService, JobAlertsDispatchService, AwsService],
+  exports: [JobAlertsService, JobAlertsDispatchService],
+})
+export class JobAlertsModule {}

--- a/apps/web-api/src/job-alerts/job-alerts.service.ts
+++ b/apps/web-api/src/job-alerts/job-alerts.service.ts
@@ -1,0 +1,188 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JobAlert, Prisma } from '@prisma/client';
+import type { JobAlertFilterState } from 'libs/contracts/src/schema/job-alert';
+import { JobOpeningsQueryService } from '../job-openings/job-openings-query.service';
+import { PrismaService } from '../shared/prisma.service';
+import { JobAlertsDispatchService } from './job-alerts-dispatch.service';
+import { canonicalizeFilterState, generateAutoName, hashFilterState } from './job-alerts.utils';
+
+@Injectable()
+export class JobAlertsService {
+  private readonly logger = new Logger(JobAlertsService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly jobOpeningsQueryService: JobOpeningsQueryService,
+    private readonly dispatchService: JobAlertsDispatchService,
+  ) {}
+
+  async resolveMemberUidByEmail(email: string | undefined): Promise<string> {
+    if (!email) {
+      throw new UnauthorizedException('Authenticated email required');
+    }
+    const member = await this.prisma.member.findUnique({
+      where: { email },
+      select: { uid: true, deletedAt: true },
+    });
+    if (!member || member.deletedAt) {
+      throw new UnauthorizedException('Member not found');
+    }
+    return member.uid;
+  }
+
+  async list(memberUid: string) {
+    const alerts = await this.prisma.jobAlert.findMany({
+      where: { memberUid, deletedAt: null },
+      orderBy: { createdAt: 'desc' },
+    });
+    const items = alerts.map((alert) => this.toResponseShape(alert));
+    return {
+      items,
+      total: items.length,
+    };
+  }
+
+  async create(memberUid: string, input: { name?: string; filterState: JobAlertFilterState }) {
+    const canonical = canonicalizeFilterState(input.filterState);
+    if (!this.hasAtLeastOneFilter(canonical)) {
+      throw new BadRequestException('Cannot save a job alert with no filters applied');
+    }
+
+    const filterStateHash = hashFilterState(canonical);
+    const name = (input.name?.trim() || generateAutoName(canonical)).slice(0, 120);
+
+    let alert: JobAlert;
+    try {
+      alert = await this.prisma.jobAlert.create({
+        data: {
+          memberUid,
+          name,
+          filterState: canonical as unknown as Prisma.InputJsonValue,
+          filterStateHash,
+        },
+      });
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        const existing = await this.prisma.jobAlert.findFirst({
+          where: { memberUid, deletedAt: null },
+          select: { uid: true },
+        });
+        throw new ConflictException({
+          existingAlertUid: existing?.uid ?? null,
+          message: 'You already have a job alert. Update it to change the filters.',
+        });
+      }
+      throw err;
+    }
+
+    void this.sendConfirmationFireAndForget(alert.uid).catch((sendErr) => {
+      this.logger.error(`Confirmation email failed for alert ${alert.uid}: ${(sendErr as Error).message}`);
+    });
+
+    return this.toResponseShape(alert);
+  }
+
+  private async sendConfirmationFireAndForget(alertUid: string): Promise<void> {
+    const alert = await this.prisma.jobAlert.findUnique({
+      where: { uid: alertUid },
+      select: {
+        uid: true,
+        name: true,
+        filterState: true,
+        member: { select: { email: true } },
+      },
+    });
+    if (!alert?.member?.email) return;
+
+    const filterState = alert.filterState as unknown as JobAlertFilterState;
+    const matches = await this.jobOpeningsQueryService.findNewMatchesSince(
+      { ...filterState, page: 1, limit: 50, sort: 'newest' },
+      null,
+    );
+    if (matches.length === 0) return;
+
+    await this.dispatchService.sendConfirmationEmail({
+      alertUid: alert.uid,
+      alertName: alert.name,
+      memberEmail: alert.member.email,
+      matches,
+      filterState,
+    });
+  }
+
+  async update(
+    memberUid: string,
+    uid: string,
+    patch: { name?: string; filterState?: JobAlertFilterState },
+  ) {
+    const existing = await this.prisma.jobAlert.findFirst({
+      where: { uid, memberUid, deletedAt: null },
+    });
+    if (!existing) throw new NotFoundException('Job alert not found');
+
+    const data: Prisma.JobAlertUpdateInput = {};
+    if (typeof patch.name === 'string') {
+      const trimmed = patch.name.trim();
+      if (!trimmed) throw new BadRequestException('Name cannot be empty');
+      data.name = trimmed.slice(0, 120);
+    }
+    if (patch.filterState) {
+      const canonical = canonicalizeFilterState(patch.filterState);
+      if (!this.hasAtLeastOneFilter(canonical)) {
+        throw new BadRequestException('Cannot save a job alert with no filters applied');
+      }
+      data.filterState = canonical as unknown as Prisma.InputJsonValue;
+      data.filterStateHash = hashFilterState(canonical);
+    }
+
+    const updated = await this.prisma.jobAlert.update({
+      where: { uid },
+      data,
+    });
+    return this.toResponseShape(updated);
+  }
+
+  async delete(memberUid: string, uid: string): Promise<void> {
+    const existing = await this.prisma.jobAlert.findFirst({
+      where: { uid, memberUid, deletedAt: null },
+      select: { uid: true, filterStateHash: true },
+    });
+    if (!existing) throw new NotFoundException('Job alert not found');
+    await this.prisma.jobAlert.update({
+      where: { uid },
+      data: {
+        deletedAt: new Date(),
+        filterStateHash: `${existing.filterStateHash}#deleted:${uid}`,
+      },
+    });
+  }
+
+  private hasAtLeastOneFilter(canonical: JobAlertFilterState): boolean {
+    return Boolean(
+      canonical.q ||
+        canonical.roleCategory.length ||
+        canonical.seniority.length ||
+        canonical.focus.length ||
+        canonical.location.length ||
+        canonical.workMode.length,
+    );
+  }
+
+  private toResponseShape(alert: JobAlert) {
+    const filterState = alert.filterState as unknown as JobAlertFilterState;
+    return {
+      uid: alert.uid,
+      name: alert.name,
+      filterState,
+      createdAt: alert.createdAt.toISOString(),
+      updatedAt: alert.updatedAt.toISOString(),
+    };
+  }
+}

--- a/apps/web-api/src/job-alerts/job-alerts.service.ts
+++ b/apps/web-api/src/job-alerts/job-alerts.service.ts
@@ -12,6 +12,7 @@ import { JobOpeningsQueryService } from '../job-openings/job-openings-query.serv
 import { PrismaService } from '../shared/prisma.service';
 import { JobAlertsDispatchService } from './job-alerts-dispatch.service';
 import { canonicalizeFilterState, generateAutoName, hashFilterState } from './job-alerts.utils';
+import { verifyJobAlertToken } from './job-alerts-token.util';
 
 @Injectable()
 export class JobAlertsService {
@@ -162,6 +163,25 @@ export class JobAlertsService {
         filterStateHash: `${existing.filterStateHash}#deleted:${uid}`,
       },
     });
+  }
+
+  async unsubscribeByToken(token: string): Promise<{ alertUid: string; alertName: string }> {
+    const payload = verifyJobAlertToken(token, 'unsubscribe');
+    const alert = await this.prisma.jobAlert.findFirst({
+      where: { uid: payload.alertUid, deletedAt: null },
+      select: { uid: true, name: true, filterStateHash: true },
+    });
+    if (!alert) {
+      throw new NotFoundException('Job alert not found');
+    }
+    await this.prisma.jobAlert.update({
+      where: { uid: alert.uid },
+      data: {
+        deletedAt: new Date(),
+        filterStateHash: `${alert.filterStateHash}#deleted:${alert.uid}`,
+      },
+    });
+    return { alertUid: alert.uid, alertName: alert.name };
   }
 
   private hasAtLeastOneFilter(canonical: JobAlertFilterState): boolean {

--- a/apps/web-api/src/job-alerts/job-alerts.utils.spec.ts
+++ b/apps/web-api/src/job-alerts/job-alerts.utils.spec.ts
@@ -105,6 +105,17 @@ describe('generateAutoName', () => {
     expect(name).toBe('Design · Mid');
   });
 
+  it('joins all values within a multi-value filter category', () => {
+    const name = generateAutoName({
+      roleCategory: ['Design', 'Product'],
+      seniority: ['Mid (L3)', 'Senior (L4)'],
+      focus: [],
+      location: [],
+      workMode: [],
+    } as any);
+    expect(name).toBe('Design, Product · Mid, Senior');
+  });
+
   it('falls back to "Job alert" when nothing is selected', () => {
     const name = generateAutoName({
       roleCategory: [],

--- a/apps/web-api/src/job-alerts/job-alerts.utils.spec.ts
+++ b/apps/web-api/src/job-alerts/job-alerts.utils.spec.ts
@@ -1,0 +1,145 @@
+import {
+  canonicalizeFilterState,
+  hashFilterState,
+  generateAutoName,
+  seniorityLabel,
+} from './job-alerts.utils';
+
+describe('canonicalizeFilterState', () => {
+  it('trims whitespace, dedupes, sorts arrays', () => {
+    const out = canonicalizeFilterState({
+      q: '  ml  ',
+      roleCategory: ['Engineering', 'Engineering', '  Design  '],
+      seniority: [],
+      focus: ['Web3'],
+      location: [],
+      workMode: ['remote', 'distributed', 'remote'],
+    } as any);
+    expect(out.q).toBe('ml');
+    expect(out.roleCategory).toEqual(['Design', 'Engineering']);
+    expect(out.workMode).toEqual(['distributed', 'remote']);
+    expect(out.focus).toEqual(['Web3']);
+  });
+
+  it('drops empty strings and falsy q', () => {
+    const out = canonicalizeFilterState({
+      q: '   ',
+      roleCategory: ['', '   ', 'Design'],
+      seniority: [],
+      focus: [],
+      location: [],
+      workMode: [],
+    } as any);
+    expect(out.q).toBeUndefined();
+    expect(out.roleCategory).toEqual(['Design']);
+  });
+});
+
+describe('hashFilterState', () => {
+  it('is deterministic and order-independent for arrays', () => {
+    const a = canonicalizeFilterState({
+      roleCategory: ['Design', 'Engineering'],
+      seniority: ['Senior (L4)'],
+      focus: [],
+      location: [],
+      workMode: ['remote', 'distributed'],
+    } as any);
+    const b = canonicalizeFilterState({
+      roleCategory: ['Engineering', 'Design'],
+      seniority: ['Senior (L4)'],
+      focus: [],
+      location: [],
+      workMode: ['distributed', 'remote'],
+    } as any);
+    expect(hashFilterState(a)).toBe(hashFilterState(b));
+  });
+
+  it('case-insensitive on q', () => {
+    const a = canonicalizeFilterState({
+      q: 'Rust',
+      roleCategory: [],
+      seniority: [],
+      focus: [],
+      location: [],
+      workMode: [],
+    } as any);
+    const b = canonicalizeFilterState({
+      q: 'RUST',
+      roleCategory: [],
+      seniority: [],
+      focus: [],
+      location: [],
+      workMode: [],
+    } as any);
+    expect(hashFilterState(a)).toBe(hashFilterState(b));
+  });
+
+  it('differs when filters differ', () => {
+    const a = canonicalizeFilterState({
+      roleCategory: ['Design'],
+      seniority: [],
+      focus: [],
+      location: [],
+      workMode: [],
+    } as any);
+    const b = canonicalizeFilterState({
+      roleCategory: ['Design', 'Product'],
+      seniority: [],
+      focus: [],
+      location: [],
+      workMode: [],
+    } as any);
+    expect(hashFilterState(a)).not.toBe(hashFilterState(b));
+  });
+});
+
+describe('generateAutoName', () => {
+  it('joins major filters and shows seniority display label', () => {
+    const name = generateAutoName({
+      roleCategory: ['Design'],
+      seniority: ['Mid (L3)'],
+      focus: [],
+      location: [],
+      workMode: [],
+    } as any);
+    expect(name).toBe('Design · Mid');
+  });
+
+  it('falls back to "Job alert" when nothing is selected', () => {
+    const name = generateAutoName({
+      roleCategory: [],
+      seniority: [],
+      focus: [],
+      location: [],
+      workMode: [],
+    } as any);
+    expect(name).toBe('Job alert');
+  });
+
+  it('truncates long names with ellipsis', () => {
+    const name = generateAutoName(
+      {
+        roleCategory: ['A very long role category name that should be truncated'],
+        seniority: [],
+        focus: [],
+        location: [],
+        workMode: [],
+      } as any,
+      20,
+    );
+    expect(name.length).toBeLessThanOrEqual(20);
+    expect(name.endsWith('…')).toBe(true);
+  });
+});
+
+describe('seniorityLabel', () => {
+  it('strips the (L#) suffix', () => {
+    expect(seniorityLabel('Mid (L3)')).toBe('Mid');
+    expect(seniorityLabel('Junior (L1-L2)')).toBe('Junior');
+    expect(seniorityLabel('Senior (L4)')).toBe('Senior');
+  });
+
+  it('returns raw when no mapping', () => {
+    expect(seniorityLabel('Other')).toBe('Other');
+  });
+});

--- a/apps/web-api/src/job-alerts/job-alerts.utils.ts
+++ b/apps/web-api/src/job-alerts/job-alerts.utils.ts
@@ -53,10 +53,10 @@ export const seniorityLabel = (raw: string): string => SENIORITY_DISPLAY[raw] ??
 
 export const generateAutoName = (canonical: JobAlertFilterState, maxLen = 60): string => {
   const parts: string[] = [];
-  if (canonical.roleCategory[0]) parts.push(canonical.roleCategory[0]);
-  if (canonical.seniority[0]) parts.push(seniorityLabel(canonical.seniority[0]));
-  if (canonical.focus[0]) parts.push(canonical.focus[0]);
-  if (canonical.workMode[0]) parts.push(canonical.workMode[0]);
+  if (canonical.roleCategory.length) parts.push(canonical.roleCategory.join(', '));
+  if (canonical.seniority.length) parts.push(canonical.seniority.map(seniorityLabel).join(', '));
+  if (canonical.focus.length) parts.push(canonical.focus.join(', '));
+  if (canonical.workMode.length) parts.push(canonical.workMode.join(', '));
   if (canonical.q) parts.push(`"${canonical.q}"`);
   const joined = parts.join(' · ') || 'Job alert';
   if (joined.length <= maxLen) return joined;

--- a/apps/web-api/src/job-alerts/job-alerts.utils.ts
+++ b/apps/web-api/src/job-alerts/job-alerts.utils.ts
@@ -1,0 +1,64 @@
+import { createHash } from 'crypto';
+import type { JobAlertFilterState } from 'libs/contracts/src/schema/job-alert';
+
+const trimAndDedupe = (values: string[]): string[] => {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of values) {
+    if (typeof raw !== 'string') continue;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out.sort((a, b) => a.localeCompare(b));
+};
+
+export const canonicalizeFilterState = (input: JobAlertFilterState): JobAlertFilterState => {
+  return {
+    q: input.q?.trim() || undefined,
+    roleCategory: trimAndDedupe(input.roleCategory ?? []),
+    seniority: trimAndDedupe(input.seniority ?? []),
+    focus: trimAndDedupe(input.focus ?? []),
+    location: trimAndDedupe(input.location ?? []),
+    workMode: trimAndDedupe(input.workMode ?? []),
+  };
+};
+
+export const hashFilterState = (canonical: JobAlertFilterState): string => {
+  const stable = JSON.stringify(
+    {
+      q: canonical.q?.toLowerCase() ?? '',
+      roleCategory: canonical.roleCategory.map((v) => v.toLowerCase()),
+      seniority: canonical.seniority.map((v) => v.toLowerCase()),
+      focus: canonical.focus.map((v) => v.toLowerCase()),
+      location: canonical.location.map((v) => v.toLowerCase()),
+      workMode: canonical.workMode.map((v) => v.toLowerCase()),
+    },
+    Object.keys({ q: 0, roleCategory: 0, seniority: 0, focus: 0, location: 0, workMode: 0 }).sort(),
+  );
+  return createHash('sha256').update(stable).digest('hex');
+};
+
+const SENIORITY_DISPLAY: Record<string, string> = {
+  'Junior (L1-L2)': 'Junior',
+  'Mid (L3)': 'Mid',
+  'Senior (L4)': 'Senior',
+  'Lead (L5)': 'Lead',
+  'Principal+ (L6-L7)': 'Principal+',
+};
+
+export const seniorityLabel = (raw: string): string => SENIORITY_DISPLAY[raw] ?? raw;
+
+export const generateAutoName = (canonical: JobAlertFilterState, maxLen = 60): string => {
+  const parts: string[] = [];
+  if (canonical.roleCategory[0]) parts.push(canonical.roleCategory[0]);
+  if (canonical.seniority[0]) parts.push(seniorityLabel(canonical.seniority[0]));
+  if (canonical.focus[0]) parts.push(canonical.focus[0]);
+  if (canonical.workMode[0]) parts.push(canonical.workMode[0]);
+  if (canonical.q) parts.push(`"${canonical.q}"`);
+  const joined = parts.join(' · ') || 'Job alert';
+  if (joined.length <= maxLen) return joined;
+  return `${joined.slice(0, maxLen - 1).trimEnd()}…`;
+};

--- a/apps/web-api/src/job-openings/job-openings-query.service.ts
+++ b/apps/web-api/src/job-openings/job-openings-query.service.ts
@@ -297,6 +297,29 @@ export class JobOpeningsQueryService {
     };
   }
 
+  async findNewMatchesSince(query: JobsListQuery, sinceTs: Date | null) {
+    const where = this.buildWhere(query);
+    const sinceFilter: Prisma.JobOpeningWhereInput[] = sinceTs ? [{ updatedAt: { gt: sinceTs } }] : [];
+    return this.prisma.jobOpening.findMany({
+      where: sinceFilter.length > 0 ? { AND: [where, ...sinceFilter] } : where,
+      select: {
+        uid: true,
+        teamUid: true,
+        roleTitle: true,
+        roleCategory: true,
+        seniority: true,
+        location: true,
+        workMode: true,
+        sourceLink: true,
+        postedDate: true,
+        detectionDate: true,
+        updatedAt: true,
+        team: { select: { uid: true, name: true, logo: { select: { url: true } } } },
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+  }
+
   async getFilters(query: JobsListQuery) {
     const functionWhere = this.buildWhere(query, { dropFunction: true });
     const seniorityWhere = this.buildWhere(query, { dropSeniority: true });

--- a/apps/web-api/src/job-openings/job-openings-service.controller.ts
+++ b/apps/web-api/src/job-openings/job-openings-service.controller.ts
@@ -55,7 +55,10 @@ export class JobOpeningsServiceController {
 
     this.logger.log(`Received ingest request with ${dto.jobs.length} jobs (runId: ${dto.runId ?? 'none'})`);
 
-    const result = await this.jobOpeningsService.ingestJobOpenings(dto.jobs);
+    const result = await this.jobOpeningsService.ingestJobOpenings(dto.jobs, {
+      runId: dto.runId ?? null,
+      source: dto.source ?? null,
+    });
 
     this.logger.log(`Ingest complete: ${result.created} created, ${result.updated} updated, ${result.failed} failed`);
 

--- a/apps/web-api/src/job-openings/job-openings.service.ts
+++ b/apps/web-api/src/job-openings/job-openings.service.ts
@@ -1,15 +1,21 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { randomUUID } from 'crypto';
 import { PrismaService } from '../shared/prisma.service';
 import { JobOpeningStatus, Prisma } from '@prisma/client';
 import { JobOpeningIngestItem, IngestJobOpeningsResponse } from './dto/ingest-job-openings.dto';
+import { JOB_INGEST_COMPLETED, JobIngestCompletedPayload } from '../job-alerts/job-alerts.events';
 
 @Injectable()
 export class JobOpeningsService {
   private readonly logger = new Logger(JobOpeningsService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService, private readonly eventEmitter: EventEmitter2) {}
 
-  async ingestJobOpenings(items: JobOpeningIngestItem[]): Promise<IngestJobOpeningsResponse> {
+  async ingestJobOpenings(
+    items: JobOpeningIngestItem[],
+    meta?: { runId?: string | null; source?: string | null },
+  ): Promise<IngestJobOpeningsResponse> {
     const result: IngestJobOpeningsResponse = {
       received: items.length,
       created: 0,
@@ -46,6 +52,17 @@ export class JobOpeningsService {
         result.errors?.push(`Failed to process ${item.dedupKey}: ${error.message}`);
       }
     }
+
+    const eventPayload: JobIngestCompletedPayload = {
+      runId: meta?.runId || randomUUID(),
+      source: meta?.source ?? null,
+      received: result.received,
+      created: result.created,
+      updated: result.updated,
+      failed: result.failed,
+      completedAt: new Date().toISOString(),
+    };
+    this.eventEmitter.emit(JOB_INGEST_COMPLETED, eventPayload);
 
     return result;
   }

--- a/apps/web-api/src/shared/jobAlertConfirmation.hbs
+++ b/apps/web-api/src/shared/jobAlertConfirmation.hbs
@@ -1,0 +1,74 @@
+<html lang='en'>
+  <body style='margin: 0; padding: 0; font-family: Inter, sans-serif;'>
+    <table width='100%' cellpadding='0' cellspacing='0' border='0' align='center' style='background-color: #ffffff;'>
+      <tr>
+        <td align='center'>
+          <table width='640' cellpadding='0' cellspacing='0' border='0' style='margin: auto;'>
+            <tr>
+              <td align='center' style='padding: 8px 24px;'>
+                <img
+                  src='https://pfps.plnetwork.io/protocol-labs-logo-246.png'
+                  style='width: 246px; height: 56px;'
+                  width='246'
+                  height='56'
+                  alt='Protocol Labs'
+                />
+              </td>
+            </tr>
+            <tr>
+              <td align='center' style='padding: 24px;'>
+                <h1 style='margin: 0; font-size: 1.5rem; font-weight: 600; text-align: left; color: #0F172A;'>Your job alert is on.</h1>
+                <br />
+                <p style='color: #475569; font-size: 1rem; line-height: 1.6rem; margin: 0; text-align: left;'>
+                  Here are the {{matchCount}} role{{#unless matchCountIsOne}}s{{/unless}} currently matching <strong>"{{alertName}}"</strong> from the Protocol Labs network.
+                </p>
+                <p style='color: #94A3B8; font-size: 0.9rem; line-height: 1.4rem; margin: 12px 0 0 0; text-align: left;'>
+                  We'll email you again when new roles match.
+                </p>
+              </td>
+            </tr>
+            {{#each roles}}
+              <tr>
+                <td style='padding: 0 24px 12px 24px;'>
+                  <table width='100%' cellpadding='0' cellspacing='0' border='0' style='border: 1px solid #E2E8F0; border-radius: 12px;'>
+                    <tr>
+                      <td style='padding: 16px;'>
+                        <p style='margin: 0; font-size: 1rem; font-weight: 600; color: #0F172A;'>{{this.roleTitle}}</p>
+                        <p style='margin: 4px 0 0 0; font-size: 0.85rem; color: #64748B;'>
+                          {{this.teamName}}{{#if this.location}} &middot; {{this.location}}{{/if}}{{#if this.seniority}} &middot; {{this.seniority}}{{/if}}
+                        </p>
+                        {{#if this.applyUrl}}
+                          <p style='margin: 12px 0 0 0;'>
+                            <a
+                              href='{{this.applyUrl}}'
+                              style='display: inline-block; background-color: #156FF7; color: #FFF; padding: 8px 16px; border-radius: 8px; font-size: 0.9rem; text-decoration: none;'
+                            >Apply</a>
+                          </p>
+                        {{/if}}
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            {{/each}}
+            {{#if hasMore}}
+              <tr>
+                <td align='center' style='padding: 8px 24px 24px 24px;'>
+                  <a href='{{viewAllUrl}}' style='color: #156FF7; font-size: 0.9rem; text-decoration: underline;'>View all matches on the directory</a>
+                </td>
+              </tr>
+            {{/if}}
+            <tr>
+              <td align='center' style='padding: 24px; border-top: 1px solid #E2E8F0;'>
+                <p style='color: #94A3B8; font-size: 0.8rem; margin: 0;'>
+                  <a href='{{unsubscribeUrl}}' style='color: #94A3B8;'>Unsubscribe from this alert</a>
+                </p>
+                <p style='color: #94A3B8; margin: 8px 0 0 0; font-size: 0.8rem;'>Protocol Labs &middot; LabOS</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/apps/web-api/src/shared/jobAlertDigest.hbs
+++ b/apps/web-api/src/shared/jobAlertDigest.hbs
@@ -1,0 +1,71 @@
+<html lang='en'>
+  <body style='margin: 0; padding: 0; font-family: Inter, sans-serif;'>
+    <table width='100%' cellpadding='0' cellspacing='0' border='0' align='center' style='background-color: #ffffff;'>
+      <tr>
+        <td align='center'>
+          <table width='640' cellpadding='0' cellspacing='0' border='0' style='margin: auto;'>
+            <tr>
+              <td align='center' style='padding: 8px 24px;'>
+                <img
+                  src='https://pfps.plnetwork.io/protocol-labs-logo-246.png'
+                  style='width: 246px; height: 56px;'
+                  width='246'
+                  height='56'
+                  alt='Protocol Labs'
+                />
+              </td>
+            </tr>
+            <tr>
+              <td align='center' style='padding: 24px;'>
+                <h1 style='margin: 0; font-size: 1.5rem; font-weight: 600; text-align: left; color: #0F172A;'>{{matchCount}} new role{{#unless matchCountIsOne}}s{{/unless}} match your job alert</h1>
+                <br />
+                <p style='color: #475569; font-size: 1rem; line-height: 1.6rem; margin: 0; text-align: left;'>
+                  New roles matching <strong>"{{alertName}}"</strong> from the Protocol Labs network.
+                </p>
+              </td>
+            </tr>
+            {{#each roles}}
+              <tr>
+                <td style='padding: 0 24px 12px 24px;'>
+                  <table width='100%' cellpadding='0' cellspacing='0' border='0' style='border: 1px solid #E2E8F0; border-radius: 12px;'>
+                    <tr>
+                      <td style='padding: 16px;'>
+                        <p style='margin: 0; font-size: 1rem; font-weight: 600; color: #0F172A;'>{{this.roleTitle}}</p>
+                        <p style='margin: 4px 0 0 0; font-size: 0.85rem; color: #64748B;'>
+                          {{this.teamName}}{{#if this.location}} &middot; {{this.location}}{{/if}}{{#if this.seniority}} &middot; {{this.seniority}}{{/if}}
+                        </p>
+                        {{#if this.applyUrl}}
+                          <p style='margin: 12px 0 0 0;'>
+                            <a
+                              href='{{this.applyUrl}}'
+                              style='display: inline-block; background-color: #156FF7; color: #FFF; padding: 8px 16px; border-radius: 8px; font-size: 0.9rem; text-decoration: none;'
+                            >Apply</a>
+                          </p>
+                        {{/if}}
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            {{/each}}
+            {{#if hasMore}}
+              <tr>
+                <td align='center' style='padding: 8px 24px 24px 24px;'>
+                  <a href='{{viewAllUrl}}' style='color: #156FF7; font-size: 0.9rem; text-decoration: underline;'>View all matches on the directory</a>
+                </td>
+              </tr>
+            {{/if}}
+            <tr>
+              <td align='center' style='padding: 24px; border-top: 1px solid #E2E8F0;'>
+                <p style='color: #94A3B8; font-size: 0.8rem; margin: 0;'>
+                  <a href='{{unsubscribeUrl}}' style='color: #94A3B8;'>Unsubscribe from this alert</a>
+                </p>
+                <p style='color: #94A3B8; margin: 8px 0 0 0; font-size: 0.8rem;'>Protocol Labs &middot; LabOS</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/libs/contracts/src/lib/contract-job-alerts.ts
+++ b/libs/contracts/src/lib/contract-job-alerts.ts
@@ -1,0 +1,77 @@
+import { initContract } from '@ts-rest/core';
+import {
+  CreateJobAlertConflictSchema,
+  CreateJobAlertSchema,
+  JobAlertSchema,
+  ListJobAlertsResponseSchema,
+  UnsubscribeRequestSchema,
+  UnsubscribeResponseSchema,
+  UpdateJobAlertSchema,
+  VerifyRedirectRequestSchema,
+  VerifyRedirectResponseSchema,
+} from '../schema/job-alert';
+import { getAPIVersionAsPath } from '../utils/versioned-path';
+
+const contract = initContract();
+
+export const apiJobAlerts = contract.router({
+  listJobAlerts: {
+    method: 'GET',
+    path: `${getAPIVersionAsPath('1')}/job-alerts`,
+    responses: {
+      200: ListJobAlertsResponseSchema,
+    },
+    summary: "List the authenticated member's job alerts",
+  },
+  createJobAlert: {
+    method: 'POST',
+    path: `${getAPIVersionAsPath('1')}/job-alerts`,
+    body: CreateJobAlertSchema,
+    responses: {
+      201: JobAlertSchema,
+      409: CreateJobAlertConflictSchema,
+      400: contract.response<{ message: string }>(),
+    },
+    summary: 'Save a job-search filter set as a recurring alert',
+  },
+  updateJobAlert: {
+    method: 'PATCH',
+    path: `${getAPIVersionAsPath('1')}/job-alerts/:uid`,
+    body: UpdateJobAlertSchema,
+    responses: {
+      200: JobAlertSchema,
+      404: contract.response<{ message: string }>(),
+    },
+    summary: 'Update name or paused state of an alert',
+  },
+  deleteJobAlert: {
+    method: 'DELETE',
+    path: `${getAPIVersionAsPath('1')}/job-alerts/:uid`,
+    body: contract.body<Record<string, never>>(),
+    responses: {
+      204: contract.response<null>(),
+      404: contract.response<{ message: string }>(),
+    },
+    summary: 'Soft-delete an alert',
+  },
+  verifyRedirect: {
+    method: 'POST',
+    path: `${getAPIVersionAsPath('1')}/job-alerts/verify-redirect`,
+    body: VerifyRedirectRequestSchema,
+    responses: {
+      200: VerifyRedirectResponseSchema,
+      400: contract.response<{ message: string }>(),
+    },
+    summary: 'Validate a signed email-click token and return its applyUrl',
+  },
+  unsubscribe: {
+    method: 'POST',
+    path: `${getAPIVersionAsPath('1')}/job-alerts/unsubscribe`,
+    body: UnsubscribeRequestSchema,
+    responses: {
+      200: UnsubscribeResponseSchema,
+      400: contract.response<{ message: string }>(),
+    },
+    summary: 'One-click unsubscribe for a specific alert',
+  },
+});

--- a/libs/contracts/src/schema/index.ts
+++ b/libs/contracts/src/schema/index.ts
@@ -38,4 +38,5 @@ export * from './demo-day-engagement-analytics';
 export * from './contact-support';
 export * from './community-affiliation';
 export * from './job-opening';
+export * from './job-alert';
 export * from './team-job-enrichment';

--- a/libs/contracts/src/schema/job-alert.ts
+++ b/libs/contracts/src/schema/job-alert.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+const toStringArray = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string' && v.length > 0);
+  }
+  if (typeof value !== 'string' || value.length === 0) {
+    return [];
+  }
+  return [value];
+};
+
+export const JobAlertFilterStateSchema = z.object({
+  q: z.string().optional(),
+  roleCategory: z.preprocess(toStringArray, z.array(z.string())).optional().default([]),
+  seniority: z.preprocess(toStringArray, z.array(z.string())).optional().default([]),
+  focus: z.preprocess(toStringArray, z.array(z.string())).optional().default([]),
+  location: z.preprocess(toStringArray, z.array(z.string())).optional().default([]),
+  workMode: z.preprocess(toStringArray, z.array(z.string())).optional().default([]),
+});
+
+export type JobAlertFilterState = z.infer<typeof JobAlertFilterStateSchema>;
+
+export const JobAlertSchema = z.object({
+  uid: z.string(),
+  name: z.string(),
+  filterState: JobAlertFilterStateSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type JobAlertResponse = z.infer<typeof JobAlertSchema>;
+
+export const CreateJobAlertSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  filterState: JobAlertFilterStateSchema,
+});
+
+export const UpdateJobAlertSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  filterState: JobAlertFilterStateSchema.optional(),
+});
+
+export const ListJobAlertsResponseSchema = z.object({
+  items: z.array(JobAlertSchema),
+  total: z.number().int(),
+});
+
+export const CreateJobAlertConflictSchema = z.object({
+  existingAlertUid: z.string(),
+  message: z.string(),
+});
+
+export const VerifyRedirectRequestSchema = z.object({
+  token: z.string(),
+});
+
+export const VerifyRedirectResponseSchema = z.object({
+  applyUrl: z.string().url(),
+  alertUid: z.string(),
+  jobUid: z.string(),
+});
+
+export const UnsubscribeRequestSchema = z.object({
+  token: z.string(),
+});
+
+export const UnsubscribeResponseSchema = z.object({
+  alertUid: z.string(),
+  alertName: z.string(),
+});

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "nodemailer": "^6.9.7",
     "nookies": "^2.5.2",
     "open-graph-scraper": "^6.11.0",
+    "p-limit": "^7.3.0",
     "pg": "^8.13.3",
     "postcss": "^8.4.12",
     "posthog-js": "1.141.4",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@nestjs/bull": "^0.6.1",
     "@nestjs/common": "^9.4.3",
     "@nestjs/core": "^9.4.3",
+    "@nestjs/event-emitter": "^2.0.0",
     "@nestjs/platform-express": "^9.4.3",
     "@nestjs/platform-socket.io": "^9.4.3",
     "@nestjs/schedule": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23799,6 +23799,13 @@ p-limit@^3.0.2, p-limit@^3.1.0:
   dependencies:
     yocto-queue "^0.1.0"
 
+p-limit@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-7.3.0.tgz#821398d91491c6b6a1340ecd09cdc402a9c8d0ee"
+  integrity sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==
+  dependencies:
+    yocto-queue "^1.2.1"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz"
@@ -30597,6 +30604,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
+  integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==
 
 yup@^1.6.1:
   version "1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5411,6 +5411,13 @@
     path-to-regexp "3.2.0"
     tslib "2.5.3"
 
+"@nestjs/event-emitter@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/event-emitter/-/event-emitter-2.1.1.tgz#4e34edc487c507edbe6d02033e3dd014a19210f9"
+  integrity sha512-6L6fBOZTyfFlL7Ih/JDdqlCzZeCW0RjCX28wnzGyg/ncv5F/EOeT1dfopQr1loBRQ3LTgu8OWM7n4zLN4xigsg==
+  dependencies:
+    eventemitter2 "6.4.9"
+
 "@nestjs/mapped-types@1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.1.0.tgz"
@@ -16513,6 +16520,11 @@ event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+eventemitter2@6.4.9:
+  version "6.4.9"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.9.tgz#41f2750781b4230ed58827bc119d293471ecb125"
+  integrity sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==
 
 eventemitter2@^6.4.3:
   version "6.4.5"


### PR DESCRIPTION
## Summary
- Members can save one filter combo as a "job alert" that drives a weekly email digest of new matching roles. Single-alert model enforced via partial unique index `WHERE deletedAt IS NULL`.
- New `JobAlerts` module: CRUD service, dispatch service (listens on `JOB_INGEST_COMPLETED`, idempotent per `(alertUid, ingestRunId)`), HMAC-signed Apply / Unsubscribe tokens, two `.hbs` email templates.
- 18 unit tests covering canonicalization, hashing, auto-naming, token sign/verify.

## Test plan
- [ ] Migrations apply cleanly (`prisma migrate deploy`)
- [ ] `POST /v1/job-alerts` creates an alert; second create returns 409
- [ ] `PATCH /v1/job-alerts/:uid` updates filterState
- [ ] `DELETE /v1/job-alerts/:uid` soft-deletes
- [ ] Confirmation email sends if alert has matches at create time
- [ ] Digest email fires on next `JOB_INGEST_COMPLETED` event with new roles since `lastSentAt`
- [ ] Re-running same ingest does not re-send digest (idempotency)
- [ ] Unsubscribe link from email soft-deletes the alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)