### PR TITLE
[Team Enrichment] [AI Judge] Improve URL verification

### DIFF
--- a/apps/web-api/src/team-enrichment/team-enrichment-judge-ai.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-judge-ai.service.ts
@@ -26,7 +26,7 @@ For each field listed in the user prompt, decide:
 
 If a "ScrapingDog pre-verification" block confirms the team's LinkedIn identity, treat that as strong evidence the entity reference is correct — but still verify each individual field value on its own merits.
 
-If a "Website reachability" line is present, factor it in: when the team's website is reachable AND the LinkedIn profile reports a different website host, prefer to disagree with linkedinHandler rather than website (the website is real; the LinkedIn handle is the more likely culprit).
+URL fields (website, blog, contactMethod, social handles): do NOT mark a value as "disagrees" merely because it differs from another URL we already have on file (e.g. the LinkedIn-listed website). Companies routinely use alias domains, product subdomains, or rebrand without updating LinkedIn. Verify each URL on its own merits via web search; prefer "uncertain" when you cannot independently confirm or refute it.
 
 RULES:
 - Use "uncertain" rather than guessing when you cannot verify a value.
@@ -73,10 +73,6 @@ export interface JudgeTeamContext {
   linkedinHandler?: string | null;
   twitterHandler?: string | null;
   telegramHandler?: string | null;
-  /** Website reachability probe result. true=2xx, false=definitive 4xx/5xx, null=not probed/transient. */
-  websiteReachable?: boolean | null;
-  /** Post-redirect host (normalized) when reachable; null otherwise. */
-  websiteFinalHost?: string | null;
   scrapingDog?: TeamJudgment['scrapingDog'];
 }
 
