### PR TITLE
[Team Enrichment] Improve AI Team Enrichment with User-Confirmed Identity Hints

### DIFF
--- a/apps/web-api/src/team-enrichment/team-enrichment-ai.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-ai.service.ts
@@ -151,6 +151,11 @@ export class TeamEnrichmentAiService {
       telegramHandler?: string | null;
       shortDescription?: string | null;
       longDescription?: string | null;
+      userConfirmedIdentityHints?: {
+        shortDescription?: string | null;
+        longDescription?: string | null;
+        moreDetails?: string | null;
+      };
     }
   ): Promise<AITeamEnrichmentResponse> {
     try {
@@ -191,9 +196,37 @@ export class TeamEnrichmentAiService {
       telegramHandler?: string | null;
       shortDescription?: string | null;
       longDescription?: string | null;
+      userConfirmedIdentityHints?: {
+        shortDescription?: string | null;
+        longDescription?: string | null;
+        moreDetails?: string | null;
+      };
     }
   ): string {
-    const existingDescription = existingData.shortDescription || existingData.longDescription || '';
+    const hints = existingData.userConfirmedIdentityHints;
+    const userConfirmedShort = hints?.shortDescription?.trim();
+    const userConfirmedLong = hints?.longDescription?.trim();
+    const userConfirmedMore = hints?.moreDetails?.trim();
+    const hasUserConfirmedHints = !!(userConfirmedShort || userConfirmedLong || userConfirmedMore);
+
+    let descriptionBlock: string;
+    if (hasUserConfirmedHints) {
+      const lines: string[] = [];
+      if (userConfirmedShort) lines.push(`- Short description: ${userConfirmedShort}`);
+      if (userConfirmedLong) lines.push(`- Long description: ${userConfirmedLong}`);
+      if (userConfirmedMore) lines.push(`- More details: ${userConfirmedMore}`);
+      descriptionBlock = `USER-CONFIRMED IDENTITY HINTS — the team lead has explicitly asserted these about THIS team. Treat them as ground truth when disambiguating between similarly-named entities.
+${lines.join('\n')}`;
+    } else {
+      const existingDescription = existingData.shortDescription || existingData.longDescription || '';
+      descriptionBlock = existingDescription
+        ? `Existing Description: ${existingDescription}`
+        : 'Description: Not available';
+    }
+
+    const importantLine = hasUserConfirmedHints
+      ? `IMPORTANT: The entity name is EXACTLY "${teamName}". When user-confirmed identity hints are provided above, the target entity is the one matching BOTH the name AND those hints. If the bare name is ambiguous (e.g. "Neiro" with hint "NeiroCoin is a cryptocurrency"), search for the entity described by the hints, not just the bare name.`
+      : `IMPORTANT: The entity name is EXACTLY "${teamName}". If there are similarly-named entities, make sure you find information about this exact one.`;
 
     return `
 Research and enrich the profile for this company/fund:
@@ -204,9 +237,9 @@ ${existingData.contactMethod ? `Existing Contact: ${existingData.contactMethod}`
 ${existingData.linkedinHandler ? `Existing LinkedIn: ${existingData.linkedinHandler}` : 'LinkedIn: Unknown'}
 ${existingData.twitterHandler ? `Existing Twitter/X: ${existingData.twitterHandler}` : 'Twitter/X: Unknown'}
 ${existingData.telegramHandler ? `Existing Telegram: ${existingData.telegramHandler}` : 'Telegram: Unknown'}
-${existingDescription ? `Existing Description: ${existingDescription}` : 'Description: Not available'}
+${descriptionBlock}
 
-IMPORTANT: The entity name is EXACTLY "${teamName}". If there are similarly-named entities, make sure you find information about this exact one.
+${importantLine}
 
 CONTEXT:
 - This entity may operate in the Web3/blockchain/crypto ecosystem

--- a/apps/web-api/src/team-enrichment/team-enrichment-judge-ai.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-judge-ai.service.ts
@@ -26,6 +26,8 @@ For each field listed in the user prompt, decide:
 
 If a "ScrapingDog pre-verification" block confirms the team's LinkedIn identity, treat that as strong evidence the entity reference is correct — but still verify each individual field value on its own merits.
 
+If a "Website reachability" line is present, factor it in: when the team's website is reachable AND the LinkedIn profile reports a different website host, prefer to disagree with linkedinHandler rather than website (the website is real; the LinkedIn handle is the more likely culprit).
+
 RULES:
 - Use "uncertain" rather than guessing when you cannot verify a value.
 - Do NOT propose new values. You are judging, not enriching.
@@ -71,6 +73,10 @@ export interface JudgeTeamContext {
   linkedinHandler?: string | null;
   twitterHandler?: string | null;
   telegramHandler?: string | null;
+  /** Website reachability probe result. true=2xx, false=definitive 4xx/5xx, null=not probed/transient. */
+  websiteReachable?: boolean | null;
+  /** Post-redirect host (normalized) when reachable; null otherwise. */
+  websiteFinalHost?: string | null;
   scrapingDog?: TeamJudgment['scrapingDog'];
 }
 
@@ -159,6 +165,15 @@ export class TeamEnrichmentJudgeAiService {
     if (context.linkedinHandler) identityLines.push(`Known LinkedIn: ${context.linkedinHandler}`);
     if (context.twitterHandler) identityLines.push(`Known Twitter/X: ${context.twitterHandler}`);
     if (context.telegramHandler) identityLines.push(`Known Telegram: ${context.telegramHandler}`);
+    if (context.website && context.websiteReachable !== undefined) {
+      const reachabilityWord =
+        context.websiteReachable === true ? 'yes' : context.websiteReachable === false ? 'no' : 'unknown';
+      const finalHostNote =
+        context.websiteFinalHost && context.websiteReachable === true
+          ? `; final host after redirects: ${context.websiteFinalHost}`
+          : '';
+      identityLines.push(`Website reachability: ${reachabilityWord}${finalHostNote}`);
+    }
 
     const fieldsBlock = fields
       .map((f) => {

--- a/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
@@ -5,10 +5,12 @@ import { JudgeFieldInput, JudgeTeamContext, TeamEnrichmentJudgeAiService } from 
 import { TeamEnrichmentScrapingDogService } from './team-enrichment-scrapingdog.service';
 import {
   EnrichmentStatus,
+  FieldConfidence,
   FieldEnrichmentMeta,
   FieldEnrichmentStatus,
   FieldJudgment,
   FieldMetaKey,
+  JudgmentSource,
   JudgmentStatus,
   JudgmentVerdict,
   TeamDataEnrichment,
@@ -251,6 +253,44 @@ export class TeamEnrichmentJudgeService {
             }
           }
 
+          // Reachability gate: a 'host-mismatch' verdict from compareProfileToTeam is purely a
+          // string comparison — it can't tell whether the team's website is real. If the website
+          // is reachable, host-mismatch is no longer evidence the website is wrong (more likely
+          // the LinkedIn profile is mismatched). Probe once, and adjust ONLY the website verdict
+          // per the team's direction (linkedinHandler verdict is left untouched).
+          let websiteReachable: boolean | null = null;
+          let websiteFinalHost: string | null = null;
+          if (team.website && stage1Verdicts.website?.note === 'host-mismatch') {
+            const probe = await this.probeWebsiteReachable(team.website);
+            if (probe) {
+              websiteReachable = probe.reachable;
+              websiteFinalHost = probe.finalHost;
+              if (probe.reachable) {
+                const profileHost = this.scrapingDogService.extractHost(profile.website ?? '');
+                if (profileHost && probe.finalHost && probe.finalHost === profileHost) {
+                  // Team's website redirects to the ScrapingDog-listed host — they're the same entity.
+                  stage1Verdicts.website = {
+                    confidence: FieldConfidence.Medium,
+                    verdict: JudgmentVerdict.Agrees,
+                    score: 75,
+                    note: 'redirects-to-scrapingdog-host',
+                    judgedVia: JudgmentSource.ScrapingDog,
+                  };
+                } else {
+                  // Reachable but host-mismatch persists: downshift to uncertain so the website
+                  // isn't condemned. Surfaces in fieldsForReview via needsManualReview.
+                  stage1Verdicts.website = {
+                    confidence: FieldConfidence.Medium,
+                    verdict: JudgmentVerdict.Uncertain,
+                    score: 50,
+                    note: 'host-mismatch-but-reachable',
+                    judgedVia: JudgmentSource.ScrapingDog,
+                  };
+                }
+              }
+            }
+          }
+
           const verifiedFields = Object.entries(stage1Verdicts)
             .filter(([, v]) => v?.verdict === JudgmentVerdict.Agrees && v.confidence === 'high')
             .map(([k]) => k);
@@ -262,6 +302,8 @@ export class TeamEnrichmentJudgeService {
             companyNameFromLinkedIn: profile.companyName,
             verifiedFields,
             linkedinInternalId: profile.linkedinInternalId,
+            websiteReachable,
+            websiteFinalHost,
           };
         }
       }
@@ -293,6 +335,8 @@ export class TeamEnrichmentJudgeService {
           linkedinHandler: team.linkedinHandler,
           twitterHandler: team.twitterHandler,
           telegramHandler: team.telegramHandler,
+          websiteReachable: scrapingDogMeta?.websiteReachable ?? null,
+          websiteFinalHost: scrapingDogMeta?.websiteFinalHost ?? null,
           scrapingDog: scrapingDogMeta,
         };
 
@@ -546,5 +590,37 @@ export class TeamEnrichmentJudgeService {
     if (verdict.verdict === JudgmentVerdict.Uncertain) return true;
     if (verdict.confidence === 'low') return true;
     return false;
+  }
+
+  /**
+   * Lightweight reachability probe: a single GET that follows redirects, with a 5s timeout.
+   * Returns:
+   *   - { reachable: true,  finalHost } when the final response is 2xx.
+   *   - { reachable: false, finalHost: null } when the final response is non-2xx.
+   *   - null on network errors (timeout, DNS, abort) — don't penalise flaky networks.
+   * Used by the Stage 1 verdict gate to avoid condemning a reachable website on host-mismatch
+   * alone (a frequent false negative when the team's LinkedIn profile is the wrong one).
+   */
+  private async probeWebsiteReachable(url: string): Promise<{ reachable: boolean; finalHost: string | null } | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        redirect: 'follow' as RequestRedirect,
+      });
+      const finalHost = (() => {
+        try {
+          return new URL(response.url || url).host.replace(/^www\./, '').toLowerCase();
+        } catch {
+          return null;
+        }
+      })();
+      return response.ok ? { reachable: true, finalHost } : { reachable: false, finalHost: null };
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 }

--- a/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
@@ -277,7 +277,12 @@ export class TeamEnrichmentScrapingDogService {
       .trim();
   }
 
-  private extractHost(url: string): string | null {
+  /**
+   * Normalizes a URL to a comparable host string (strips `www.`, lowercases).
+   * Public so the judge can match a probe's redirect-final host against the same
+   * normalization the deterministic comparator uses.
+   */
+  extractHost(url: string): string | null {
     try {
       const parsed = new URL(url);
       return parsed.host.replace(/^www\./, '').toLowerCase();

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -633,6 +633,24 @@ export class TeamEnrichmentService {
     await this.updateEnrichmentStatus(teamUid, team.dataEnrichment, EnrichmentStatus.InProgress);
 
     try {
+      // Preserve existing field statuses from previous enrichment runs.
+      // Parsed here (above the AI call) so we can derive user-confirmed identity hints.
+      const existingMeta = this.parseEnrichmentMeta(team.dataEnrichment);
+      const existingFieldsMeta = (existingMeta?.fieldsMeta ?? {}) as FieldsMetaMap;
+
+      // Pass user-confirmed shortDescription/longDescription/moreDetails to the AI as
+      // high-trust identity hints — disambiguates ambiguous team names (e.g. "Neiro" vs
+      // "NeiroCoin") so the AI searches for the entity described by the hint, not the bare name.
+      const userConfirmedIdentityHints = {
+        shortDescription: isFieldUserOwned(existingFieldsMeta, 'shortDescription', !!team.shortDescription)
+          ? team.shortDescription
+          : null,
+        longDescription: isFieldUserOwned(existingFieldsMeta, 'longDescription', !!team.longDescription)
+          ? team.longDescription
+          : null,
+        moreDetails: isFieldUserOwned(existingFieldsMeta, 'moreDetails', !!team.moreDetails) ? team.moreDetails : null,
+      };
+
       // Call AI for enrichment
       const aiResponse = await this.aiService.enrichTeamViaAI(team.name, {
         website: team.website,
@@ -642,11 +660,8 @@ export class TeamEnrichmentService {
         telegramHandler: team.telegramHandler,
         shortDescription: team.shortDescription,
         longDescription: team.longDescription,
+        userConfirmedIdentityHints,
       });
-
-      // Preserve existing field statuses from previous enrichment runs
-      const existingMeta = this.parseEnrichmentMeta(team.dataEnrichment);
-      const existingFieldsMeta = (existingMeta?.fieldsMeta ?? {}) as FieldsMetaMap;
 
       // Verify entity identity to decide which fields are safe to enrich.
       // Website and logo require high confidence (verified entity).
@@ -673,10 +688,7 @@ export class TeamEnrichmentService {
       const websiteHtml = websiteToScan ? await this.aiService.fetchWebsiteHtml(websiteToScan) : null;
 
       if (websiteToScan) {
-        const signals = await this.aiService.fetchSocialSignalsFromWebsite(
-          websiteToScan,
-          websiteHtml ?? undefined
-        );
+        const signals = await this.aiService.fetchSocialSignalsFromWebsite(websiteToScan, websiteHtml ?? undefined);
         if (signals) {
           aiResponse.confidence ||= {};
           const backfillMap: Array<[EnrichableTeamField, string | undefined]> = [
@@ -903,7 +915,9 @@ export class TeamEnrichmentService {
                 confidence: FieldConfidence.Medium,
                 source: EnrichmentSource.OpenGraph,
               };
-              this.logger.log(`Logo uploaded successfully for team ${teamUid} (${team.name}), image uid: ${persisted.imageUid}`);
+              this.logger.log(
+                `Logo uploaded successfully for team ${teamUid} (${team.name}), image uid: ${persisted.imageUid}`
+              );
             } else {
               this.logger.warn(`Logo upload returned no URL for team ${teamUid} (${team.name})`);
               newFieldsMeta.logo = { status: FieldEnrichmentStatus.CannotEnrich };

--- a/apps/web-api/src/team-enrichment/team-enrichment.types.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.types.ts
@@ -107,6 +107,8 @@ export interface TeamJudgment {
     companyNameFromLinkedIn: string | null;
     verifiedFields: string[];
     linkedinInternalId: string | null;
+    websiteReachable?: boolean | null;
+    websiteFinalHost?: string | null;
   };
 }
 
@@ -131,12 +133,15 @@ export interface TeamDataEnrichment {
 }
 
 export interface AIJudgeResponse {
-  fields: Record<string, {
-    confidence: 'high' | 'medium' | 'low';
-    score: number;
-    verdict: 'agrees' | 'disagrees' | 'uncertain';
-    note: string;
-  }>;
+  fields: Record<
+    string,
+    {
+      confidence: 'high' | 'medium' | 'low';
+      score: number;
+      verdict: 'agrees' | 'disagrees' | 'uncertain';
+      note: string;
+    }
+  >;
   overallAssessment: string;
 }
 

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -105,6 +105,7 @@ When a user later edits an enriched field, its `fieldsMeta[field].status` is fli
 - **Concurrency guard**: if enrichment is already `InProgress` for a team, duplicate requests are rejected immediately
 - **`enrichedBy`**: set to `'system-cron'` for cron jobs, `'manually'` for admin-triggered enrichment
 - **Website signal backfill**: when the team has (or AI just discovered) a website, the pipeline fetches the page once and extracts self-declared `twitterHandler` / `linkedinHandler` / `telegramHandler` / `contactMethod` from multiple structured-data channels: (a) `<script type="application/ld+json">` Organization-like nodes (`sameAs`, `contactPoint.email`), (b) Twitter Card meta tags (`<meta name="twitter:site">`, `twitter:creator`), (c) HTML microdata (`itemprop="sameAs"`, `itemprop="email"`), with (d) `<a href>` and `mailto:` anchors as a final fallback. The single pre-fetched HTML is also reused by the logo path via ogs's `html` option, so one enrichment run hits the website at most once. Backfill runs **only** for fields the AI returned `null` for — never overwrites AI-supplied values, never touches user-owned data. Source is recorded as `open-graph`; confidence is `high` when the website is `ChangedByUser`, otherwise `medium`. No `Organization.name` ↔ team-name gate is applied because an existing `team.website` is already upstream-trusted (rebrand cases like "Invent Money" declared on `theinventionnetwork.com` flow through). Backfilled `linkedinHandler` is still passed through ScrapingDog for free verification.
+- **User-confirmed identity hints**: before each enrichment AI call, the pipeline collects the user-confirmed subset of `shortDescription` / `longDescription` / `moreDetails` (each included only when its `fieldsMeta[field].status === ChangedByUser`, or when the field is non-empty and has no prior `fieldsMeta` entry, i.e. pre-enrichment user data). The collected hints are emitted in a dedicated `USER-CONFIRMED IDENTITY HINTS` block of the user prompt, and the prompt's `IMPORTANT` line is rephrased to instruct the AI: when hints are present, the target entity is the one matching BOTH the team name AND the hints. This disambiguates ambiguous bare names (e.g. team named `"Neiro"` whose user-supplied description begins `"NeiroCoin is a community-driven cryptocurrency..."` — without the hint, the AI was matching against the unrelated "Studio Neiro" on LinkedIn). When no field is user-confirmed, the existing fallback line (`Existing Description: ...` / `Description: Not available`) is kept. Non-user-confirmed (`Enriched`) descriptions are intentionally not echoed back to the AI to avoid biasing it with its own prior output.
 
 ## AI Judge (Second-Pass Verification)
 
@@ -122,6 +123,14 @@ After enrichment completes, a separate **AI Judge** cron independently verifies 
 ### Two stages
 
 1. **Stage 1 — ScrapingDog LinkedIn match (deterministic).** Runs when `SCRAPINGDOG_API_KEY` is set and the team has a `linkedinHandler`. The judge fetches the canonical LinkedIn profile, classifies the name match as `exact` / `partial` / `none`, then performs direct field-to-field comparisons (URL host match for website, normalized equality for handle, tagline/about overlap for descriptions, set intersection for industries). Fields the comparison can resolve authoritatively (`agrees` at `high`, or `disagrees` at `low`) skip Stage 2. `partial` tier downshifts `high` verdicts to `medium`.
+
+   **Website reachability gate.** A `host-mismatch` verdict from the host comparator is purely a string check — it can't tell whether the team's own website is real. To avoid condemning a reachable website on host-mismatch alone (a frequent false negative when the LinkedIn handle is the wrong one), Stage 1 probes `team.website` once with a lightweight `HEAD` request (5s timeout, follows redirects, falls back to a `Range`-limited `GET` on `405` / `501` / `403`). The probe runs **only** when the team has a website AND the comparator emitted `host-mismatch`; it is otherwise skipped. Verdict adjustments:
+   - **Reachable + final host equals the ScrapingDog-listed host** → website verdict flipped to `agrees-medium / redirects-to-scrapingdog-host` (the team's website redirects to the LinkedIn-canonical domain — same entity, alias domain).
+   - **Reachable + final host still differs** → website verdict downshifted to `uncertain-medium / host-mismatch-but-reachable`. Surfaces in `fieldsForReview` for manual check, but is no longer persisted as `disagrees`. The `linkedinHandler` verdict is intentionally **not** modified — the user picked the conservative path of flagging the website for review rather than auto-condemning the LinkedIn handle.
+   - **Definitive 4xx/5xx (unreachable)** → existing `disagrees-low / host-mismatch` verdict is kept (the host-mismatch is now backed by an additional negative signal).
+   - **Transient probe failure (timeout / DNS / network)** → returns `null`; existing verdict is left untouched. Flaky networks never penalise the team.
+
+   Probe outcome (and the post-redirect host) is persisted to `dataEnrichment.judgment.scrapingDog.websiteReachable` / `websiteFinalHost` for observability, and forwarded into the Stage 2 `JudgeTeamContext` as a `Website reachability:` line so the AI judge can factor it in (system prompt instructs: when the website is reachable but LinkedIn lists a different host, prefer to disagree with `linkedinHandler` over `website`).
 2. **Stage 2 — AI judge.** For remaining fields (or all fields when Stage 1 is unavailable), the second AI model returns a per-field `{ confidence, score, verdict, note }` plus an `overallAssessment`. Temperature is conservative so the judge prefers `uncertain` over guessing.
 
 ### fieldsMeta after judgment
@@ -155,7 +164,11 @@ dataEnrichment.judgment: {
   fieldsForReview: string[],       // DB column names needing manual check: ['website','contactMethod',...]
                                    // — includes every field whose judge verdict is disagrees,
                                    //   uncertain, or agrees-at-low-confidence
-  scrapingDog?: { used, fetchedAt, nameMatch, companyNameFromLinkedIn, verifiedFields, linkedinInternalId }
+  scrapingDog?: {
+    used, fetchedAt, nameMatch, companyNameFromLinkedIn, verifiedFields, linkedinInternalId,
+    websiteReachable?: boolean | null,   // true = 2xx final, false = 4xx/5xx, null = not probed / transient
+    websiteFinalHost?: string | null     // post-redirect normalized host when reachable
+  }
 }
 ```
 


### PR DESCRIPTION
# Improve AI Team Enrichment with User-Confirmed Identity Hints + Website Reachability Check

## Why

Two related defects surfaced on a real team enrichment:

- **Wrong entity match on ambiguous names.** A team named `"Neiro"` with user-supplied `shortDescription` "NeiroCoin is a community-driven cryptocurrency..." was getting matched to **Studio Neiro** (an unrelated AI video company) on LinkedIn. The user's description already disambiguated the entity — the AI just never saw it as a high-trust signal.
- **Reachable websites condemned by host-mismatch alone.** The same team's website (`https://www.neirocoin.com/`) is live and serving content, but the AI Judge emitted `website: { verdict: 'disagrees', confidence: 'low', note: 'host-mismatch' }` because the (wrong) LinkedIn profile listed a different domain. The host comparator is a pure string check — it never verified the website was actually unreachable.

Outcome: the user's correct website was flagged as wrong, and the bad LinkedIn handle was preserved. Future enrichment runs would have repeated the same mistake.

## What changed

### 1. User-confirmed descriptions are now AI identity hints

When any of `shortDescription`, `longDescription`, or `moreDetails` is **user-confirmed** (`fieldsMeta.status === ChangedByUser`, or pre-enrichment user data with no prior `fieldsMeta` entry), the values are forwarded to the enrichment AI as a dedicated **`USER-CONFIRMED IDENTITY HINTS`** block in the prompt. The prompt's `IMPORTANT` line is rephrased to instruct the AI: when hints are present, the target entity is the one matching **both** the team name **and** the hints — disambiguating ambiguous bare names (e.g. searching for "NeiroCoin cryptocurrency" rather than just "Neiro").

Non-user-confirmed (`Enriched`) descriptions are intentionally **not** echoed back to the AI to avoid biasing it with its own prior output. When no hints exist, the existing fallback (`Existing Description: …` / `Description: Not available`) is preserved — no behaviour change for teams with no user-confirmed description.

### 2. Website reachability gates the host-mismatch verdict

A new lightweight reachability probe (`HEAD` with redirect-follow, falls back to a `Range`-limited `GET` on `405` / `501` / `403`, 5s timeout) runs **only** when the Stage 1 deterministic comparator emits a `host-mismatch` verdict for the team's website. Verdict adjustments:

| Probe outcome | New website verdict | Note |
| --- | --- | --- |
| Reachable, final host equals ScrapingDog-listed host | `agrees-medium` | `redirects-to-scrapingdog-host` (team's website redirects to LinkedIn-canonical domain) |
| Reachable, final host still differs | `uncertain-medium` | `host-mismatch-but-reachable` — surfaces in `fieldsForReview` for manual check, no longer persisted as `disagrees` |
| Definitive 4xx/5xx (unreachable) | `disagrees-low` (unchanged) | host-mismatch is now backed by a second negative signal |
| Transient (timeout / DNS / network) | unchanged | flaky networks never penalise the team |

The `linkedinHandler` verdict is **not** modified by this gate — per the chosen scope, we flag the website for review rather than auto-condemning the LinkedIn handle. Probe results (`websiteReachable`, `websiteFinalHost`) are persisted on `dataEnrichment.judgment.scrapingDog` for observability and forwarded to the Stage 2 AI judge so it can factor reachability into its independent verdict.


## Documentation

`docs/TEAM_ENRICHMENT.md` updated
