### PR TITLE
[Team Enrichment] API Updates for Admin

### DIFF
--- a/apps/web-api/src/admin/admin-teams.controller.ts
+++ b/apps/web-api/src/admin/admin-teams.controller.ts
@@ -22,13 +22,14 @@ import { ZodValidationPipe } from '@abitia/zod-dto';
 import { AdminTeamsService } from './admin-teams.service';
 import {
   ApproveEnrichmentFieldsBodyDto,
-  EnrichmentReviewQueryDto,
   TriggerForceEnrichmentQueryDto,
   UploadTeamTiersQueryDto,
 } from './schema/admin-teams';
 import { TeamEnrichmentService } from '../team-enrichment/team-enrichment.service';
 import { TeamEnrichmentJudgeService } from '../team-enrichment/team-enrichment-judge.service';
 import { TeamEnrichmentReportService } from '../team-enrichment/team-enrichment-report.service';
+import { TeamEnrichmentJob } from '../team-enrichment/team-enrichment.job';
+import { TeamEnrichmentJudgeJob } from '../team-enrichment/team-enrichment-judge.job';
 
 @ApiTags('Admin Teams')
 @Controller('v1/admin/teams')
@@ -38,7 +39,9 @@ export class AdminTeamsController {
     private readonly adminTeamsService: AdminTeamsService,
     private readonly teamEnrichmentService: TeamEnrichmentService,
     private readonly teamEnrichmentJudgeService: TeamEnrichmentJudgeService,
-    private readonly teamEnrichmentReportService: TeamEnrichmentReportService
+    private readonly teamEnrichmentReportService: TeamEnrichmentReportService,
+    private readonly teamEnrichmentJob: TeamEnrichmentJob,
+    private readonly teamEnrichmentJudgeJob: TeamEnrichmentJudgeJob
   ) {}
 
   @Post('tiers/upload')
@@ -102,17 +105,54 @@ export class AdminTeamsController {
   }
 
   /**
-   * Paginated list of teams whose enrichment has at least one reviewable field —
-   * any `fieldsMeta[k].judgment.confidence !== 'high'`, or a latest logo verification
-   * whose `confidence !== 'high'`. Only teams in `EnrichmentStatus.Enriched` are included.
+   * Full list of teams whose enrichment is in `EnrichmentStatus.Enriched`, including every
+   * judged field regardless of confidence. The response carries both the live `teamLogo`
+   * (`Team.logo`) and the candidate `logo` (`TeamEnrichment.logo`) so admins can compare.
    */
   @Get('enrichment-review')
   @NoCache()