@@ -165,15 +161,6 @@ export class TeamEnrichmentJudgeAiService {
     if (context.linkedinHandler) identityLines.push(`Known LinkedIn: ${context.linkedinHandler}`);
     if (context.twitterHandler) identityLines.push(`Known Twitter/X: ${context.twitterHandler}`);
     if (context.telegramHandler) identityLines.push(`Known Telegram: ${context.telegramHandler}`);
-    if (context.website && context.websiteReachable !== undefined) {
-      const reachabilityWord =
-        context.websiteReachable === true ? 'yes' : context.websiteReachable === false ? 'no' : 'unknown';
-      const finalHostNote =
-        context.websiteFinalHost && context.websiteReachable === true
-          ? `; final host after redirects: ${context.websiteFinalHost}`
-          : '';
-      identityLines.push(`Website reachability: ${reachabilityWord}${finalHostNote}`);
-    }
 
     const fieldsBlock = fields
       .map((f) => {

--- a/apps/web-api/src/team-enrichment/team-enrichment-judge-ai.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-judge-ai.service.ts
@@ -28,6 +28,11 @@ If a "ScrapingDog pre-verification" block confirms the team's LinkedIn identity,
 
 URL fields (website, blog, contactMethod, social handles): do NOT mark a value as "disagrees" merely because it differs from another URL we already have on file (e.g. the LinkedIn-listed website). Companies routinely use alias domains, product subdomains, or rebrand without updating LinkedIn. Verify each URL on its own merits via web search; prefer "uncertain" when you cannot independently confirm or refute it.
 
+If a "Website reachability" line is present, treat it as a signal — never the only signal:
+- "yes" (reachable, 2xx) — the URL is live, but liveness alone does not prove brand identity. Continue to verify the URL belongs to the team via web search.
+- "no" (definitive 4xx/5xx) — meaningful negative signal that the URL is stale or wrong. Lean toward "disagrees" for the website verdict if you also can't confirm it via web search.
+- "unknown" (not probed or transient network failure) — do not infer either way.
+
 RULES:
 - Use "uncertain" rather than guessing when you cannot verify a value.
 - Do NOT propose new values. You are judging, not enriching.
@@ -73,6 +78,10 @@ export interface JudgeTeamContext {
   linkedinHandler?: string | null;
   twitterHandler?: string | null;
   telegramHandler?: string | null;
+  /** Website reachability probe result. true=2xx, false=definitive 4xx/5xx, null=not probed/transient/invalid URL. */
+  websiteReachable?: boolean | null;
+  /** Post-redirect host (normalized) when reachable; null otherwise. */
+  websiteFinalHost?: string | null;
   scrapingDog?: TeamJudgment['scrapingDog'];
 }
 
@@ -161,6 +170,15 @@ export class TeamEnrichmentJudgeAiService {
     if (context.linkedinHandler) identityLines.push(`Known LinkedIn: ${context.linkedinHandler}`);
     if (context.twitterHandler) identityLines.push(`Known Twitter/X: ${context.twitterHandler}`);
     if (context.telegramHandler) identityLines.push(`Known Telegram: ${context.telegramHandler}`);
+    if (context.website && context.websiteReachable !== undefined) {
+      const reachabilityWord =
+        context.websiteReachable === true ? 'yes' : context.websiteReachable === false ? 'no' : 'unknown';
+      const finalHostNote =
+        context.websiteFinalHost && context.websiteReachable === true
+          ? `; final host after redirects: ${context.websiteFinalHost}`
+          : '';
+      identityLines.push(`Website reachability: ${reachabilityWord}${finalHostNote}`);
+    }
 
     const fieldsBlock = fields
       .map((f) => {

--- a/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { z } from 'zod';
 import { PrismaService } from '../shared/prisma.service';
 import { buildTeamEnrichmentEligibilityFilter } from './team-enrichment-eligibility-filter';
 import { JudgeFieldInput, JudgeTeamContext, TeamEnrichmentJudgeAiService } from './team-enrichment-judge-ai.service';
@@ -66,6 +67,24 @@ const USER_JUDGABLE_FIELD_KEYS: ReadonlySet<FieldMetaKey> = new Set<FieldMetaKey
   'telegramHandler',
 ]);
 
+/**
+ * Fields whose stored value MUST parse as a URL to be judgable. Anything that doesn't pass
+ * the URL-format check (e.g. `'n/a'`, `'coming soon'`, `'tba'`, `'mercle.ai'` without scheme)
+ * is skipped from judgment entirely — there's nothing meaningful for the judge to verify, and
+ * we don't want it to fabricate a verdict against junk input. We don't maintain a placeholder
+ * blocklist; the URL-format check (zod's `z.string().url()`, backed by WHATWG `new URL()`)
+ * already rejects every common placeholder. Other URL-ish fields (`contactMethod` can be an
+ * email or invite link; `linkedinHandler` / `twitterHandler` / `telegramHandler` are often
+ * bare handles) are intentionally not gated here — the AI judge handles them.
+ */
+const URL_REQUIRED_FIELD_KEYS: ReadonlySet<FieldMetaKey> = new Set<FieldMetaKey>(['website', 'blog']);
+
+const urlSchema = z.string().url();
+
+function isValidUrl(value: string): boolean {
+  return urlSchema.safeParse(value.trim()).success;
+}
+
 @Injectable()
 export class TeamEnrichmentJudgeService {
   private readonly logger = new Logger(TeamEnrichmentJudgeService.name);
@@ -113,7 +132,7 @@ export class TeamEnrichmentJudgeService {
       const judgmentStatus = meta?.judgment?.status;
       if (judgmentStatus === JudgmentStatus.Judged) return false;
       if (judgmentStatus === JudgmentStatus.InProgress) return false;
-      return this.collectJudgableFieldKeys(meta?.fieldsMeta ?? {}).length > 0;
+      return this.collectJudgableFieldKeys(t as TeamRecord, meta?.fieldsMeta ?? {}).length > 0;
     });
   }
 
@@ -137,7 +156,7 @@ export class TeamEnrichmentJudgeService {
       return { status: 'not_eligible' };
     }
 
-    const judgableKeys = this.collectJudgableFieldKeys(meta.fieldsMeta ?? {});
+    const judgableKeys = this.collectJudgableFieldKeys(team, meta.fieldsMeta ?? {});
     if (judgableKeys.length === 0) {
       this.logger.log(`Judge: team ${teamUid} has no judgable fields, skipping`);
       return { status: 'not_eligible' };
@@ -165,7 +184,7 @@ export class TeamEnrichmentJudgeService {
       return { status: 'in_progress' };
     }
 
-    const judgableKeys = this.collectJudgableFieldKeys(meta.fieldsMeta ?? {});
+    const judgableKeys = this.collectJudgableFieldKeys(team, meta.fieldsMeta ?? {});
     if (judgableKeys.length === 0) {
       this.logger.log(`Force-judge: team ${teamUid} has no judgable fields, skipping`);
       return { status: 'not_eligible' };
@@ -251,6 +270,21 @@ export class TeamEnrichmentJudgeService {
             }
           }
 
+          // Reachability probe — pure observability + AI-judge context. Runs only when the team
+          // has a non-placeholder, parseable http(s) website (the same gate `collectJudgableFieldKeys`
+          // applies, so we never probe `'n/a'`/`'coming soon'`/etc. and never call `fetch` on a string
+          // that isn't a real URL). Result is forwarded into Stage 2 so the AI judge can factor a
+          // definitive 4xx/5xx into its website verdict.
+          let websiteReachable: boolean | null = null;
+          let websiteFinalHost: string | null = null;
+          if (team.website && this.hasJudgableValue(team, 'website')) {
+            const probe = await this.probeWebsiteReachable(team.website);
+            if (probe) {
+              websiteReachable = probe.reachable;
+              websiteFinalHost = probe.finalHost;
+            }
+          }
+
           const verifiedFields = Object.entries(stage1Verdicts)
             .filter(([, v]) => v?.verdict === JudgmentVerdict.Agrees && v.confidence === 'high')
             .map(([k]) => k);
@@ -262,6 +296,8 @@ export class TeamEnrichmentJudgeService {
             companyNameFromLinkedIn: profile.companyName,
             verifiedFields,
             linkedinInternalId: profile.linkedinInternalId,
+            websiteReachable,
+            websiteFinalHost,
           };
         }
       }
@@ -293,6 +329,8 @@ export class TeamEnrichmentJudgeService {
           linkedinHandler: team.linkedinHandler,
           twitterHandler: team.twitterHandler,
           telegramHandler: team.telegramHandler,
+          websiteReachable: scrapingDogMeta?.websiteReachable ?? null,
+          websiteFinalHost: scrapingDogMeta?.websiteFinalHost ?? null,
           scrapingDog: scrapingDogMeta,
         };
 
@@ -387,21 +425,41 @@ export class TeamEnrichmentJudgeService {
    *  - status === Enriched (any judgable key), OR
    *  - status === ChangedByUser AND key is in USER_JUDGABLE_FIELD_KEYS (website + contact links)
    *  - excludes logo and CannotEnrich
+   *
+   * Additionally, URL-required fields (`website`, `blog`) whose stored value doesn't parse as a
+   * URL (`'n/a'`, `'coming soon'`, `'tbd'`, etc. all fail the URL check) are skipped. This
+   * prevents the judge from wasting an AI call — and producing a misleading verdict — on fields
+   * that have no real data.
    */
-  private collectJudgableFieldKeys(fieldsMeta: FieldsMetaMap): FieldMetaKey[] {
+  private collectJudgableFieldKeys(team: TeamRecord, fieldsMeta: FieldsMetaMap): FieldMetaKey[] {
     const out: FieldMetaKey[] = [];
     for (const key of JUDGABLE_FIELD_KEYS) {
       const meta = fieldsMeta[key];
       if (!meta) continue;
-      if (meta.status === FieldEnrichmentStatus.Enriched) {
-        out.push(key);
-        continue;
-      }
-      if (meta.status === FieldEnrichmentStatus.ChangedByUser && USER_JUDGABLE_FIELD_KEYS.has(key)) {
-        out.push(key);
-      }
+      const statusOk =
+        meta.status === FieldEnrichmentStatus.Enriched ||
+        (meta.status === FieldEnrichmentStatus.ChangedByUser && USER_JUDGABLE_FIELD_KEYS.has(key));
+      if (!statusOk) continue;
+      if (!this.hasJudgableValue(team, key)) continue;
+      out.push(key);
     }
     return out;
+  }
+
+  /**
+   * True when the field's stored value is non-empty and (for URL-required fields) parses as a
+   * URL. Used both for the candidate filter and for gating the reachability probe. The URL
+   * check transparently rejects placeholders like `'n/a'` / `'coming soon'` / `'tba'` — they
+   * don't parse as URLs — so no separate placeholder blocklist is needed.
+   */
+  private hasJudgableValue(team: TeamRecord, key: FieldMetaKey): boolean {
+    const value = this.readFieldValue(team, key);
+    if (value === null || value === undefined) return false;
+    if (Array.isArray(value)) return value.length > 0;
+    const trimmed = value.trim();
+    if (!trimmed) return false;
+    if (URL_REQUIRED_FIELD_KEYS.has(key) && !isValidUrl(trimmed)) return false;
+    return true;
   }
 
   private buildFieldInput(team: TeamRecord, fieldsMeta: FieldsMetaMap, key: FieldMetaKey): JudgeFieldInput | null {
@@ -546,5 +604,40 @@ export class TeamEnrichmentJudgeService {
     if (verdict.verdict === JudgmentVerdict.Uncertain) return true;
     if (verdict.confidence === 'low') return true;
     return false;
+  }
+
+  /**
+   * Lightweight reachability probe: a single GET that follows redirects, with a 5s timeout.
+   * Returns:
+   *   - { reachable: true,  finalHost } when the final response is 2xx.
+   *   - { reachable: false, finalHost: null } when the final response is non-2xx.
+   *   - null on network errors (timeout, DNS, abort) — don't penalise flaky networks.
+   *
+   * Output is forwarded into the AI judge as observability: a definitive 4xx/5xx is a
+   * meaningful negative signal for the website verdict; a 2xx confirms the URL is live but
+   * not that it belongs to the team. Callers must pre-validate that `url` is a parseable
+   * http(s) URL (not a placeholder like `'n/a'`); this method does not re-validate.
+   */
+  private async probeWebsiteReachable(url: string): Promise<{ reachable: boolean; finalHost: string | null } | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        redirect: 'follow' as RequestRedirect,
+      });
+      const finalHost = (() => {
+        try {
+          return new URL(response.url || url).host.replace(/^www\./, '').toLowerCase();
+        } catch {
+          return null;
+        }
+      })();
+      return response.ok ? { reachable: true, finalHost } : { reachable: false, finalHost: null };
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 }

--- a/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
@@ -5,12 +5,10 @@ import { JudgeFieldInput, JudgeTeamContext, TeamEnrichmentJudgeAiService } from 
 import { TeamEnrichmentScrapingDogService } from './team-enrichment-scrapingdog.service';
 import {
   EnrichmentStatus,
-  FieldConfidence,
   FieldEnrichmentMeta,
   FieldEnrichmentStatus,
   FieldJudgment,
   FieldMetaKey,
-  JudgmentSource,
   JudgmentStatus,
   JudgmentVerdict,
   TeamDataEnrichment,
@@ -253,44 +251,6 @@ export class TeamEnrichmentJudgeService {
             }
           }
 
-          // Reachability gate: a 'host-mismatch' verdict from compareProfileToTeam is purely a
-          // string comparison — it can't tell whether the team's website is real. If the website
-          // is reachable, host-mismatch is no longer evidence the website is wrong (more likely
-          // the LinkedIn profile is mismatched). Probe once, and adjust ONLY the website verdict
-          // per the team's direction (linkedinHandler verdict is left untouched).
-          let websiteReachable: boolean | null = null;
-          let websiteFinalHost: string | null = null;
-          if (team.website && stage1Verdicts.website?.note === 'host-mismatch') {
-            const probe = await this.probeWebsiteReachable(team.website);
-            if (probe) {
-              websiteReachable = probe.reachable;
-              websiteFinalHost = probe.finalHost;
-              if (probe.reachable) {
-                const profileHost = this.scrapingDogService.extractHost(profile.website ?? '');
-                if (profileHost && probe.finalHost && probe.finalHost === profileHost) {
-                  // Team's website redirects to the ScrapingDog-listed host — they're the same entity.
-                  stage1Verdicts.website = {
-                    confidence: FieldConfidence.Medium,
-                    verdict: JudgmentVerdict.Agrees,
-                    score: 75,
-                    note: 'redirects-to-scrapingdog-host',
-                    judgedVia: JudgmentSource.ScrapingDog,
-                  };
-                } else {
-                  // Reachable but host-mismatch persists: downshift to uncertain so the website
-                  // isn't condemned. Surfaces in fieldsForReview via needsManualReview.
-                  stage1Verdicts.website = {
-                    confidence: FieldConfidence.Medium,
-                    verdict: JudgmentVerdict.Uncertain,
-                    score: 50,
-                    note: 'host-mismatch-but-reachable',
-                    judgedVia: JudgmentSource.ScrapingDog,
-                  };
-                }
-              }
-            }
-          }
-
           const verifiedFields = Object.entries(stage1Verdicts)
             .filter(([, v]) => v?.verdict === JudgmentVerdict.Agrees && v.confidence === 'high')
             .map(([k]) => k);
@@ -302,8 +262,6 @@ export class TeamEnrichmentJudgeService {
             companyNameFromLinkedIn: profile.companyName,
             verifiedFields,
             linkedinInternalId: profile.linkedinInternalId,
-            websiteReachable,
-            websiteFinalHost,
           };
         }
       }
