### PR TITLE
[Team Enrichment] Fix extract LinkedIn HandleId company's profile

### DIFF
--- a/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
@@ -235,8 +235,19 @@ export class TeamEnrichmentScrapingDogService {
 
   private extractHandleId(handler: string): string | null {
     if (!handler) return null;
-    const match = handler.match(/(?:linkedin\.com\/)?(?:company\/)?([a-zA-Z0-9_-]+)/);
-    return match ? match[1] : null;
+    const trimmed = handler.trim();
+    if (!trimmed) return null;
+    // Full or partial LinkedIn URL — only accept company paths.
+    if (/linkedin\.com\//i.test(trimmed)) {
+      const m = trimmed.match(/linkedin\.com\/company\/([a-zA-Z0-9_.-]+)/i);
+      return m ? m[1].replace(/\/+$/, '') : null;
+    }
+    // Otherwise treat as a bare handle (optionally prefixed with `company/`), stripping query/path.
+    const cleaned = trimmed
+      .replace(/^company\//i, '')
+      .replace(/[\/?#].*$/, '')
+      .trim();
+    return /^[a-zA-Z0-9_.-]+$/.test(cleaned) ? cleaned : null;
   }
 
   private isNotFoundBody(raw: unknown): boolean {


### PR DESCRIPTION
### Problem

Root cause: `extractHandleId` in `apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts:236` had a regex with two optional non-capturing groups followed by a greedy capture. For any URL starting with `https://`, both optional groups matched empty at position 0, and the capture group greedily consumed "https", which is exactly what ScrapingDog 404'd on. 

### Fix
Rewrote `extractHandleId` to 
* require `linkedin.com/company/<handle>` when input is a LinkedIn URL, 
* reject non-company LinkedIn paths like /in/, /school/, (c) accept bare handles with optional company/ prefix and trailing slash/query/fragment. 