-  async listEnrichmentsForReview(@Query(new ZodValidationPipe()) query: EnrichmentReviewQueryDto) {
-    return this.teamEnrichmentService.listEnrichmentsForReview({
-      page: query.page,
-      pageSize: query.pageSize,
-    });
+  async listEnrichmentsForReview() {
+    return this.teamEnrichmentService.listEnrichmentsForReview();
+  }
+
+  /**
+   * Enrich + judge status snapshot for the enrichment + judge cron jobs.
+   *
+   * `isRunning` is a per-pod in-memory flag — accurate within this process, but if the API
+   * runs as multiple replicas only one pod will see `true`. Pending / in-progress counts come
+   * from the DB and are authoritative across pods.
+   *
+   * Declared before `/:uid/enrichment-status` so Nest routes the static segment first.
+   */
+  @Get('enrichment-status')
+  @NoCache()
+  async getEnrichmentCronStatus() {
+    const counts = await this.teamEnrichmentService.getCronCounts();
+    return {
+      enrichment: {
+        isRunning: this.teamEnrichmentJob.enrichmentRunning,
+        pending: counts.enrichment.pending,
+        inProgress: counts.enrichment.inProgress,
+      },
+      marking: { isRunning: this.teamEnrichmentJob.markingRunning },
+      judge: {
+        isRunning: this.teamEnrichmentJudgeJob.judgmentRunning,
+        pending: counts.judge.pending,
+        inProgress: counts.judge.inProgress,
+      },
+    };
+  }
+
+  /**
+   * Per-team enrich + judge status snapshot — enrichment status (e.g. PendingEnrichment /
+   * Enriched / Reviewed), `enrichedAt` / `judgedAt` timestamps, and judge `fieldsForReview`.
+   * Returns 404 if the team uid doesn't exist; returns `enrichment: null` if the team has no
+   * `TeamEnrichment` row yet.
+   */
+  @Get('/:uid/enrichment-status')
+  @NoCache()
+  async getEnrichmentStatus(@Param('uid') uid: string) {
+    return this.teamEnrichmentService.getEnrichmentStatus(uid);
   }
 
   /**

--- a/apps/web-api/src/admin/schema/admin-teams.ts
+++ b/apps/web-api/src/admin/schema/admin-teams.ts
@@ -71,24 +71,6 @@ export const TriggerForceEnrichmentQuerySchema = z.object({
 export class TriggerForceEnrichmentQueryDto extends createZodDto(TriggerForceEnrichmentQuerySchema) {}
 
 /**
- * Query parameters for GET /v1/admin/teams/enrichment-review (paginated list of teams
- * with at least one low/medium-confidence reviewable field or logo verification).
- *
- * Service-side clamps bounds — the DTO only converts string → number.
- */
-const toOptionalInt = (v: unknown): number | undefined => {
-  if (v === undefined || v === null || v === '') return undefined;
-  const num = typeof v === 'string' ? parseInt(v, 10) : typeof v === 'number' ? v : NaN;
-  return Number.isFinite(num) ? num : undefined;
-};
-
-export const EnrichmentReviewQuerySchema = z.object({
-  page: z.union([z.string(), z.number()]).optional().transform(toOptionalInt),
-  pageSize: z.union([z.string(), z.number()]).optional().transform(toOptionalInt),
-});
-export class EnrichmentReviewQueryDto extends createZodDto(EnrichmentReviewQuerySchema) {}
-
-/**
  * Reviewable field keys for the field-level approve endpoint. Mirrors FieldMetaKey from
  * team-enrichment.types.ts — duplicated here so the Zod layer can validate without dragging
  * an enum import into the schema module. Keep in sync if FieldMetaKey changes.

--- a/apps/web-api/src/team-enrichment/team-enrichment-judge.job.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-judge.job.ts
@@ -9,6 +9,11 @@ export class TeamEnrichmentJudgeJob {
 
   constructor(private readonly judgeService: TeamEnrichmentJudgeService) {}
 
+  /** Per-pod in-memory flag — `true` while this pod's judge cron tick is mid-flight. */
+  get judgmentRunning(): boolean {
+    return this.isJudgmentRunning;
+  }
+
   // Default: daily at 4 AM UTC (one hour after the default 3 AM enrichment cron).
   @Cron(process.env.TEAM_ENRICHMENT_JUDGE_CRON || '0 4 * * *', {
     name: 'team-enrichment-judge',

--- a/apps/web-api/src/team-enrichment/team-enrichment.job.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.job.ts
@@ -10,6 +10,16 @@ export class TeamEnrichmentJob {
 
   constructor(private readonly teamEnrichmentService: TeamEnrichmentService) { }
 
+  /** Per-pod in-memory flag — `true` while this pod's enrichment cron tick is mid-flight. */
+  get enrichmentRunning(): boolean {
+    return this.isEnrichmentRunning;
+  }
+
+  /** Per-pod in-memory flag — `true` while this pod's marking cron tick is mid-flight. */
+  get markingRunning(): boolean {
+    return this.isMarkingRunning;
+  }
+
   // Default: every 5 minutes
   @Cron(process.env.TEAM_ENRICHMENT_CRON || '*/5 * * * *', {
     name: 'team-enrichment',

--- a/apps/web-api/src/team-enrichment/team-enrichment.module.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.module.ts
@@ -31,6 +31,8 @@ import { LogoVerificationJobService } from './logo-verification-job.service';
     TeamEnrichmentService,
     TeamEnrichmentJudgeService,
     TeamEnrichmentReportService,
+    TeamEnrichmentJob,
+    TeamEnrichmentJudgeJob,
     LogoVerificationService,
     LogoVerificationPersistenceService,
   ],

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -26,14 +26,14 @@ import {
 
 export type EnrichmentReviewFieldEntry = {
   content: string | string[];
-  metadata: { source?: EnrichmentSource; lastModifiedAt?: string };
+  metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
   judgment: { note?: string; score?: number };
   promotable: boolean;
 };
 
 export type EnrichmentReviewLogo = {
   content: { uid: string; url: string } | null;
-  metadata: { source?: EnrichmentSource; lastModifiedAt?: string };
+  metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
   verification: {
     verdict: string;
     confidence: string;
@@ -47,7 +47,6 @@ export type EnrichmentReviewItem = {
   uid: string;
   name: string;
   enrichmentStatus: EnrichmentStatus;
-  teamLogo: { uid: string; url: string } | null;
   fields: Partial<Record<FieldMetaKey, EnrichmentReviewFieldEntry>>;
   logo?: EnrichmentReviewLogo;
 };
@@ -1214,7 +1213,21 @@ export class TeamEnrichmentService {
       where: { dataEnrichment: { path: ['status'], equals: EnrichmentStatus.Enriched } },
       select: {
         teamUid: true,
-        team: { select: { uid: true, name: true, logo: { select: { uid: true, url: true } } } },
+        team: {
+          select: {
+            uid: true,
+            name: true,
+            logo: { select: { uid: true, url: true } },
+            website: true,
+            blog: true,
+            contactMethod: true,
+            twitterHandler: true,
+            linkedinHandler: true,
+            telegramHandler: true,
+            shortDescription: true,
+            longDescription: true,
+          },
+        },
         website: true,
         blog: true,
         contactMethod: true,
@@ -1223,7 +1236,6 @@ export class TeamEnrichmentService {
         telegramHandler: true,
         shortDescription: true,
         longDescription: true,
-        moreDetails: true,
         logoUid: true,
         logo: { select: { uid: true, url: true } },
         investmentFocus: true,
@@ -1271,17 +1283,55 @@ export class TeamEnrichmentService {
       for (const [keyStr, fieldMeta] of Object.entries(meta.fieldsMeta) as Array<
         [FieldMetaKey, FieldEnrichmentMeta | undefined]
       >) {
-        if (!fieldMeta?.judgment) continue;
-        if (keyStr === 'logo') continue;
+        if (keyStr === 'moreDetails') continue;
 
-        const candidate = (row as any)[keyStr];
-        if (candidate === null || candidate === undefined) continue;
-        if (typeof candidate === 'string' && candidate.trim() === '') continue;
-        if (Array.isArray(candidate) && candidate.length === 0) continue;
+        // Logo: no AI judgment exists (logo isn't judged — binary presence, not semantic).
+        // Emit it as a regular field with `content = Image.url` so the UI can iterate
+        // uniformly. The richer VLM verification still lives on the top-level `logo` block.
+        if (keyStr === 'logo') {
+          const logoUrl = row.logo?.url ?? row.team.logo?.url;
+          if (!logoUrl) continue;
+          fields.logo = {
+            content: logoUrl,
+            metadata: {
+              status: fieldMeta?.status,
+              source: fieldMeta?.source,
+              lastModifiedAt: fieldMeta?.lastModifiedAt,
+            },
+            judgment: {},
+            promotable: fieldMeta?.status !== FieldEnrichmentStatus.ChangedByUser,
+          };
+          continue;
+        }
+
+        if (!fieldMeta?.judgment) continue;
+
+        // Status decides the source of truth:
+        //   - ChangedByUser → Team.<field> (user-owned value lives on Team; the TeamEnrichment
+        //     candidate, if any, is informational provenance)
+        //   - Enriched / CannotEnrich → TeamEnrichment.<field> (AI candidate not yet promoted)
+        // Fallback to the other side covers rows where one side is empty (e.g. AI candidate
+        // promoted-then-cleared, or pre-tracking user data with stale meta).
+        const isUserOwned = fieldMeta.status === FieldEnrichmentStatus.ChangedByUser;
+        const teamValue = (row.team as any)[keyStr];
+        const enrichmentValue = (row as any)[keyStr];
+        const isEmpty = (v: any) =>
+          v === null ||
+          v === undefined ||
+          (typeof v === 'string' && v.trim() === '') ||
+          (Array.isArray(v) && v.length === 0);
+        const primary = isUserOwned ? teamValue : enrichmentValue;
+        const fallback = isUserOwned ? enrichmentValue : teamValue;
+        const candidate = !isEmpty(primary) ? primary : fallback;
+        if (isEmpty(candidate)) continue;
 
         fields[keyStr] = {
           content: candidate,
-          metadata: { source: fieldMeta.source, lastModifiedAt: fieldMeta.lastModifiedAt },
+          metadata: {
+            status: fieldMeta.status,
+            source: fieldMeta.source,
+            lastModifiedAt: fieldMeta.lastModifiedAt,
+          },
           judgment: { note: fieldMeta.judgment.note, score: fieldMeta.judgment.score },
           promotable: fieldMeta.status !== FieldEnrichmentStatus.ChangedByUser,
         };
@@ -1293,7 +1343,11 @@ export class TeamEnrichmentService {
       if (row.logoUid) {
         logo = {
           content: row.logo ? { uid: row.logo.uid, url: row.logo.url } : null,
-          metadata: { source: logoMeta?.source, lastModifiedAt: logoMeta?.lastModifiedAt },
+          metadata: {
+            status: logoMeta?.status,
+            source: logoMeta?.source,
+            lastModifiedAt: logoMeta?.lastModifiedAt,
+          },
           verification: latestLogoVerif
             ? {
                 verdict: latestLogoVerif.verdict,
@@ -1310,7 +1364,6 @@ export class TeamEnrichmentService {
         uid: row.team.uid,
         name: row.team.name,
         enrichmentStatus: meta.status,
-        teamLogo: row.team.logo ? { uid: row.team.logo.uid, url: row.team.logo.url } : null,
         fields,
         ...(logo ? { logo } : {}),
       });

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
 import { FileUploadService } from '../utils/file-upload/file-upload.service';
@@ -19,6 +19,7 @@ import {
   FieldMetaKey,
   ForceEnrichmentMode,
   JudgmentSource,
+  JudgmentStatus,
   JudgmentVerdict,
   TeamDataEnrichment,
 } from './team-enrichment.types';
@@ -46,6 +47,7 @@ export type EnrichmentReviewItem = {
   uid: string;
   name: string;
   enrichmentStatus: EnrichmentStatus;
+  teamLogo: { uid: string; url: string } | null;
   fields: Partial<Record<FieldMetaKey, EnrichmentReviewFieldEntry>>;
   logo?: EnrichmentReviewLogo;
 };
@@ -55,6 +57,45 @@ export type ApproveEnrichmentFieldsResult = {
   promoted: string[];
   skipped: Array<{ field: string; reason: string }>;
   message?: string;
+};
+
+export type TeamEnrichmentStatusEntry = {
+  status: EnrichmentStatus;
+  shouldEnrich: boolean;
+  enrichedAt: string | null;
+  enrichedBy: string | null;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+  errorMessage: string | null;
+  aiModel: string | null;
+};
+
+export type TeamJudgmentStatusEntry = {
+  status: JudgmentStatus;
+  judgedAt: string | null;
+  judgedBy: string | null;
+  aiModel: string | null;
+  errorMessage: string | null;
+  overallAssessment: string | null;
+  fieldsForReview: string[];
+};
+
+export type TeamEnrichmentStatusResult = {
+  uid: string;
+  name: string;
+  enrichment: TeamEnrichmentStatusEntry | null;
+  judgment: TeamJudgmentStatusEntry | null;
+};
+
+export type EnrichmentCronCounts = {
+  enrichment: { pending: number; inProgress: number };
+  judge: { pending: number; inProgress: number };
+};
+
+export type EnrichmentCronStatusResult = {
+  enrichment: { isRunning: boolean; pending: number; inProgress: number };
+  marking: { isRunning: boolean };
+  judge: { isRunning: boolean; pending: number; inProgress: number };
 };
 
 const CONFIDENCE_RANK: Record<string, number> = {
@@ -1156,30 +1197,24 @@ export class TeamEnrichmentService {
   }
 
   /**
-   * Paginated list of teams whose enrichment has at least one reviewable item:
-   *  - any `fieldsMeta[k].judgment.confidence` is medium/low (k ∈ scalars + industryTags + investmentFocus), OR
-   *  - latest `TeamLogoVerificationResult` row has `confidence !== 'high'`.
-   *
-   * Only teams whose top-level `dataEnrichment.status === 'Enriched'` are considered — Reviewed /
-   * Approved / PendingEnrichment / InProgress / FailedToEnrich are out of scope.
+   * Full list of teams whose enrichment is in `EnrichmentStatus.Enriched`. Includes every
+   * judged field regardless of confidence so admins can spot-check what the judge promoted.
    *
    * Per-field rules:
-   *  - high-confidence fields are hidden (already promoted by judge)
-   *  - empty candidates are excluded
+   *  - fields without a `fieldsMeta[k].judgment` entry are skipped (not review-ready)
+   *  - empty candidate values (null / empty string / empty array) are excluded
    *  - ChangedByUser fields are surfaced with `promotable: false`
+   *
+   * Logos: emitted whenever `TeamEnrichment.logoUid` is set; the latest
+   * `TeamLogoVerificationResult` (any confidence) populates `verification`. The live
+   * `Team.logo` is exposed separately as `teamLogo` for current-vs-candidate comparison.
    */
-  async listEnrichmentsForReview(params: { page?: number; pageSize?: number }): Promise<{
-    pagination: { page: number; pageSize: number; totalTeams: number; totalPages: number };
-    teams: EnrichmentReviewItem[];
-  }> {
-    const pageSize = Math.min(Math.max(params.pageSize ?? 20, 1), 100);
-    const requestedPage = Math.max(params.page ?? 1, 1);
-
+  async listEnrichmentsForReview(): Promise<{ teams: EnrichmentReviewItem[] }> {
     const rows = await this.prisma.teamEnrichment.findMany({
       where: { dataEnrichment: { path: ['status'], equals: EnrichmentStatus.Enriched } },
       select: {
         teamUid: true,
-        team: { select: { uid: true, name: true } },
+        team: { select: { uid: true, name: true, logo: { select: { uid: true, url: true } } } },
         website: true,
         blog: true,
         contactMethod: true,
@@ -1199,10 +1234,7 @@ export class TeamEnrichmentService {
     });
 
     if (rows.length === 0) {
-      return {
-        pagination: { page: 1, pageSize, totalTeams: 0, totalPages: 0 },
-        teams: [],
-      };
+      return { teams: [] };
     }
 
     const teamUids = rows.map((r) => r.teamUid);
@@ -1241,7 +1273,6 @@ export class TeamEnrichmentService {
       >) {
         if (!fieldMeta?.judgment) continue;
         if (keyStr === 'logo') continue;
-        if (fieldMeta.judgment.confidence === FieldConfidence.High) continue;
 
         const candidate = (row as any)[keyStr];
         if (candidate === null || candidate === undefined) continue;
@@ -1259,8 +1290,7 @@ export class TeamEnrichmentService {
       let logo: EnrichmentReviewLogo | undefined;
       const logoMeta = meta.fieldsMeta.logo;
       const latestLogoVerif = latestByTeam.get(row.teamUid);
-      const logoConfidenceLow = !!latestLogoVerif && latestLogoVerif.confidence !== 'high';
-      if (row.logoUid && logoConfidenceLow) {
+      if (row.logoUid) {
         logo = {
           content: row.logo ? { uid: row.logo.uid, url: row.logo.url } : null,
           metadata: { source: logoMeta?.source, lastModifiedAt: logoMeta?.lastModifiedAt },
@@ -1276,24 +1306,111 @@ export class TeamEnrichmentService {
         };
       }
 
-      if (Object.keys(fields).length === 0 && !logo) continue;
-
       items.push({
         uid: row.team.uid,
         name: row.team.name,
         enrichmentStatus: meta.status,
+        teamLogo: row.team.logo ? { uid: row.team.logo.uid, url: row.team.logo.url } : null,
         fields,
         ...(logo ? { logo } : {}),
       });
     }
 
-    const totalTeams = items.length;
-    const totalPages = totalTeams === 0 ? 0 : Math.ceil(totalTeams / pageSize);
-    const page = totalPages === 0 ? 1 : Math.min(requestedPage, totalPages);
-    const start = (page - 1) * pageSize;
+    return { teams: items };
+  }
+
+  /**
+   * Per-team enrich + judge status snapshot. Returns `enrichment: null` if the team has no
+   * `TeamEnrichment` row yet. Throws `NotFoundException` if the team uid doesn't exist.
+   */
+  async getEnrichmentStatus(teamUid: string): Promise<TeamEnrichmentStatusResult> {
+    const team = await this.prisma.team.findUnique({
+      where: { uid: teamUid },
+      select: {
+        uid: true,
+        name: true,
+        teamEnrichment: { select: { dataEnrichment: true } },
+      },
+    });
+
+    if (!team) {
+      throw new NotFoundException(`Team ${teamUid} not found`);
+    }
+
+    const meta = this.parseEnrichmentMeta(team.teamEnrichment?.dataEnrichment);
+    if (!meta) {
+      return { uid: team.uid, name: team.name, enrichment: null, judgment: null };
+    }
+
+    const enrichment: TeamEnrichmentStatusEntry = {
+      status: meta.status,
+      shouldEnrich: !!meta.shouldEnrich,
+      enrichedAt: meta.enrichedAt ?? null,
+      enrichedBy: meta.enrichedBy ?? null,
+      reviewedAt: meta.reviewedAt ?? null,
+      reviewedBy: meta.reviewedBy ?? null,
+      errorMessage: meta.errorMessage ?? null,
+      aiModel: meta.aiModel ?? null,
+    };
+
+    const judgment: TeamJudgmentStatusEntry | null = meta.judgment
+      ? {
+          status: meta.judgment.status,
+          judgedAt: meta.judgment.judgedAt ?? null,
+          judgedBy: meta.judgment.judgedBy ?? null,
+          aiModel: meta.judgment.aiModel ?? null,
+          errorMessage: meta.judgment.errorMessage ?? null,
+          overallAssessment: meta.judgment.overallAssessment ?? null,
+          fieldsForReview: meta.judgment.fieldsForReview ?? [],
+        }
+      : null;
+
+    return { uid: team.uid, name: team.name, enrichment, judgment };
+  }
+
+  /**
+   * Pending / in-progress counts for the enrichment + judge crons. Pending judge count uses the
+   * same SQL pre-filter as the cron itself (`status=Enriched`, excluding rows already Judged or
+   * InProgress); the cron's post-filter (`collectJudgableFieldKeys`) is not applied here because
+   * it requires materializing every row, and the SQL-pre-filter count is the same shape the cron
+   * logs report.
+   */
+  async getCronCounts(): Promise<EnrichmentCronCounts> {
+    const [enrichPending, enrichInProgress, judgePending, judgeInProgress] = await Promise.all([
+      this.prisma.teamEnrichment.count({
+        where: {
+          AND: [
+            { dataEnrichment: { path: ['shouldEnrich'], equals: true } },
+            { dataEnrichment: { path: ['status'], equals: EnrichmentStatus.PendingEnrichment } },
+          ],
+        },
+      }),
+      this.prisma.teamEnrichment.count({
+        where: { dataEnrichment: { path: ['status'], equals: EnrichmentStatus.InProgress } },
+      }),
+      this.prisma.teamEnrichment.count({
+        where: {
+          AND: [
+            { dataEnrichment: { path: ['status'], equals: EnrichmentStatus.Enriched } },
+            {
+              NOT: {
+                OR: [
+                  { dataEnrichment: { path: ['judgment', 'status'], equals: JudgmentStatus.Judged } },
+                  { dataEnrichment: { path: ['judgment', 'status'], equals: JudgmentStatus.InProgress } },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      this.prisma.teamEnrichment.count({
+        where: { dataEnrichment: { path: ['judgment', 'status'], equals: JudgmentStatus.InProgress } },
+      }),
+    ]);
+
     return {
-      pagination: { page, pageSize, totalTeams, totalPages },
-      teams: items.slice(start, start + pageSize),
+      enrichment: { pending: enrichPending, inProgress: enrichInProgress },
+      judge: { pending: judgePending, inProgress: judgeInProgress },
     };
   }
 

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -429,30 +429,28 @@ Team-level status flip only — sets `dataEnrichment.status` to `Reviewed` or `A
 ### Admin Field-Level Review — List
 
 ```
-GET /v1/admin/teams/enrichment-review?page=<int>&pageSize=<int>
+GET /v1/admin/teams/enrichment-review
 Guard: AdminAuthGuard
 ```
 
-Paginated list of teams that have at least one reviewable item — non-`high` judgment on any `fieldsMeta[k]`, or a latest `TeamLogoVerificationResult` whose `confidence !== 'high'`. Only teams whose top-level `dataEnrichment.status === 'Enriched'` are included (Reviewed / Approved / PendingEnrichment / InProgress / FailedToEnrich are out of scope). Sorted by `team.name` ASC.
-
-- `page` (default `1`) — 1-based page index. Out-of-range pages clamp to the last available page.
-- `pageSize` (default `20`, capped at `100`) — items per page.
+Full list of teams whose top-level `dataEnrichment.status === 'Enriched'`. Reviewed / Approved / PendingEnrichment / InProgress / FailedToEnrich are out of scope. Sorted by `team.name` ASC. No pagination — the portal carries ~1K teams and the back-office UI consumes the full set at once.
 
 Per-field rules:
-- High-confidence fields are hidden (already promoted by the judge).
+- Every field that has a `fieldsMeta[k].judgment` entry is surfaced, including those the judge already promoted at `agrees + high`. Admins use this view to spot-check promotion decisions.
 - Empty candidate values (null / empty string / empty array) are excluded.
-- `ChangedByUser` fields with low/medium judgment are surfaced with `promotable: false` (visibility only — admin can't promote the user's own value).
-- Logo is included when the team has a `TeamEnrichment.logoUid` and the latest verification's `confidence !== 'high'`. The latest row is selected across all providers, newest by `createdAt`.
+- `ChangedByUser` fields are surfaced with `promotable: false` (visibility only — admin can't promote the user's own value).
+- Logo is included whenever `TeamEnrichment.logoUid` is set, regardless of the latest verification's confidence. The latest `TeamLogoVerificationResult` row (any provider, newest by `createdAt`) populates `verification`; `verification` is `null` when no row exists.
+- `teamLogo` carries the live `Team.logo` (joined from `Image`) so admins can compare the user-visible logo against the candidate `logo` (which holds the `TeamEnrichment.logo` row).
 
 Response shape:
 
 ```ts
 {
-  pagination: { page, pageSize, totalTeams, totalPages },
   teams: Array<{
     uid: string;
     name: string;
     enrichmentStatus: EnrichmentStatus;          // always 'Enriched' in this list
+    teamLogo: { uid: string; url: string } | null;  // live Team.logo (left-join Image)
     fields: Partial<Record<FieldMetaKey, {
       content: string | string[];                // candidate value from TeamEnrichment
       metadata: { source?: EnrichmentSource; lastModifiedAt?: string };
@@ -460,7 +458,7 @@ Response shape:
       promotable: boolean;                        // false when fieldsMeta[k].status === ChangedByUser
     }>>;
     logo?: {
-      content: { uid: string; url: string } | null;
+      content: { uid: string; url: string } | null;   // candidate logo from TeamEnrichment
       metadata: { source?: EnrichmentSource; lastModifiedAt?: string };
       verification: {
         verdict: string;
@@ -473,6 +471,81 @@ Response shape:
   }>
 }
 ```
+
+### Admin Enrichment Status — Single Team
+
+```
+GET /v1/admin/teams/:uid/enrichment-status
+Guard: AdminAuthGuard
+```
+
+Per-team enrich + judge status snapshot. Useful for back-office to ask "what's the current state of team X?" without parsing the full enrichment-review list.
+
+- Returns 404 if the team uid doesn't exist.
+- Returns `enrichment: null` and `judgment: null` when the team has no `TeamEnrichment` row.
+- Returns `judgment: null` when the team has been enriched but the judge has not run yet.
+
+Response shape:
+
+```ts
+{
+  uid: string;
+  name: string;
+  enrichment: {
+    status: EnrichmentStatus;             // PendingEnrichment | InProgress | Enriched | FailedToEnrich | Reviewed | Approved
+    shouldEnrich: boolean;
+    enrichedAt: string | null;            // ISO timestamp of last successful enrichment
+    enrichedBy: string | null;            // 'system-cron' | 'manually' | <email>
+    reviewedAt: string | null;
+    reviewedBy: string | null;
+    errorMessage: string | null;
+    aiModel: string | null;
+  } | null;
+  judgment: {
+    status: JudgmentStatus;               // PendingJudgment | InProgress | Judged | FailedToJudge
+    judgedAt: string | null;
+    judgedBy: string | null;
+    aiModel: string | null;
+    errorMessage: string | null;
+    overallAssessment: string | null;
+    fieldsForReview: string[];            // DB column names the judge flagged for manual review
+  } | null;
+}
+```
+
+### Admin Enrichment Status — Cron Jobs
+
+```
+GET /v1/admin/teams/enrichment-status
+Guard: AdminAuthGuard
+```
+
+Cron progress snapshot — `isRunning` flags for the three cron jobs (enrichment, marking, judge), plus pending / in-progress team counts. Admins use this to confirm whether a manual `trigger-enrichment` is still mid-batch, or to know whether the daily cron has anything queued.
+
+Response shape:
+
+```ts
+{
+  enrichment: {
+    isRunning: boolean;        // per-pod in-memory flag
+    pending: number;           // TeamEnrichment rows with shouldEnrich=true AND status=PendingEnrichment
+    inProgress: number;        // TeamEnrichment rows with status=InProgress
+  };
+  marking: {
+    isRunning: boolean;        // per-pod in-memory flag (separate marking cron)
+  };
+  judge: {
+    isRunning: boolean;        // per-pod in-memory flag
+    pending: number;           // status=Enriched AND judgment.status NOT IN (Judged, InProgress) — SQL pre-filter only
+    inProgress: number;        // judgment.status=InProgress
+  };
+}
+```
+
+Caveats:
+
+- **`isRunning` is per-pod**. The flag is an in-memory boolean on the cron-job class — accurate within this pod, but if the API runs as multiple replicas, only the pod actually executing the cron will report `true`. Counts come from the DB and are authoritative across pods.
+- **Judge `pending` is the SQL pre-filter only**, before `collectJudgableFieldKeys` weeds out rows with nothing to judge. The true cron-eligible count is `≤ pending` — same shape as the cron's own log line.
 
 ### Admin Field-Level Review — Approve
 

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -437,10 +437,13 @@ Full list of teams whose top-level `dataEnrichment.status === 'Enriched'`. Revie
 
 Per-field rules:
 - Every field that has a `fieldsMeta[k].judgment` entry is surfaced, including those the judge already promoted at `agrees + high`. Admins use this view to spot-check promotion decisions.
-- Empty candidate values (null / empty string / empty array) are excluded.
+- `content` source is decided by `fieldsMeta[k].status`:
+  - `ChangedByUser` → reads from `Team.<field>` (user's value is the source of truth; the `TeamEnrichment.<field>` candidate, if any, is informational provenance).
+  - `Enriched` / `CannotEnrich` → reads from `TeamEnrichment.<field>` (AI candidate not yet promoted).
+  The other side is used as a fallback if the primary side is empty. Fields that are empty in **both** places are skipped — there's nothing to review.
 - `ChangedByUser` fields are surfaced with `promotable: false` (visibility only — admin can't promote the user's own value).
 - Logo is included whenever `TeamEnrichment.logoUid` is set, regardless of the latest verification's confidence. The latest `TeamLogoVerificationResult` row (any provider, newest by `createdAt`) populates `verification`; `verification` is `null` when no row exists.
-- `teamLogo` carries the live `Team.logo` (joined from `Image`) so admins can compare the user-visible logo against the candidate `logo` (which holds the `TeamEnrichment.logo` row).
+- The logo URL also appears in `fields.logo.content` (mirrors the scalar-field shape so the UI can iterate uniformly). The richer VLM verdict stays on the top-level `logo` block.
 
 Response shape:
 
@@ -450,7 +453,6 @@ Response shape:
     uid: string;
     name: string;
     enrichmentStatus: EnrichmentStatus;          // always 'Enriched' in this list
-    teamLogo: { uid: string; url: string } | null;  // live Team.logo (left-join Image)
     fields: Partial<Record<FieldMetaKey, {
       content: string | string[];                // candidate value from TeamEnrichment
       metadata: { source?: EnrichmentSource; lastModifiedAt?: string };


### PR DESCRIPTION
# Team Enrichment API Updates — Summary & Examples

Branch: `feat/refactor-team-enrichment-apis`

## What changed

| # | Endpoint | Change |
|---|---|---|
| 1 | `GET /v1/admin/teams/enrichment-review` | Pagination removed. All judged fields returned regardless of confidence. Logo URL appears in `fields.logo.content` (mirrors scalar-field shape). `moreDetails` excluded. `metadata.status` (`Enriched` / `ChangedByUser` / `CannotEnrich`) added to every field. `content` source now decided by status: `ChangedByUser` → `Team.<field>`, `Enriched`/`CannotEnrich` → `TeamEnrichment.<field>` (other side used as fallback). The richer VLM verification block stays at top-level `logo`. |
| 2 | `GET /v1/admin/teams/:uid/enrichment-status` (new) | Per-team enrich + judge status snapshot — `status`, `enrichedAt`, `judgedAt`, `fieldsForReview`, etc. |
| 3 | `GET /v1/admin/teams/enrichment-status` (new) | Cron job snapshot — `isRunning` flags for enrichment / marking / judge crons plus pending + in-progress counts from the DB. |

Auth: all three endpoints require an admin JWT (`AdminAuthGuard`, configured at the controller class).

## Important behavior notes / caveats

- **`content` source rule**: `ChangedByUser` reads from `Team`, everything else from `TeamEnrichment`. Empty-on-primary falls back to the other side. Skipped only when both are empty.
- **`teamLogo` was removed** from the response (intermediate state). The logo URL now lives in `fields.logo.content` so the UI can iterate over `fields` uniformly. The top-level `logo` block stays for the rich VLM verification (verdict/confidence/reason/verifiedAt).
- **`moreDetails` is excluded** from the review response (UI doesn't render it).
- **`isRunning` on cron-status is per-pod** — in a multi-replica deployment only one pod sees `true`. Counts come from the DB and are authoritative.
- **`ContentTypeMiddleware`** rejects any POST/PUT/PATCH without `Content-Type: application/json` with `{ status: 415, message: "Unsupported Content Type" }`. The Postman collection sets the header on every POST and includes an empty `{}` body so Postman actually sends the header.

## Breaking change

Removing `pagination` from `enrichment-review` is a backward-incompatible response shape change. The only consumer is the internal back-office UI — coordinate with that team before deploying.

## REST API examples

The examples below assume `$API` is the API base (e.g. `http://localhost:3000`) and `$TOKEN` is an admin JWT.

### 1. `GET /v1/admin/teams/enrichment-review`

#### Request

```bash
curl -s "$API/v1/admin/teams/enrichment-review" \
  -H "Authorization: Bearer $TOKEN"
```

#### Response

```json
{
  "teams": [
    {
      "uid": "team-abc",
      "name": "Acme Capital",
      "enrichmentStatus": "Enriched",
      "fields": {
        "website": {
          "content": "https://acme.capital",
          "metadata": {
            "status": "Enriched",
            "source": "ai",
            "lastModifiedAt": "2026-05-10T03:14:22.000Z"
          },
          "judgment": { "note": "name-match+website", "score": 100 },
          "promotable": true
        },
        "shortDescription": {
          "content": "Early-stage fund focused on AI infra.",
          "metadata": {
            "status": "Enriched",
            "source": "scrapingdog",
            "lastModifiedAt": "2026-05-10T03:14:22.000Z"
          },
          "judgment": { "note": "tagline-overlap", "score": 75 },
          "promotable": true
        },
        "linkedinHandler": {
          "content": "acme-capital",
          "metadata": {
            "status": "ChangedByUser",
            "source": "ai",
            "lastModifiedAt": "2026-05-09T11:02:09.000Z"
          },
          "judgment": { "note": "user-supplied", "score": 90 },
          "promotable": false
        },
        "logo": {
          "content": "https://cdn.example.com/team-logos/acme-candidate.png",
          "metadata": {
            "status": "Enriched",
            "source": "scrapingdog",
            "lastModifiedAt": "2026-05-10T03:14:22.000Z"
          },
          "judgment": {},
          "promotable": true
        }
      },
      "logo": {
        "content": {
          "uid": "img-candidate-009",
          "url": "https://cdn.example.com/team-logos/acme-candidate.png"
        },
        "metadata": {
          "status": "Enriched",
          "source": "scrapingdog",
          "lastModifiedAt": "2026-05-10T03:14:22.000Z"
        },
        "verification": {
          "verdict": "weak_match",
          "confidence": "medium",
          "reason": "Logo readable but only partial brand match.",
          "verifiedAt": "2026-05-10T06:00:11.000Z"
        },
        "promotable": true
      }
    }
  ]
}
```

Notes:

- `fields.logo` is the simple URL-shaped entry (parallel to `website`, etc.). Its `judgment` is always `{}` because logos aren't AI-judged.
- The top-level `logo` block carries the rich VLM verification snapshot.
- `metadata.status` is always present when `fieldsMeta[k]` exists; `source` / `lastModifiedAt` are present only when the enrichment pipeline recorded them.
- `promotable: false` indicates a `ChangedByUser` field — the user's value lives on `Team`, so admins can't overwrite it via approve.

### 2. `GET /v1/admin/teams/:uid/enrichment-status`

#### Request

```bash
curl -s "$API/v1/admin/teams/team-abc/enrichment-status" \
  -H "Authorization: Bearer $TOKEN"
```

#### Response — judged team

```json
{
  "uid": "team-abc",
  "name": "Acme Capital",
  "enrichment": {
    "status": "Reviewed",
    "shouldEnrich": false,
    "enrichedAt": "2026-05-10T03:14:22.000Z",
    "enrichedBy": "system-cron",
    "reviewedAt": "2026-05-11T09:42:00.000Z",
    "reviewedBy": "admin@example.com",
    "errorMessage": null,
    "aiModel": "gemini-2.5-flash"
  },
  "judgment": {
    "status": "Judged",
    "judgedAt": "2026-05-10T04:00:11.000Z",
    "judgedBy": "system-cron",
    "aiModel": "claude-sonnet-4-6",
    "errorMessage": null,
    "overallAssessment": "Most fields agree with LinkedIn profile; website verified.",
    "fieldsForReview": ["industryTags"]
  }
}
```

#### Response — team without any enrichment row yet

```json
{
  "uid": "team-fresh",
  "name": "Newly Created Team",
  "enrichment": null,
  "judgment": null
}
```

#### Response — unknown uid

```http
HTTP/1.1 404 Not Found
Content-Type: application/json

{
  "statusCode": 404,
  "message": "Team team-bogus not found",
  "error": "Not Found"
}
```

### 3. `GET /v1/admin/teams/enrichment-status`

#### Request

```bash
curl -s "$API/v1/admin/teams/enrichment-status" \
  -H "Authorization: Bearer $TOKEN"
```

#### Response — cron idle, some pending work

```json
{
  "enrichment": {
    "isRunning": false,
    "pending": 42,
    "inProgress": 0
  },
  "marking": { "isRunning": false },
  "judge": {
    "isRunning": false,
    "pending": 17,
    "inProgress": 0
  }
}
```

#### Response — enrichment cron mid-flight on this pod

```json
{
  "enrichment": {
    "isRunning": true,
    "pending": 39,
    "inProgress": 3
  },
  "marking": { "isRunning": false },
  "judge": {
    "isRunning": false,
    "pending": 17,
    "inProgress": 0
  }
}
```

Caveats:

- **Judge `pending`** is the SQL pre-filter only (`status === 'Enriched'` minus already-judged / in-progress rows). The cron applies a further in-app filter (`collectJudgableFieldKeys`) so the truly-eligible count is `≤ pending`.