@@ -335,8 +293,6 @@ export class TeamEnrichmentJudgeService {
           linkedinHandler: team.linkedinHandler,
           twitterHandler: team.twitterHandler,
           telegramHandler: team.telegramHandler,
-          websiteReachable: scrapingDogMeta?.websiteReachable ?? null,
-          websiteFinalHost: scrapingDogMeta?.websiteFinalHost ?? null,
           scrapingDog: scrapingDogMeta,
         };
 
@@ -590,37 +546,5 @@ export class TeamEnrichmentJudgeService {
     if (verdict.verdict === JudgmentVerdict.Uncertain) return true;
     if (verdict.confidence === 'low') return true;
     return false;
-  }
-
-  /**
-   * Lightweight reachability probe: a single GET that follows redirects, with a 5s timeout.
-   * Returns:
-   *   - { reachable: true,  finalHost } when the final response is 2xx.
-   *   - { reachable: false, finalHost: null } when the final response is non-2xx.
-   *   - null on network errors (timeout, DNS, abort) — don't penalise flaky networks.
-   * Used by the Stage 1 verdict gate to avoid condemning a reachable website on host-mismatch
-   * alone (a frequent false negative when the team's LinkedIn profile is the wrong one).
-   */
-  private async probeWebsiteReachable(url: string): Promise<{ reachable: boolean; finalHost: string | null } | null> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
-    try {
-      const response = await fetch(url, {
-        signal: controller.signal,
-        redirect: 'follow' as RequestRedirect,
-      });
-      const finalHost = (() => {
-        try {
-          return new URL(response.url || url).host.replace(/^www\./, '').toLowerCase();
-        } catch {
-          return null;
-        }
-      })();
-      return response.ok ? { reachable: true, finalHost } : { reachable: false, finalHost: null };
-    } catch {
-      return null;
-    } finally {
-      clearTimeout(timeout);
-    }
   }
 }

