### PR TITLE
feat(rbac): add investor_db.view + edit permissions and pl_investment_team policy

### DIFF
--- a/apps/web-api/prisma/migrations/20260514213000_add_rbac_for_investor_db/migration.sql
+++ b/apps/web-api/prisma/migrations/20260514213000_add_rbac_for_investor_db/migration.sql
@@ -1,0 +1,79 @@
+-- Add RBAC permissions for the LabOS Investor DB module.
+--
+-- Two flat permissions (the 3 frontend tabs are lenses over the same dataset,
+-- so per-tab splits don't map to anything meaningful in the backend):
+--   investor_db.view  — read access to the page (required to see the module at all)
+--   investor_db.edit  — mutate (tag, save view, CSV export, bulk actions)
+--
+-- Granted to:
+--   directory_admin_pl_internal   — admins always have full access
+--   pl_investment_team_pl_internal — new dedicated policy for the PL investment team
+--
+-- All steps idempotent: re-runs are safe (NOT EXISTS guards on Permission +
+-- PolicyPermission; ON CONFLICT DO NOTHING on Policy).
+
+BEGIN;
+
+-- =========================================================
+-- 1. Insert permissions
+--    `module` is the feature-area grouping displayed in the back-office RBAC UI.
+-- =========================================================
+WITH seed(uid, code, module, description) AS (
+  VALUES
+    ('investor_db.view', 'investor_db.view', 'Investor DB', 'View the LabOS Investor DB module (page + table + drawer)'),
+    ('investor_db.edit', 'investor_db.edit', 'Investor DB', 'Mutate Investor DB: tag, save view, CSV export, bulk actions')
+)
+INSERT INTO "Permission" ("uid", "code", "module", "description", "createdAt", "updatedAt")
+SELECT s.uid, s.code, s.module, s.description, NOW(), NOW()
+FROM seed s
+WHERE NOT EXISTS (
+  SELECT 1 FROM "Permission" p WHERE p."code" = s.code
+);
+
+-- =========================================================
+-- 2. Create dedicated policy for PL investment team
+-- =========================================================
+INSERT INTO "Policy" ("uid", "code", "name", "description", "role", "group", "isSystem", "hidden", "createdAt", "updatedAt")
+VALUES (
+  'policy_pl_investment_team_pl_internal',
+  'pl_investment_team_pl_internal',
+  'PL Investment Team / PL Internal',
+  'PL capital / investment team — access to the internal Investor DB module',
+  'PL Investment Team',
+  'PL Internal',
+  true,
+  false,
+  NOW(),
+  NOW()
+)
+ON CONFLICT ("code") DO NOTHING;
+
+-- =========================================================
+-- 3. Link permissions to policies
+-- =========================================================
+WITH mappings(policy_code, permission_code) AS (
+  VALUES
+    -- Admins get full access
+    ('directory_admin_pl_internal', 'investor_db.view'),
+    ('directory_admin_pl_internal', 'investor_db.edit'),
+    -- Dedicated investment-team policy gets full access
+    ('pl_investment_team_pl_internal', 'investor_db.view'),
+    ('pl_investment_team_pl_internal', 'investor_db.edit')
+)
+INSERT INTO "PolicyPermission" ("uid", "policyUid", "permissionUid", "createdAt")
+SELECT
+  'pp_' || md5(p."uid" || ':' || perm."uid"),
+  p."uid",
+  perm."uid",
+  NOW()
+FROM mappings m
+       JOIN "Policy" p ON p."code" = m.policy_code
+       JOIN "Permission" perm ON perm."code" = m.permission_code
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "PolicyPermission" pp
+  WHERE pp."policyUid" = p."uid"
+    AND pp."permissionUid" = perm."uid"
+);
+
+COMMIT;

--- a/apps/web-api/src/rbac/rbac.constants.ts
+++ b/apps/web-api/src/rbac/rbac.constants.ts
@@ -13,6 +13,8 @@ export const RBAC_PERMISSION_CODES = {
   DIRECTORY_ADMIN: 'directory.admin.full',
   ADMIN_TOOLS_ACCESS: 'admin.tools.access',
   TEAM_MEMBERSHIP_SOURCE_READ: 'team.membership_source.read',
+  INVESTOR_DB_VIEW: 'investor_db.view',
+  INVESTOR_DB_EDIT: 'investor_db.edit',
 } as const;
 
 export const RBAC_SCOPES = {


### PR DESCRIPTION
Two flat permissions (the 3 frontend tabs are lenses over the same dataset, so per-tab splits don't map to anything meaningful):

- `investor_db.view` — read access to the page (required to see the module)
- `investor_db.edit` — mutate (tag, save view, CSV export, bulk actions)

Module: "Investor DB" (used for grouping in the back-office RBAC UI).

Granted by default to:
- `directory_admin_pl_internal` — admins always have full access
- `pl_investment_team_pl_internal` — new dedicated policy for the PL investment/capital team (role "PL Investment Team", group "PL Internal")

Migration is idempotent: NOT EXISTS guards on Permission + PolicyPermission, ON CONFLICT DO NOTHING on Policy. Safe to re-run.

For local testing: assign your user to `pl_investment_team_pl_internal` via the back-office (`/members` → RBAC section → PolicyMultiSelect). Production roll-out happens via the same UI.

Frontend consumes via services/rbac/hooks/useInvestorsAccess.ts using the V2 `/v2/access-control-v2/me/access` endpoint (legacy /v1/rbac/me only reads V1 RoleAssignment and would miss these policy grants).

## Description

_Add a few lines describing your changes_

## Tickets

- https://pixelmatters.atlassian.net/browse/PL-<ID>

---

## Checklist before requesting a review

- [ ] I've performed a self-review of my code
- [ ] I've added relevant tests for my changes
- [ ] I've confirmed that my code passes linting
- [ ] I've confirmed that my code passes all tests
- [ ] I've confirmed that my code builds correctly
