### PR TITLE
[Team Enrichment] [AI Judge] LinkedIn handle verification

### DIFF
--- a/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
@@ -105,7 +105,9 @@ export class TeamEnrichmentScrapingDogService {
       // treat as not-found rather than ok. Preserves the original callers' ability to trust
       // classifyNameMatch on an 'ok' response.
       if (!profile.companyName && !profile.universalNameId) {
-        this.logger.warn(`ScrapingDog returned profile with no company_name/universal_name_id for id "${id}", treating as not-found`);
+        this.logger.warn(
+          `ScrapingDog returned profile with no company_name/universal_name_id for id "${id}", treating as not-found`
+        );
         return { kind: 'not-found' };
       }
 
@@ -173,14 +175,38 @@ export class TeamEnrichmentScrapingDogService {
       }
     }
 
-    // linkedinHandler — normalized equality with universal_name_id
-    if (team.linkedinHandler && profile.universalNameId) {
-      const teamHandle = this.normalizeHandleForCompare(team.linkedinHandler);
-      const profileHandle = this.normalizeHandleForCompare(profile.universalNameId);
-      if (teamHandle === profileHandle) {
-        result.linkedinHandler = mkJudgment(FieldConfidence.High, JudgmentVerdict.Agrees, 100, 'handle-match');
+    // linkedinHandler — corroborated by company_name match (and optionally website host).
+    // The actual identity signal is that ScrapingDog returned a profile whose `company_name` matches the team.
+    // Website host equality is a strong corroborating signal when both sides declare a website.
+    if (team.linkedinHandler && profile.companyName) {
+      const websiteCorroborates =
+        !!team.website && !!profile.website && this.extractHost(team.website) === this.extractHost(profile.website);
+
+      if (nameMatch === 'exact') {
+        result.linkedinHandler = mkJudgment(
+          FieldConfidence.High,
+          JudgmentVerdict.Agrees,
+          websiteCorroborates ? 100 : 95,
+          websiteCorroborates ? 'name-match+website' : 'name-match'
+        );
       } else {
-        result.linkedinHandler = mkJudgment(FieldConfidence.Low, JudgmentVerdict.Disagrees, 15, 'handle-mismatch');
+        // nameMatch === 'partial'. A partial-only match (e.g. "Acme Inc" vs "Acme BV")
+        // is too risky to mark as Agrees on its own — surface it for review.
+        if (websiteCorroborates) {
+          result.linkedinHandler = mkJudgment(
+            FieldConfidence.High,
+            JudgmentVerdict.Agrees,
+            90,
+            'name-match-partial+website'
+          );
+        } else {
+          result.linkedinHandler = mkJudgment(
+            FieldConfidence.Medium,
+            JudgmentVerdict.Uncertain,
+            55,
+            'name-match-partial-only'
+          );
+        }
       }
     }
 
@@ -265,15 +291,6 @@ export class TeamEnrichmentScrapingDogService {
       .toLowerCase()
       .replace(/[^a-z0-9\s]/g, '')
       .replace(/\s+/g, ' ')
-      .trim();
-  }
-
-  private normalizeHandleForCompare(s: string): string {
-    return s
-      .toLowerCase()
-      .replace(/^https?:\/\/(www\.)?linkedin\.com\//, '')
-      .replace(/^company\//, '')
-      .replace(/[\/\s]+$/, '')
       .trim();
   }
 

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -123,7 +123,19 @@ After enrichment completes, a separate **AI Judge** cron independently verifies 
 
 ### Two stages
 
-1. **Stage 1 — ScrapingDog LinkedIn match (deterministic).** Runs when `SCRAPINGDOG_API_KEY` is set and the team has a `linkedinHandler`. The judge fetches the canonical LinkedIn profile, classifies the name match as `exact` / `partial` / `none`, then performs direct field-to-field comparisons (URL host match for website, normalized equality for handle, tagline/about overlap for descriptions, set intersection for industries). Fields the comparison can resolve authoritatively (`agrees` at `high`, or `disagrees` at `low`) skip Stage 2. `partial` tier downshifts `high` verdicts to `medium`.
+1. **Stage 1 — ScrapingDog LinkedIn match (deterministic).** Runs when `SCRAPINGDOG_API_KEY` is set and the team has a `linkedinHandler`. The judge fetches the canonical LinkedIn profile, classifies the name match as `exact` / `partial` / `none`, then performs direct field-to-field comparisons (URL host match for website, **`company_name` match + optional website-host corroboration for the LinkedIn handle itself**, tagline/about overlap for descriptions, set intersection for industries). Fields the comparison can resolve authoritatively (`agrees` at `high`, or `disagrees` at `low`) skip Stage 2. `partial` tier downshifts `high` verdicts to `medium`.
+
+   **`linkedinHandler` verification — name match, not slug match.** The handle verdict is **not** produced by comparing the team's stored slug to ScrapingDog's `universal_name_id`. LinkedIn 301-redirects renamed companies to their canonical slug, so a stored `company/oldco` resolving to a profile whose `universal_name_id` is `newco-rebrand` would falsely look like a mismatch even though it points at the correct entity. Instead, Stage 1 trusts the precondition that produced this comparator run: ScrapingDog returned a profile whose `company_name` matched the team (per `classifyNameMatch`), so the handle pointed at the right company. Optionally, a website-host equality between `team.website` and `profile.website` corroborates the match and bumps confidence/score. Verdict matrix:
+
+   | `nameMatch` | website host equal | verdict     | confidence | score | note                          |
+   | ----------- | ------------------ | ----------- | ---------- | ----- | ----------------------------- |
+   | `exact`     | yes                | `agrees`    | `high`     | 100   | `name-match+website`          |
+   | `exact`     | no / unknown       | `agrees`    | `high`     | 95    | `name-match`                  |
+   | `partial`   | yes                | `agrees`    | `medium`¹  | 90    | `name-match-partial+website`  |
+   | `partial`   | no / unknown       | `uncertain` | `medium`   | 55    | `name-match-partial-only`     |
+   | `none`      | —                  | —           | —          | —     | _no Stage 1 verdict — falls through to Stage 2 AI judge_ |
+
+   ¹ via the existing `partial → medium` downshift in `mkJudgment`. A partial-only name match with no corroborating website (e.g. "Acme Inc" vs "Acme BV") is intentionally surfaced as `uncertain` rather than silently agreed, so it lands in `fieldsForReview`. `nameMatch === 'none'` continues to skip the comparator entirely; the AI judge handles those.
 
    **Website reachability gate.** A `host-mismatch` verdict from the host comparator is purely a string check — it can't tell whether the team's own website is real. To avoid condemning a reachable website on host-mismatch alone (a frequent false negative when the LinkedIn handle is the wrong one), Stage 1 probes `team.website` once with a lightweight `HEAD` request (5s timeout, follows redirects, falls back to a `Range`-limited `GET` on `405` / `501` / `403`). The probe runs **only** when the team has a website AND the comparator emitted `host-mismatch`; it is otherwise skipped. Verdict adjustments:
 


### PR DESCRIPTION
## Problem

The AI Judge's Stage 1 (deterministic ScrapingDog) was verifying a team's `linkedinHandler` by string-comparing the stored slug against ScrapingDog's `universal_name_id`. That check is misleading:

- **LinkedIn 301-redirects renamed companies to a new canonical slug.** A perfectly valid stored handle like `company/oldco` resolves to a profile whose `universal_name_id` is now `newco-rebrand` — same company, different string. The judge flagged it as `disagrees / low / handle-mismatch` and surfaced it for manual review. False negative.
- **Slug equality has no semantic meaning by itself.** Two slugs being identical doesn't prove identity (handle could simply have been guessed correctly), and two slugs differing doesn't prove a mismatch (rename redirects). The slug is a routing key, not an entity assertion.
- **The real identity signal was already in the same payload but unused for the handle verdict.** ScrapingDog returns `company_name`, which we already compare to the team name elsewhere via `classifyNameMatch`.

Net effect: real teams with renamed LinkedIn handles were repeatedly landing in `fieldsForReview`, and on the flip side, lookalike companies with coincidentally matching slugs got rubber-stamped.

## Improvement

Replace the slug-vs-slug check with a **company-name match plus optional website-host corroboration**. The fact that ScrapingDog resolved the team's stored handle to a profile whose `company_name` matches the team is the actual proof the handle is correct. When the team's `website` host also equals ScrapingDog's `profile.website` host, that's an independent corroborating signal that bumps confidence/score.

Outcomes by case:

- **Exact name match** → `agrees / high` (resolved by Stage 1, no AI judge call). Correctly handles LinkedIn renames.
- **Exact name match + website host also agrees** → `agrees / high / 100` (top score).
- **Partial name match + website host agrees** → `agrees / medium`. Strong enough to trust but kept at medium so the AI judge gives a second opinion.
- **Partial name match alone** → `uncertain / medium`. Lookalike companies (e.g. "Acme Inc" vs "Acme BV") are now surfaced for review instead of silently approved.
- **No name match** → unchanged: no Stage 1 verdict, falls through to the AI judge.

## Impact

- Eliminates the false-positive `handle-mismatch` flag triggered by LinkedIn renames.
- Tightens the partial-name-match path so similarly-named different entities surface for review instead of getting auto-approved.
- No change to data shape or downstream consumers; existing `fieldJudgment.note` strings become more meaningful (`name-match`, `name-match+website`, `name-match-partial+website`, `name-match-partial-only`) instead of the binary `handle-match` / `handle-mismatch`.
- Documentation in `docs/TEAM_ENRICHMENT.md` updated with the new verdict matrix and rationale.