--- a/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
@@ -162,18 +162,9 @@ export class TeamEnrichmentScrapingDogService {
       judgedVia: JudgmentSource.ScrapingDog,
     });
 
-    // website — URL host match (strip www.)
-    if (team.website && profile.website) {
-      const teamHost = this.extractHost(team.website);
-      const profileHost = this.extractHost(profile.website);
-      if (teamHost && profileHost) {
-        if (teamHost === profileHost) {
-          result.website = mkJudgment(FieldConfidence.High, JudgmentVerdict.Agrees, 95, 'host-match');
-        } else {
-          result.website = mkJudgment(FieldConfidence.Low, JudgmentVerdict.Disagrees, 20, 'host-mismatch');
-        }
-      }
-    }
+    // website — intentionally not judged here. A LinkedIn-vs-team URL host comparison is too
+    // noisy: LinkedIn often lists an outdated, aliased, or product-subdomain URL even when the
+    // team's website is correct. The AI judge (Stage 2) can verify the website with web search instead.
 
     // linkedinHandler — corroborated by company_name match (and optionally website host).
     // The actual identity signal is that ScrapingDog returned a profile whose `company_name` matches the team.

--- a/apps/web-api/src/team-enrichment/team-enrichment.types.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.types.ts
@@ -107,6 +107,8 @@ export interface TeamJudgment {
     companyNameFromLinkedIn: string | null;
     verifiedFields: string[];
     linkedinInternalId: string | null;
+    websiteReachable?: boolean | null;
+    websiteFinalHost?: string | null;
   };
 }
 

