### PR TITLE
[Team Enrichment] AI judge for fields provided by user

### DIFF
--- a/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
@@ -51,6 +51,21 @@ const JUDGABLE_FIELD_KEYS: FieldMetaKey[] = [
   'investmentFocus',
 ];
 
+/**
+ * Subset of fields the judge will evaluate when their status is `ChangedByUser`.
+ * Limited to website + contact links
+ * The judge stays non-destructive: it only attaches `fieldsMeta[field].judgment`;
+ * the field's value, status, confidence, and source are preserved.
+ */
+const USER_JUDGABLE_FIELD_KEYS: ReadonlySet<FieldMetaKey> = new Set<FieldMetaKey>([
+  'website',
+  'blog',
+  'contactMethod',
+  'twitterHandler',
+  'linkedinHandler',
+  'telegramHandler',
+]);
+
 @Injectable()
 export class TeamEnrichmentJudgeService {
   private readonly logger = new Logger(TeamEnrichmentJudgeService.name);
@@ -118,9 +133,7 @@ export class TeamEnrichmentJudgeService {
       return { status: 'already_judged' };
     }
     if (meta.status !== EnrichmentStatus.Enriched) {
-      this.logger.log(
-        `Judge: team ${teamUid} enrichment status is "${meta.status}", not Enriched — skipping`
-      );
+      this.logger.log(`Judge: team ${teamUid} enrichment status is "${meta.status}", not Enriched — skipping`);
       return { status: 'not_eligible' };
     }
 
@@ -314,13 +327,19 @@ export class TeamEnrichmentJudgeService {
       const mergedFieldsMeta: FieldsMetaMap = { ...baseFieldsMeta };
 
       // The judge is non-destructive: it annotates with a `judgment` sub-object but never
-      // overrides enrichment-time values like `confidence` or `source`. Readers who want the
-      // judge's verdict should read `fieldsMeta[field].judgment.confidence`.
+      // overrides enrichment-time values like `confidence` or `source`, and never touches the
+      // field's `status` — including for ChangedByUser fields (the user's data is preserved
+      // verbatim). Readers who want the judge's verdict should read
+      // `fieldsMeta[field].judgment.confidence`.
       const fieldsForReview: string[] = [];
       for (const [key, verdict] of Object.entries(allVerdicts) as Array<[FieldMetaKey, FieldJudgment | undefined]>) {
         if (!verdict) continue;
         const current = mergedFieldsMeta[key];
-        if (!current || current.status !== FieldEnrichmentStatus.Enriched) continue;
+        if (!current) continue;
+        const isEnriched = current.status === FieldEnrichmentStatus.Enriched;
+        const isUserJudgable =
+          current.status === FieldEnrichmentStatus.ChangedByUser && USER_JUDGABLE_FIELD_KEYS.has(key);
+        if (!isEnriched && !isUserJudgable) continue;
         mergedFieldsMeta[key] = {
           ...current,
           judgment: verdict,
@@ -350,13 +369,12 @@ export class TeamEnrichmentJudgeService {
       });
 
       this.logger.log(
-        `Judge: team ${teamUid} (${team.name}) judged — stage1=${Object.keys(stage1Verdicts).length} stage2=${Object.keys(stage2Verdicts).length} fieldsForReview=[${fieldsForReview.join(',')}]`
+        `Judge: team ${teamUid} (${team.name}) judged — stage1=${Object.keys(stage1Verdicts).length} stage2=${
+          Object.keys(stage2Verdicts).length
+        } fieldsForReview=[${fieldsForReview.join(',')}]`
       );
     } catch (error) {
-      this.logger.error(
-        `Judge pipeline error for team ${teamUid} (${team.name}): ${error.message}`,
-        error.stack
-      );
+      this.logger.error(`Judge pipeline error for team ${teamUid} (${team.name}): ${error.message}`, error.stack);
       await this.writeJudgmentStatus(teamUid, existingMeta, {
         status: JudgmentStatus.FailedToJudge,
         errorMessage: error.message,
@@ -366,25 +384,27 @@ export class TeamEnrichmentJudgeService {
 
   /**
    * Returns the list of fieldsMeta keys that are candidates for judgment:
-   *  - status === Enriched
-   *  - excludes logo, ChangedByUser, CannotEnrich
+   *  - status === Enriched (any judgable key), OR
+   *  - status === ChangedByUser AND key is in USER_JUDGABLE_FIELD_KEYS (website + contact links)
+   *  - excludes logo and CannotEnrich
    */
   private collectJudgableFieldKeys(fieldsMeta: FieldsMetaMap): FieldMetaKey[] {
     const out: FieldMetaKey[] = [];
     for (const key of JUDGABLE_FIELD_KEYS) {
       const meta = fieldsMeta[key];
       if (!meta) continue;
-      if (meta.status !== FieldEnrichmentStatus.Enriched) continue;
-      out.push(key);
+      if (meta.status === FieldEnrichmentStatus.Enriched) {
+        out.push(key);
+        continue;
+      }
+      if (meta.status === FieldEnrichmentStatus.ChangedByUser && USER_JUDGABLE_FIELD_KEYS.has(key)) {
+        out.push(key);
+      }
     }
     return out;
   }
 
-  private buildFieldInput(
-    team: TeamRecord,
-    fieldsMeta: FieldsMetaMap,
-    key: FieldMetaKey
-  ): JudgeFieldInput | null {
+  private buildFieldInput(team: TeamRecord, fieldsMeta: FieldsMetaMap, key: FieldMetaKey): JudgeFieldInput | null {
     const meta = fieldsMeta[key];
     if (!meta) return null;
     const value = this.readFieldValue(team, key);

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -105,8 +105,11 @@ After enrichment completes, a separate **AI Judge** cron independently verifies 
 ### What the judge evaluates
 
 - Only teams matching the shared eligibility filter (`TEAM_ENRICHMENT_FILTER_PRIORITY` set → `priority IN (...)`; otherwise `isFund=true`) and `dataEnrichment.status = Enriched`.
-- Per-field: only fields whose `fieldsMeta[field].status === Enriched`.
-- **Excluded**: `logo` (binary presence, not a semantic value), anything `ChangedByUser` (user-owned), `CannotEnrich`.
+- Per-field, the judge runs on either:
+  - any field whose `fieldsMeta[field].status === Enriched`, OR
+  - a **user-supplied** website / contact link (`fieldsMeta[field].status === ChangedByUser`) — restricted to: `website`, `blog`, `contactMethod`, `linkedinHandler`, `twitterHandler`, `telegramHandler`. These are the high-signal identity fields a team lead can fill in directly, and we want an independent check that the value really belongs to the team.
+- **Excluded**: `logo` (binary presence, not a semantic value), `CannotEnrich`, any `ChangedByUser` field outside the user-judgable subset above (descriptions, `industryTags`, `investmentFocus`).
+- **Non-destructive for user data**: when judging a `ChangedByUser` field, the judge still only writes the `judgment` sub-object. The field's value, `status`, `confidence`, and `source` on `Team` and in `fieldsMeta` are preserved verbatim. A "disagrees" verdict surfaces the field in `fieldsForReview` for admin review but never overwrites the user's input. The bad-LinkedIn-handle nulling path also continues to skip user-supplied handles.
 
 ### Two stages
 
@@ -115,7 +118,7 @@ After enrichment completes, a separate **AI Judge** cron independently verifies 
 
 ### fieldsMeta after judgment
 
-The judge is **non-destructive**: it adds a `judgment` sub-object to each enriched field but does not overwrite any enrichment-time values. The top-level `confidence` remains as enrichment set it (including any ScrapingDog upgrade applied during enrichment). Admins who want the judge's independent confidence should read `fieldsMeta[field].judgment.confidence`.
+The judge is **non-destructive**: it adds a `judgment` sub-object to each judged field but does not overwrite any enrichment-time values. The top-level `status`, `confidence`, and `source` remain as enrichment (or the user) set them — including any ScrapingDog confidence upgrade applied during enrichment, and including `ChangedByUser` for user-supplied website/contact-link fields that the judge now also evaluates. Admins who want the judge's independent confidence should read `fieldsMeta[field].judgment.confidence`.
 
 ```ts
 fieldsMeta[field]: {


### PR DESCRIPTION
### Summary                                                                                                                                                                                                                                                                
   
  Previously the AI Judge only verified fields filled by the enricher (Enriched) and skipped anything ChangedByUser. This PR extends the judge to also independently verify user-supplied website and contact links (blog, contactMethod, linkedinHandler,  twitterHandler, telegramHandler), so admins can catch cases where a team lead entered the wrong domain, mistyped LinkedIn handle, etc.
                                                                                                                                                                                                                                                                         
### Behavior                                               

  - The judge now evaluates a user-supplied website/contact-link field whose status is ChangedByUser.
  - Other ChangedByUser fields (descriptions, industryTags, investmentFocus) remain excluded.
  - User data is never modified. The judge only attaches its judgment sub-object; the field's value, status, confidence, and source are preserved verbatim. Disagreements surface in fieldsForReview for admin review.

### Docs

  - [docs/TEAM_ENRICHMENT.md](https://github.com/memser-spaceport/pln-directory-portal/blob/feat/team-enrichment-users-data/docs/TEAM_ENRICHMENT.md#ai-judge-second-pass-verification) updated to reflect the new judge scope and the non-destructive guarantee for user-supplied fields.       