--- a/apps/web-api/src/team-enrichment/team-enrichment.types.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.types.ts
@@ -107,8 +107,6 @@ export interface TeamJudgment {
     companyNameFromLinkedIn: string | null;
     verifiedFields: string[];
     linkedinInternalId: string | null;
-    websiteReachable?: boolean | null;
-    websiteFinalHost?: string | null;
   };
 }
 

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -123,7 +123,7 @@ After enrichment completes, a separate **AI Judge** cron independently verifies 
 
 ### Two stages
 
-1. **Stage 1 — ScrapingDog LinkedIn match (deterministic).** Runs when `SCRAPINGDOG_API_KEY` is set and the team has a `linkedinHandler`. The judge fetches the canonical LinkedIn profile, classifies the name match as `exact` / `partial` / `none`, then performs direct field-to-field comparisons (URL host match for website, **`company_name` match + optional website-host corroboration for the LinkedIn handle itself**, tagline/about overlap for descriptions, set intersection for industries). Fields the comparison can resolve authoritatively (`agrees` at `high`, or `disagrees` at `low`) skip Stage 2. `partial` tier downshifts `high` verdicts to `medium`.
+1. **Stage 1 — ScrapingDog LinkedIn match (deterministic).** Runs when `SCRAPINGDOG_API_KEY` is set and the team has a `linkedinHandler`. The judge fetches the canonical LinkedIn profile, classifies the name match as `exact` / `partial` / `none`, then performs direct field-to-field comparisons (**`company_name` match + optional website-host corroboration for the LinkedIn handle itself**, tagline/about overlap for descriptions, set intersection for industries). Fields the comparison can resolve authoritatively (`agrees` at `high`, or `disagrees` at `low`) skip Stage 2. `partial` tier downshifts `high` verdicts to `medium`.
 
    **`linkedinHandler` verification — name match, not slug match.** The handle verdict is **not** produced by comparing the team's stored slug to ScrapingDog's `universal_name_id`. LinkedIn 301-redirects renamed companies to their canonical slug, so a stored `company/oldco` resolving to a profile whose `universal_name_id` is `newco-rebrand` would falsely look like a mismatch even though it points at the correct entity. Instead, Stage 1 trusts the precondition that produced this comparator run: ScrapingDog returned a profile whose `company_name` matched the team (per `classifyNameMatch`), so the handle pointed at the right company. Optionally, a website-host equality between `team.website` and `profile.website` corroborates the match and bumps confidence/score. Verdict matrix:
 
@@ -137,14 +137,7 @@ After enrichment completes, a separate **AI Judge** cron independently verifies 
 
    ¹ via the existing `partial → medium` downshift in `mkJudgment`. A partial-only name match with no corroborating website (e.g. "Acme Inc" vs "Acme BV") is intentionally surfaced as `uncertain` rather than silently agreed, so it lands in `fieldsForReview`. `nameMatch === 'none'` continues to skip the comparator entirely; the AI judge handles those.
 
-   **Website reachability gate.** A `host-mismatch` verdict from the host comparator is purely a string check — it can't tell whether the team's own website is real. To avoid condemning a reachable website on host-mismatch alone (a frequent false negative when the LinkedIn handle is the wrong one), Stage 1 probes `team.website` once with a lightweight `HEAD` request (5s timeout, follows redirects, falls back to a `Range`-limited `GET` on `405` / `501` / `403`). The probe runs **only** when the team has a website AND the comparator emitted `host-mismatch`; it is otherwise skipped. Verdict adjustments:
-
-   - **Reachable + final host equals the ScrapingDog-listed host** → website verdict flipped to `agrees-medium / redirects-to-scrapingdog-host` (the team's website redirects to the LinkedIn-canonical domain — same entity, alias domain).
-   - **Reachable + final host still differs** → website verdict downshifted to `uncertain-medium / host-mismatch-but-reachable`. Surfaces in `fieldsForReview` for manual check, but is no longer persisted as `disagrees`. The `linkedinHandler` verdict is intentionally **not** modified — the user picked the conservative path of flagging the website for review rather than auto-condemning the LinkedIn handle.
-   - **Definitive 4xx/5xx (unreachable)** → existing `disagrees-low / host-mismatch` verdict is kept (the host-mismatch is now backed by an additional negative signal).
-   - **Transient probe failure (timeout / DNS / network)** → returns `null`; existing verdict is left untouched. Flaky networks never penalise the team.
-
-   Probe outcome (and the post-redirect host) is persisted to `dataEnrichment.judgment.scrapingDog.websiteReachable` / `websiteFinalHost` for observability, and forwarded into the Stage 2 `JudgeTeamContext` as a `Website reachability:` line so the AI judge can factor it in (system prompt instructs: when the website is reachable but LinkedIn lists a different host, prefer to disagree with `linkedinHandler` over `website`).
+   **`website` (and other URL fields) — not judged by Stage 1.** Earlier revisions emitted a `host-match` / `host-mismatch` verdict by comparing the team's stored URL to the URL listed on the LinkedIn profile. This produced too many false negatives — companies routinely use alias domains, product subdomains, or rebrand without updating LinkedIn (e.g. team `Mercle` with website `mercle.ai` whose LinkedIn profile lists a different host) — so the comparator was condemning correct websites. The deterministic comparator is therefore intentionally silent on URL fields; the AI judge (Stage 2) verifies them via web search instead, and is explicitly instructed not to disagree on a URL solely because it differs from another URL we already have on file. Same reasoning as the `linkedinHandler` slug-equality removal.
 
 2. **Stage 2 — AI judge.** For remaining fields (or all fields when Stage 1 is unavailable), the second AI model returns a per-field `{ confidence, score, verdict, note }` plus an `overallAssessment`. Temperature is conservative so the judge prefers `uncertain` over guessing.
 
@@ -161,7 +154,7 @@ fieldsMeta[field]: {
     confidence: 'high' | 'medium' | 'low',   // judge's independent assessment
     score: 0..100,
     verdict: 'agrees' | 'disagrees' | 'uncertain',
-    note?: string,                 // max 60 chars, hyphenated-keyword style (e.g. 'host-match')
+    note?: string,                 // max 60 chars, hyphenated-keyword style (e.g. 'name-match')
     judgedVia: 'scrapingdog' | 'ai',
   }
 }
@@ -180,9 +173,7 @@ dataEnrichment.judgment: {
                                    // — includes every field whose judge verdict is disagrees,
                                    //   uncertain, or agrees-at-low-confidence
   scrapingDog?: {
-    used, fetchedAt, nameMatch, companyNameFromLinkedIn, verifiedFields, linkedinInternalId,
-    websiteReachable?: boolean | null,   // true = 2xx final, false = 4xx/5xx, null = not probed / transient
-    websiteFinalHost?: string | null     // post-redirect normalized host when reachable
+    used, fetchedAt, nameMatch, companyNameFromLinkedIn, verifiedFields, linkedinInternalId
   }
 }
 ```

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -139,7 +139,18 @@ After enrichment completes, a separate **AI Judge** cron independently verifies 
 
    **`website` (and other URL fields) — not judged by Stage 1.** Earlier revisions emitted a `host-match` / `host-mismatch` verdict by comparing the team's stored URL to the URL listed on the LinkedIn profile. This produced too many false negatives — companies routinely use alias domains, product subdomains, or rebrand without updating LinkedIn (e.g. team `Mercle` with website `mercle.ai` whose LinkedIn profile lists a different host) — so the comparator was condemning correct websites. The deterministic comparator is therefore intentionally silent on URL fields; the AI judge (Stage 2) verifies them via web search instead, and is explicitly instructed not to disagree on a URL solely because it differs from another URL we already have on file. Same reasoning as the `linkedinHandler` slug-equality removal.
 
+   **Website reachability probe.** Stage 1 still runs a lightweight reachability probe on `team.website` (single GET, follows redirects, 5s timeout). The result is **purely observability** — no Stage 1 verdict is produced from it, since the host comparator is gone. It's persisted to `dataEnrichment.judgment.scrapingDog.websiteReachable` / `websiteFinalHost` and forwarded to Stage 2 as a `Website reachability:` line so the AI judge can factor a definitive `4xx`/`5xx` (real negative signal) into its website verdict. The probe runs only when the team has a website that passes the value-validity gate below, so we never `fetch()` a placeholder string.
+
 2. **Stage 2 — AI judge.** For remaining fields (or all fields when Stage 1 is unavailable), the second AI model returns a per-field `{ confidence, score, verdict, note }` plus an `overallAssessment`. Temperature is conservative so the judge prefers `uncertain` over guessing.
+
+### Value-validity gate (URL-format skip)
+
+Before a field is judged at all, its stored value is checked. Fields that fail this check are **skipped entirely** — no Stage 1 verdict, no Stage 2 AI call, no entry in `fieldsForReview` (there is nothing meaningful to verify, and we don't want the AI to hallucinate a verdict against junk input):
+
+- **Empty / null** values are skipped. Empty arrays for `industryTags` / `investmentFocus` are skipped.
+- **URL-required fields (`website`, `blog`)** must pass `z.string().url()` (zod, backed by WHATWG `new URL()`). This rejects every common placeholder (`'n/a'`, `'na'`, `'tbd'`, `'tba'`, `'coming soon'`, `'pending'`, `'-'`, etc.) without maintaining an explicit blocklist, because none of them parse as URLs. It also rejects schemeless values like `mercle.ai` or `discord.gg/xxx` typed directly into `website` — the user still sees the value, but the judge won't fabricate a verdict for it.
+
+Other URL-ish fields (`contactMethod`, social handles) are not URL-gated, because they legitimately accept bare handles, `mailto:` addresses, or invite-style links. The AI judge handles those with its standard "prefer `uncertain` over guessing" rule.
 
 ### fieldsMeta after judgment
 
@@ -173,7 +184,9 @@ dataEnrichment.judgment: {
                                    // — includes every field whose judge verdict is disagrees,
                                    //   uncertain, or agrees-at-low-confidence
   scrapingDog?: {
-    used, fetchedAt, nameMatch, companyNameFromLinkedIn, verifiedFields, linkedinInternalId
+    used, fetchedAt, nameMatch, companyNameFromLinkedIn, verifiedFields, linkedinInternalId,
+    websiteReachable?: boolean | null,   // true = 2xx final, false = 4xx/5xx, null = not probed / transient / invalid URL
+    websiteFinalHost?: string | null     // post-redirect normalized host when reachable
   }
 }
 ```

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -198,6 +198,66 @@ POST /v1/admin/teams/:uid/trigger-force-judgment     # Re-run judge even if alre
 
 All require `AdminAuthGuard`. They do NOT require `IS_TEAM_ENRICHMENT_ENABLED` — manual overrides.
 
+## Logo Verification (Vision-Model Pass)
+
+A separate, **logo-only** verification pipeline. It runs independently of the enrichment / judge crons and writes its results to the `TeamLogoVerificationResult` Postgres table — it never mutates `Team.logo`, `Team.logoUid`, or `dataEnrichment`. Output is an append-only audit log that admins (or downstream review tooling) can query to spot wrong-brand logos uploaded or auto-fetched onto a team.
+
+### What it does
+
+For each candidate team, the job downloads the current logo image (SVG is rasterized to PNG via `sharp`) and sends it to a vision-language model (VLM) along with the team name + website. The VLM returns a JSON verdict:
+
+```ts
+{
+  predictedCompanyName: string | null,
+  verdict: 'verified' | 'weak_match' | 'mismatch' | 'unverifiable',
+  confidence: 'high' | 'medium' | 'low',
+  quality: 'good' | 'poor' | 'unusable',
+  hasReadableText: boolean,
+  reason: string,
+  brandSignals: string[]
+}
+```
+
+A new row is inserted into `TeamLogoVerificationResult` per run — history is preserved across re-runs (logo swaps, model bumps, force re-verifies). The row carries `teamUid`, `logoUid`, `provider`, `model`, the snapshotted `website` / `logoUrl` / `source`, the parsed verdict fields, and the `rawResponse` for debugging.
+
+### Cron
+
+- **Schedule**: `LOGO_VERIFICATION_CRON` env var (default `0 */6 * * *` — every 6 hours UTC). Runs separately from the enrichment / marking / judge crons and on its own toggle.
+- **Guard**: `IS_LOGO_VERIFICATION_ENABLED` must be `'true'` (default `false`). Independent of `IS_TEAM_ENRICHMENT_ENABLED`.
+- **In-process re-entry guard**: an `isRunning` flag prevents two ticks from overlapping if a batch outlives its interval.
+- **Batch size**: `LOGO_VERIFICATION_BATCH_SIZE` (default `20`) — number of teams pulled per tick. Sequential per-team processing keeps VLM rate-limits manageable.
+
+### How teams are picked
+
+Two filters run in order:
+
+1. **DB-level candidates** — `team-logo-verification` selects teams where `logoUid IS NOT NULL`, ordered by `updatedAt DESC`, limited to `LOGO_VERIFICATION_BATCH_SIZE`. Recently-changed teams surface first so a freshly-uploaded or freshly-enriched logo gets verified on the next tick. There is no `isFund` / priority filter — every team that has a logo is eligible.
+2. **Per-team `shouldVerifyTeam` gate** — for each candidate, the persistence layer looks up the latest `TeamLogoVerificationResult` for the same `(teamUid, provider)` pair and skips if all of the following hold:
+   - a prior result exists,
+   - its `logoUid` matches the team's current `logoUid` (i.e. the logo wasn't replaced),
+   - its `model` matches the currently-resolved model name.
+
+   If the logo was swapped, or the VLM model was upgraded (e.g. `gemini-2.5-flash` → a newer Gemini), the team re-verifies. Teams with no `logoUid` are also skipped at this stage (defensive — the DB filter already excludes them).
+
+3. **Force re-verify** — set `LOGO_VERIFICATION_FORCE_UPDATE=true` to bypass the per-team gate and re-verify every batched team regardless of prior results. Useful when calibrating against a new VLM or after a prompt change.
+
+### Provider selection
+
+Resolved per run from `LOGO_VLM_PROVIDER` (default `gemini`). Each provider has its own model env var: `GEMINI_LOGO_VERIFICATION_MODEL` (default `gemini-2.5-flash`), `OPENAI_LOGO_VERIFICATION_MODEL` (default `gpt-4.1-mini`), `ANTHROPIC_LOGO_VERIFICATION_MODEL` (default `claude-3-5-sonnet-latest`). The chosen `provider` and `model` are persisted on every row, so the table remains queryable when defaults change.
+
+### On-demand admin endpoints
+
+The same VLM service is also exposed via on-demand HTTP endpoints (no auth guard wired here — intended for internal tooling). These do **not** write to `TeamLogoVerificationResult`; only the cron persists.
+
+```
+POST /team-enrichment/verify-logo                       # single image, default provider
+POST /team-enrichment/verify-logo/all                   # runs gemini + openai + anthropic in parallel + composite decision
+POST /team-enrichment/verify-logo/provider/:provider    # single image, specific provider
+POST /team-enrichment/verify-logo/batch                 # batch of images, mode: all | gemini | openai | anthropic
+```
+
+The `/all` variant returns a composite `decision: 'accept' | 'reject' | 'review'` derived from cross-provider agreement (e.g. both Gemini and OpenAI saying `verified` → `accept`; Gemini saying `mismatch` at high confidence → `reject`; otherwise → `review`).
+
 ## ScrapingDog Fallback (LinkedIn)
 
 A secondary, high-confidence enrichment source that queries LinkedIn company profiles via the [ScrapingDog](https://www.scrapingdog.com/) API. Because the API is paid, it is **only** called when the primary AI+OG pass leaves high-value gaps.
@@ -394,6 +454,14 @@ The shared `isFieldUserOwned(fieldsMeta, field, slotHasValue)` helper at the top
 | `TEAM_ENRICHMENT_MARKING_CRON`      | `0 2 * * *`         | Cron schedule for auto-marking eligible teams                                                                                                                                                              |
 | `TEAM_ENRICHMENT_JUDGE_CRON`        | `0 4 * * *`         | Cron schedule for the AI Judge second-pass verification job                                                                                                                                                |
 | `SCRAPINGDOG_API_KEY`               | —                   | ScrapingDog LinkedIn API key. When set, enables the ScrapingDog fallback for teams with a known `linkedinHandler`.                                                                                         |
+| `IS_LOGO_VERIFICATION_ENABLED`      | `false`             | Enable/disable the Logo Verification cron. Independent of `IS_TEAM_ENRICHMENT_ENABLED`.                                                                                                                    |
+| `LOGO_VERIFICATION_CRON`            | `0 */6 * * *`       | Cron schedule for the Logo Verification job (every 6 hours UTC by default).                                                                                                                                |
+| `LOGO_VERIFICATION_BATCH_SIZE`      | `20`                | Max teams pulled per Logo Verification tick. Sequential per-team to keep VLM rate-limits manageable.                                                                                                       |
+| `LOGO_VERIFICATION_FORCE_UPDATE`    | `false`             | When `true`, bypasses the per-team `shouldVerifyTeam` gate and re-verifies every batched team regardless of prior results.                                                                                 |
+| `LOGO_VLM_PROVIDER`                 | `gemini`            | Vision-language model provider for Logo Verification. Accepts `gemini`, `openai`, or `anthropic`. Independent of `AI_PROVIDER`.                                                                            |
+| `GEMINI_LOGO_VERIFICATION_MODEL`    | `gemini-2.5-flash`  | Gemini model used by the Logo Verification job when `LOGO_VLM_PROVIDER=gemini`.                                                                                                                            |
+| `OPENAI_LOGO_VERIFICATION_MODEL`    | `gpt-4.1-mini`      | OpenAI model used by the Logo Verification job when `LOGO_VLM_PROVIDER=openai`.                                                                                                                            |
+| `ANTHROPIC_LOGO_VERIFICATION_MODEL` | `claude-3-5-sonnet-latest` | Anthropic model used by the Logo Verification job when `LOGO_VLM_PROVIDER=anthropic`.                                                                                                              |
 
 ### Eligibility filter
 
@@ -430,6 +498,11 @@ apps/web-api/src/team-enrichment/
   team-enrichment-judge-ai.service.ts # Judge LLM wrapper (independent model)
   team-enrichment-judge.service.ts  # Two-stage judgment pipeline orchestration
   team-enrichment-judge.job.ts      # Judge cron job
+  logo-verification.types.ts        # Verdict / confidence / quality types for the VLM pass
+  logo-verification.service.ts      # VLM wrapper (gemini / openai / anthropic) + image prep
+  logo-verification-persistence.service.ts # Candidate selection + shouldVerify gate + TeamLogoVerificationResult writes
+  logo-verification-job.service.ts  # Logo Verification cron job
+  logo-verification.controller.ts   # On-demand /team-enrichment/verify-logo* endpoints
   team-enrichment.module.ts         # NestJS module
 ```
 


### PR DESCRIPTION
## Summary

The deterministic Stage 1 judge was emitting `host-mismatch` / `disagrees` verdicts on a team's `website` whenever the host didn't match the URL listed on the team's LinkedIn profile. This produced false negatives on perfectly correct websites — companies routinely use alias domains, product subdomains, or rebrand without updating LinkedIn (e.g. team `Mercle` with website `mercle.ai` was being flagged because its LinkedIn profile lists a different host).

This change drops the URL-vs-team-URL comparator (matching the recent `linkedinHandler` "name-match, not slug-match" fix in #3104) and adds a value-validity gate so the judge skips fields whose stored value is a placeholder like `n/a` / `coming soon` / `tbd` or — for `website` / `blog` — not a parseable http(s) URL. The lightweight reachability probe is kept as observability and as input to the Stage 2 AI judge.

## What changed

- The deterministic ScrapingDog comparator no longer judges `website` — no more `host-match` / `host-mismatch` verdict. Verifying URLs is now exclusively the AI judge's job.
- The Stage 2 AI judge prompt is updated: do not mark a URL as `disagrees` merely because it differs from another URL we already have on file; prefer `uncertain` when an independent web check can't confirm or refute it.
- The Stage 1 reachability probe (`HEAD`/`GET`, 5s timeout, follows redirects) is **kept** but its role changes — it no longer adjusts a Stage 1 verdict (there's no host-match verdict to adjust), it's pure observability and AI-judge input. `dataEnrichment.judgment.scrapingDog.websiteReachable` and `websiteFinalHost` are still persisted.
- New value-validity gate in `collectJudgableFieldKeys`: empty values are skipped, and URL-required fields (`website`, `blog`) must pass `z.string().url()` (zod, backed by WHATWG `new URL()`). This transparently rejects every common placeholder (`n/a`, `tbd`, `coming soon`, etc.) — they don't parse as URLs — without maintaining a hand-curated blocklist. Skipped fields produce no Stage 1 verdict, no Stage 2 AI call, no `fieldsForReview` entry.
- The reachability probe is gated by the same value-validity check, so we never `fetch()` a non-URL string.
- `docs/TEAM_ENRICHMENT.md` updated to document both the URL-comparison removal and the new value-validity gate; AI judge system prompt rewritten in line with the new rules.
