### PR TITLE
[Team Enrichment] Admin Review API Rework

### DIFF
--- a/apps/web-api/src/admin/admin-teams.controller.ts
+++ b/apps/web-api/src/admin/admin-teams.controller.ts
@@ -20,11 +20,7 @@ import { NoCache } from '../decorators/no-cache.decorator';
 import { ZodValidationPipe } from '@abitia/zod-dto';
 
 import { AdminTeamsService } from './admin-teams.service';
-import {
-  ApproveEnrichmentFieldsBodyDto,
-  TriggerForceEnrichmentQueryDto,
-  UploadTeamTiersQueryDto,
-} from './schema/admin-teams';
+import { ReviewEnrichmentBodyDto, TriggerForceEnrichmentQueryDto, UploadTeamTiersQueryDto } from './schema/admin-teams';
 import { TeamEnrichmentService } from '../team-enrichment/team-enrichment.service';
 import { TeamEnrichmentJudgeService } from '../team-enrichment/team-enrichment-judge.service';
 import { TeamEnrichmentReportService } from '../team-enrichment/team-enrichment-report.service';
@@ -90,18 +86,28 @@ export class AdminTeamsController {
     return this.adminTeamsService.updateTeam(teamUid, body);
   }
 
+  /**
+   * Admin team approval. Body lists per-field decisions:
+   *   { fields: [{ key: 'website', content: 'https://...' }, { key: 'blog' }, ...] }
+   *
+   * For each entry:
+   *  - `content` provided → admin edited the field. Value goes to Team; FieldEnrichmentStatus
+   *    flips to ChangedByUser; judgment.score bumps to 100.
+   *  - `content` omitted → admin confirmed the value as-is. The current Team / candidate value
+   *    is preserved; judgment.score bumps to 100; status is unchanged.
+   *
+   * Team-level: dataEnrichment.status → Approved, reviewedAt / reviewedBy stamped, approved
+   * keys dropped from judgment.fieldsForReview. Logo approval also marks the latest
+   * TeamLogoVerificationResult row `verified` at high confidence.
+   */
   @Patch('/:uid/enrichment-review')
   @NoCache()
   async reviewEnrichment(
     @Param('uid') uid: string,
-    @Body() body: { status: 'Reviewed' | 'Approved' },
+    @Body(new ZodValidationPipe()) body: ReviewEnrichmentBodyDto,
     @Req() req: any
   ) {
-    if (!body.status || !['Reviewed', 'Approved'].includes(body.status)) {
-      throw new BadRequestException('status must be "Reviewed" or "Approved"');
-    }
-    await this.teamEnrichmentService.reviewEnrichment(uid, body.status, req?.userEmail ?? 'admin');
-    return { success: true };
+    return this.teamEnrichmentService.approveEnrichmentForTeam(uid, body.fields, req?.userEmail ?? 'admin');
   }
 
   /**
@@ -153,23 +159,6 @@ export class AdminTeamsController {
   @NoCache()
   async getEnrichmentStatus(@Param('uid') uid: string) {
     return this.teamEnrichmentService.getEnrichmentStatus(uid);
-  }
-
-  /**
-   * Approve a list of enrichment fields for a team. Promotes the candidate values from
-   * TeamEnrichment to Team (scalars + industryTags M2M + InvestorProfile.investmentFocus +
-   * Team.logoUid), normalizes per-field judgment metadata (verdict=agrees, confidence=high,
-   * score=90), flips `dataEnrichment.status` to `Reviewed`, and on logo approval also marks
-   * the latest TeamLogoVerificationResult row `verified` at high confidence.
-   */
-  @Patch('/:uid/enrichment-review/fields')
-  @NoCache()
-  async approveEnrichmentFields(
-    @Param('uid') uid: string,
-    @Body(new ZodValidationPipe()) body: ApproveEnrichmentFieldsBodyDto,
-    @Req() req: any
-  ) {
-    return this.teamEnrichmentService.approveEnrichmentFields(uid, body.fields, req?.userEmail ?? 'admin');
   }
 
   @Post('/:uid/trigger-enrichment')
@@ -321,16 +310,11 @@ export class AdminTeamsController {
    */
   @Get('ai-report')
   @NoCache()
-  async aiReport(
-    @Query('since') since?: string,
-    @Query('page') page?: string,
-    @Query('pageSize') pageSize?: string
-  ) {
+  async aiReport(@Query('since') since?: string, @Query('page') page?: string, @Query('pageSize') pageSize?: string) {
     return this.teamEnrichmentReportService.generateReport({
       since,
       page: page ? parseInt(page, 10) : undefined,
       pageSize: pageSize ? parseInt(pageSize, 10) : undefined,
     });
   }
-
 }

--- a/apps/web-api/src/admin/schema/admin-teams.ts
+++ b/apps/web-api/src/admin/schema/admin-teams.ts
@@ -38,7 +38,7 @@ export const UploadTeamTiersDryRunSchema = z.object({
         uid: z.string().optional(),
         name: z.string().optional(),
         tier: z.number().min(1).max(4),
-      }),
+      })
     )
     .max(5),
   note: z.string(),
@@ -71,7 +71,7 @@ export const TriggerForceEnrichmentQuerySchema = z.object({
 export class TriggerForceEnrichmentQueryDto extends createZodDto(TriggerForceEnrichmentQuerySchema) {}
 
 /**
- * Reviewable field keys for the field-level approve endpoint. Mirrors FieldMetaKey from
+ * Reviewable field keys for the admin enrichment review endpoint. Mirrors FieldMetaKey from
  * team-enrichment.types.ts — duplicated here so the Zod layer can validate without dragging
  * an enum import into the schema module. Keep in sync if FieldMetaKey changes.
  */
@@ -91,9 +91,24 @@ export const REVIEWABLE_FIELD_KEYS = [
 ] as const;
 
 /**
- * Body schema for PATCH /v1/admin/teams/:uid/enrichment-review/fields.
+ * Body schema for PATCH /v1/admin/teams/:uid/enrichment-review.
+ *
+ * `content` is optional per-field. When present, the admin edited the field — the value is
+ * written to Team and `FieldEnrichmentStatus` flips to `ChangedByUser`. When absent, the admin
+ * confirmed the existing candidate / user value as-is and the status is unchanged. In both
+ * cases, `judgment.score` is bumped to 100 and the team-level `EnrichmentStatus` flips to
+ * `Approved`. Scalars and `logo` accept a `string`; `industryTags` and `investmentFocus`
+ * accept `string[]` (titles for industry tags; the resolver matches them case-insensitively
+ * against existing IndustryTag rows).
  */
-export const ApproveEnrichmentFieldsBodySchema = z.object({
-  fields: z.array(z.enum(REVIEWABLE_FIELD_KEYS)).min(1),
+export const ReviewEnrichmentBodySchema = z.object({
+  fields: z
+    .array(
+      z.object({
+        key: z.enum(REVIEWABLE_FIELD_KEYS),
+        content: z.union([z.string(), z.array(z.string())]).optional(),
+      })
+    )
+    .min(1),
 });
-export class ApproveEnrichmentFieldsBodyDto extends createZodDto(ApproveEnrichmentFieldsBodySchema) {}
+export class ReviewEnrichmentBodyDto extends createZodDto(ReviewEnrichmentBodySchema) {}

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -5,7 +5,6 @@ import { FileUploadService } from '../utils/file-upload/file-upload.service';
 import { TeamEnrichmentAiService } from './team-enrichment-ai.service';
 import { buildTeamEnrichmentEligibilityFilter } from './team-enrichment-eligibility-filter';
 import { formatUsageLog, mergeUsageEntries } from './team-enrichment-cost';
-import { buildPromotionPayload, executePromotion } from './team-enrichment-promotion';
 import { ScrapingDogCompanyProfile, TeamEnrichmentScrapingDogService } from './team-enrichment-scrapingdog.service';
 import {
   ENRICHABLE_TEAM_FIELDS,
@@ -28,7 +27,6 @@ export type EnrichmentReviewFieldEntry = {
   content: string | string[];
   metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
   judgment: { note?: string; score?: number };
-  promotable: boolean;
 };
 
 export type EnrichmentReviewLogo = {
@@ -40,22 +38,34 @@ export type EnrichmentReviewLogo = {
     reason: string | null;
     verifiedAt: string;
   } | null;
-  promotable: boolean;
 };
 
 export type EnrichmentReviewItem = {
   uid: string;
   name: string;
+  priority: number;
   enrichmentStatus: EnrichmentStatus;
+  enrichmentAt: string | null;
+  judgedAt: string | null;
   fields: Partial<Record<FieldMetaKey, EnrichmentReviewFieldEntry>>;
   logo?: EnrichmentReviewLogo;
 };
 
-export type ApproveEnrichmentFieldsResult = {
+export type ApproveEnrichmentTeamSkip = {
+  key: FieldMetaKey;
+  reason: 'empty_value' | 'no_candidate';
+};
+
+export type ApproveEnrichmentTeamResult = {
   success: boolean;
-  promoted: string[];
-  skipped: Array<{ field: string; reason: string }>;
+  approved: FieldMetaKey[];
+  skipped: ApproveEnrichmentTeamSkip[];
   message?: string;
+};
+
+export type ApproveEnrichmentFieldInput = {
+  key: FieldMetaKey;
+  content?: string | string[];
 };
 
 export type TeamEnrichmentStatusEntry = {
@@ -1197,16 +1207,14 @@ export class TeamEnrichmentService {
 
   /**
    * Full list of teams whose enrichment is in `EnrichmentStatus.Enriched`. Includes every
-   * judged field regardless of confidence so admins can spot-check what the judge promoted.
+   * judged field regardless of confidence so admins can spot-check what the judge produced.
    *
    * Per-field rules:
    *  - fields without a `fieldsMeta[k].judgment` entry are skipped (not review-ready)
    *  - empty candidate values (null / empty string / empty array) are excluded
-   *  - ChangedByUser fields are surfaced with `promotable: false`
    *
    * Logos: emitted whenever `TeamEnrichment.logoUid` is set; the latest
-   * `TeamLogoVerificationResult` (any confidence) populates `verification`. The live
-   * `Team.logo` is exposed separately as `teamLogo` for current-vs-candidate comparison.
+   * `TeamLogoVerificationResult` (any confidence) populates `verification`.
    */
   async listEnrichmentsForReview(): Promise<{ teams: EnrichmentReviewItem[] }> {
     const rows = await this.prisma.teamEnrichment.findMany({
@@ -1217,6 +1225,7 @@ export class TeamEnrichmentService {
           select: {
             uid: true,
             name: true,
+            priority: true,
             logo: { select: { uid: true, url: true } },
             website: true,
             blog: true,
@@ -1299,7 +1308,6 @@ export class TeamEnrichmentService {
               lastModifiedAt: fieldMeta?.lastModifiedAt,
             },
             judgment: {},
-            promotable: fieldMeta?.status !== FieldEnrichmentStatus.ChangedByUser,
           };
           continue;
         }
@@ -1333,7 +1341,6 @@ export class TeamEnrichmentService {
             lastModifiedAt: fieldMeta.lastModifiedAt,
           },
           judgment: { note: fieldMeta.judgment.note, score: fieldMeta.judgment.score },
-          promotable: fieldMeta.status !== FieldEnrichmentStatus.ChangedByUser,
         };
       }
 
@@ -1356,14 +1363,16 @@ export class TeamEnrichmentService {
                 verifiedAt: latestLogoVerif.createdAt.toISOString(),
               }
             : null,
-          promotable: logoMeta?.status !== FieldEnrichmentStatus.ChangedByUser,
         };
       }
 
       items.push({
         uid: row.team.uid,
         name: row.team.name,
+        priority: row.team.priority,
         enrichmentStatus: meta.status,
+        enrichmentAt: meta.usage?.enrichment?.lastRunAt ?? null,
+        judgedAt: meta.judgment?.judgedAt ?? null,
         fields,
         ...(logo ? { logo } : {}),
       });
@@ -1468,42 +1477,38 @@ export class TeamEnrichmentService {
   }
 
   /**
-   * Approve a specific set of enrichment fields (and optionally `logo`) for one team.
+   * Admin team approval. For each requested field, writes the value to Team and normalizes
+   * the per-field judgment to `{ verdict: agrees, confidence: high, score: 100 }`.
    *
-   * For each approved field:
-   *  - copy the candidate value from TeamEnrichment to Team (scalars), or set the M2M
-   *    (industryTags), or upsert InvestorProfile.investmentFocus, or set Team.logoUid (logo) —
-   *    via the shared promotion helpers, so the write path matches the AI judge's.
-   *  - normalize `fieldsMeta[field].judgment` to `{ verdict: 'agrees', confidence: 'high', score: 90 }`
-   *    while preserving `note` and `judgedVia` (audit signal).
-   *  - drop the field from team-level `dataEnrichment.judgment.fieldsForReview`.
+   * Per-field rule:
+   *  - `content` provided → admin edited the value. Final value is the admin input;
+   *    `fieldsMeta[key].status` flips to `ChangedByUser`.
+   *  - `content` omitted ("Confirm") → admin accepted the existing value. Final value is
+   *    read from the canonical source: `Team.<field>` when current status is `ChangedByUser`
+   *    (the user's value is already there), otherwise the AI candidate on `TeamEnrichment.<field>`.
+   *    `status` is left unchanged.
    *
-   * Team-level: flip `dataEnrichment.status` to `Reviewed`, write `reviewedAt` / `reviewedBy`.
-   *
-   * Logo approval also mutates the latest `TeamLogoVerificationResult` row for the team
-   * (any provider, newest by createdAt) → `verdict='verified'`, `confidence='high'`. Other columns
-   * (reason, brandSignals, rawResponse, predictedCompanyName, quality, hasReadableText, model,
-   * provider) are left verbatim as the model's snapshot.
-   *
-   * Skipped fields are returned with a `reason` (`user_owned`, `not_enriched`, `no_field_meta`,
-   * `empty_candidate`) so the caller can surface partial outcomes.
+   * Empty resolved values are pushed into `skipped` (`empty_value` / `no_candidate`) and not
+   * promoted. Team-level `dataEnrichment.status` flips to `Approved`; approved keys are dropped
+   * from `judgment.fieldsForReview`. Logo approval also marks the latest
+   * `TeamLogoVerificationResult` row `verified` at high confidence.
    */
-  async approveEnrichmentFields(
+  async approveEnrichmentForTeam(
     teamUid: string,
-    fields: string[],
+    inputs: ApproveEnrichmentFieldInput[],
     reviewerEmail: string
-  ): Promise<ApproveEnrichmentFieldsResult> {
+  ): Promise<ApproveEnrichmentTeamResult> {
     const team = await this.prisma.team.findUnique({
       where: { uid: teamUid },
       select: TEAM_WITH_ENRICHMENT_SELECT,
     });
     if (!team) {
-      return { success: false, promoted: [], skipped: [], message: `Team ${teamUid} not found` };
+      return { success: false, approved: [], skipped: [], message: `Team ${teamUid} not found` };
     }
     if (!team.teamEnrichment) {
       return {
         success: false,
-        promoted: [],
+        approved: [],
         skipped: [],
         message: `Team ${teamUid} has no enrichment row`,
       };
@@ -1512,7 +1517,7 @@ export class TeamEnrichmentService {
     if (!meta) {
       return {
         success: false,
-        promoted: [],
+        approved: [],
         skipped: [],
         message: `Team ${teamUid} has no enrichment data`,
       };
@@ -1520,70 +1525,130 @@ export class TeamEnrichmentService {
     if (meta.status === EnrichmentStatus.InProgress) {
       return {
         success: false,
-        promoted: [],
+        approved: [],
         skipped: [],
         message: `Enrichment already in progress for team ${teamUid}`,
       };
     }
 
     const fieldsMeta = meta.fieldsMeta ?? {};
-    const skipped: Array<{ field: string; reason: string }> = [];
-    const promotableKeys: FieldMetaKey[] = [];
+    const skipped: ApproveEnrichmentTeamSkip[] = [];
 
-    for (const f of fields) {
-      const key = f as FieldMetaKey;
-      const fm = fieldsMeta[key];
-      if (!fm) {
-        skipped.push({ field: f, reason: 'no_field_meta' });
+    const isEmpty = (v: unknown): boolean =>
+      v === null ||
+      v === undefined ||
+      (typeof v === 'string' && v.trim() === '') ||
+      (Array.isArray(v) && v.length === 0);
+
+    // `write` is the value to send to Team; null means "no Team write needed" (already there
+    // for ChangedByUser + confirm). We still normalize fieldsMeta regardless.
+    type Resolved = { key: FieldMetaKey; flip: boolean; write: string | string[] | null };
+    const resolved: Resolved[] = [];
+    const seen = new Set<FieldMetaKey>();
+
+    for (const { key, content } of inputs) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const adminProvided = content !== undefined;
+      if (adminProvided) {
+        if (isEmpty(content)) {
+          skipped.push({ key, reason: 'empty_value' });
+          continue;
+        }
+        resolved.push({ key, flip: true, write: content as string | string[] });
         continue;
       }
-      if (fm.status === FieldEnrichmentStatus.ChangedByUser) {
-        skipped.push({ field: f, reason: 'user_owned' });
+
+      const currentStatus = fieldsMeta[key]?.status;
+      // For ChangedByUser + confirm: value is already on Team / InvestorProfile. Bump score
+      // only — no Team write needed (and reading team.<field> isn't well-typed for relations).
+      if (currentStatus === FieldEnrichmentStatus.ChangedByUser) {
+        resolved.push({ key, flip: false, write: null });
         continue;
       }
-      if (fm.status !== FieldEnrichmentStatus.Enriched) {
-        skipped.push({ field: f, reason: 'not_enriched' });
+
+      const candidate =
+        key === 'logo'
+          ? team.teamEnrichment.logoUid
+          : key === 'investmentFocus'
+          ? team.teamEnrichment.investmentFocus
+          : key === 'industryTags'
+          ? team.teamEnrichment.industryTags
+          : (team.teamEnrichment as any)[key];
+      if (isEmpty(candidate)) {
+        skipped.push({ key, reason: 'no_candidate' });
         continue;
       }
-      promotableKeys.push(key);
+      resolved.push({ key, flip: false, write: candidate as string | string[] });
     }
 
-    if (promotableKeys.length === 0) {
-      return { success: true, promoted: [], skipped, message: 'No promotable fields' };
+    if (resolved.length === 0) {
+      return { success: true, approved: [], skipped, message: 'No fields to approve' };
     }
 
-    const promotion = await buildPromotionPayload(this.prisma, team.teamEnrichment, promotableKeys, fieldsMeta);
-    const promotedSet = new Set<string>(promotion.promotedFields);
-    for (const requested of promotableKeys) {
-      if (!promotedSet.has(requested)) {
-        skipped.push({ field: requested, reason: 'empty_candidate' });
+    const teamUpdate: Prisma.TeamUpdateInput = {};
+    let investmentFocus: string[] | null = null;
+
+    for (const r of resolved) {
+      if (r.write === null) continue;
+      if (r.key === 'industryTags') {
+        const titles = (r.write as string[]).filter((s) => typeof s === 'string' && s.trim() !== '');
+        const matched =
+          titles.length === 0
+            ? []
+            : await this.prisma.industryTag.findMany({
+                where: { title: { in: titles, mode: 'insensitive' } },
+                select: { uid: true },
+              });
+        teamUpdate.industryTags = { set: matched.map((t) => ({ uid: t.uid })) };
+        continue;
       }
+      if (r.key === 'investmentFocus') {
+        investmentFocus = r.write as string[];
+        continue;
+      }
+      if (r.key === 'logo') {
+        const logoUid = Array.isArray(r.write) ? r.write[0] : r.write;
+        teamUpdate.logo = { connect: { uid: logoUid } };
+        continue;
+      }
+      // scalar
+      (teamUpdate as any)[r.key] = Array.isArray(r.write) ? r.write[0] : r.write;
     }
 
-    if (promotion.promotedFields.length === 0) {
-      return { success: true, promoted: [], skipped, message: 'No values to promote' };
-    }
+    const now = new Date().toISOString();
+    const approvedKeys = resolved.map((r) => r.key);
+    const approvedSet = new Set<FieldMetaKey>(approvedKeys);
 
     const newFieldsMeta: FieldsMetaMap = { ...fieldsMeta };
-    for (const k of promotion.promotedFields) {
-      const existing = newFieldsMeta[k];
-      if (!existing) continue;
-      newFieldsMeta[k] = {
-        ...existing,
-        judgment: {
-          note: existing.judgment?.note,
-          judgedVia: existing.judgment?.judgedVia ?? JudgmentSource.AI,
-          verdict: JudgmentVerdict.Agrees,
-          confidence: FieldConfidence.High,
-          score: 90,
+    for (const r of resolved) {
+      const existing = newFieldsMeta[r.key];
+      const nextStatus = r.flip
+        ? FieldEnrichmentStatus.ChangedByUser
+        : existing?.status ?? FieldEnrichmentStatus.Enriched;
+      newFieldsMeta[r.key] = stampModified(
+        {
+          ...(existing ?? {}),
+          status: nextStatus,
+          judgment: {
+            // Admin approval supersedes the AI's note — clear it so stale judgment
+            // text ("matches-known-...") doesn't outlive the value it described.
+            note: '',
+            judgedVia: existing?.judgment?.judgedVia ?? JudgmentSource.AI,
+            verdict: JudgmentVerdict.Agrees,
+            confidence: FieldConfidence.High,
+            score: 100,
+          },
         },
-      };
+        now
+      );
     }
 
     const updatedTeamJudgment = meta.judgment
       ? {
           ...meta.judgment,
-          fieldsForReview: (meta.judgment.fieldsForReview ?? []).filter((f) => !promotedSet.has(f)),
+          fieldsForReview: (meta.judgment.fieldsForReview ?? []).filter((f) => !approvedSet.has(f as FieldMetaKey)),
         }
       : meta.judgment;
 
@@ -1591,13 +1656,13 @@ export class TeamEnrichmentService {
       ...meta,
       fieldsMeta: newFieldsMeta,
       judgment: updatedTeamJudgment,
-      status: EnrichmentStatus.Reviewed,
-      reviewedAt: new Date().toISOString(),
+      status: EnrichmentStatus.Approved,
+      reviewedAt: now,
       reviewedBy: reviewerEmail,
     };
 
     let latestLogoVerificationUid: string | null = null;
-    if (promotedSet.has('logo')) {
+    if (approvedSet.has('logo')) {
       const latest = await this.prisma.teamLogoVerificationResult.findFirst({
         where: { teamUid },
         orderBy: { createdAt: 'desc' },
@@ -1611,7 +1676,24 @@ export class TeamEnrichmentService {
         where: { teamUid },
         data: { dataEnrichment: updated as any },
       });
-      await executePromotion(tx, teamUid, team, promotion);
+      if (Object.keys(teamUpdate).length > 0) {
+        await tx.team.update({ where: { uid: teamUid }, data: teamUpdate });
+      }
+      if (investmentFocus !== null) {
+        if (team.investorProfile) {
+          await tx.investorProfile.update({
+            where: { uid: team.investorProfile.uid },
+            data: { investmentFocus },
+          });
+        } else {
+          await tx.investorProfile.create({
+            data: {
+              investmentFocus,
+              team: { connect: { uid: teamUid } },
+            },
+          });
+        }
+      }
       if (latestLogoVerificationUid) {
         await tx.teamLogoVerificationResult.update({
           where: { uid: latestLogoVerificationUid },
@@ -1621,16 +1703,14 @@ export class TeamEnrichmentService {
     });
 
     this.logger.log(
-      `Admin enrichment approve: team ${teamUid} promoted=[${promotion.promotedFields.join(
-        ','
-      )}] reviewer=${reviewerEmail}`
+      `Admin enrichment approve: team ${teamUid} approved=[${approvedKeys.join(',')}] reviewer=${reviewerEmail}`
     );
 
     return {
       success: true,
-      promoted: promotion.promotedFields,
+      approved: approvedKeys,
       skipped,
-      message: `Approved ${promotion.promotedFields.length} field(s) for team ${teamUid}`,
+      message: `Approved ${approvedKeys.length} field(s) for team ${teamUid}`,
     };
   }
 

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -416,16 +416,6 @@ scrapingDog?: {
 
 ## Endpoints
 
-### Admin Review
-
-```
-PATCH /v1/admin/teams/:uid/enrichment-review
-Guard: AdminAuthGuard
-Body: { status: 'Reviewed' | 'Approved' }
-```
-
-Team-level status flip only — sets `dataEnrichment.status` to `Reviewed` or `Approved` and stamps `reviewedAt` / `reviewedBy`. Does not touch field values; for field-level approval + Team promotion use the two endpoints below.
-
 ### Admin Field-Level Review — List
 
 ```
@@ -436,12 +426,11 @@ Guard: AdminAuthGuard
 Full list of teams whose top-level `dataEnrichment.status === 'Enriched'`. Reviewed / Approved / PendingEnrichment / InProgress / FailedToEnrich are out of scope. Sorted by `team.name` ASC. No pagination — the portal carries ~1K teams and the back-office UI consumes the full set at once.
 
 Per-field rules:
-- Every field that has a `fieldsMeta[k].judgment` entry is surfaced, including those the judge already promoted at `agrees + high`. Admins use this view to spot-check promotion decisions.
+- Every field that has a `fieldsMeta[k].judgment` entry is surfaced, including those at `agrees + high`. Admins use this view to spot-check the AI's output before approving.
 - `content` source is decided by `fieldsMeta[k].status`:
   - `ChangedByUser` → reads from `Team.<field>` (user's value is the source of truth; the `TeamEnrichment.<field>` candidate, if any, is informational provenance).
   - `Enriched` / `CannotEnrich` → reads from `TeamEnrichment.<field>` (AI candidate not yet promoted).
   The other side is used as a fallback if the primary side is empty. Fields that are empty in **both** places are skipped — there's nothing to review.
-- `ChangedByUser` fields are surfaced with `promotable: false` (visibility only — admin can't promote the user's own value).
 - Logo is included whenever `TeamEnrichment.logoUid` is set, regardless of the latest verification's confidence. The latest `TeamLogoVerificationResult` row (any provider, newest by `createdAt`) populates `verification`; `verification` is `null` when no row exists.
 - The logo URL also appears in `fields.logo.content` (mirrors the scalar-field shape so the UI can iterate uniformly). The richer VLM verdict stays on the top-level `logo` block.
 
@@ -452,27 +441,69 @@ Response shape:
   teams: Array<{
     uid: string;
     name: string;
+    priority: number;                            // Team.priority (1 = highest, 5 = lowest, 99 = NA)
     enrichmentStatus: EnrichmentStatus;          // always 'Enriched' in this list
+    enrichmentAt: string | null;                 // dataEnrichment.usage.enrichment.lastRunAt (ISO)
+    judgedAt: string | null;                     // dataEnrichment.judgment.judgedAt (ISO)
     fields: Partial<Record<FieldMetaKey, {
       content: string | string[];                // candidate value from TeamEnrichment
-      metadata: { source?: EnrichmentSource; lastModifiedAt?: string };
+      metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
       judgment: { note?: string; score?: number };
-      promotable: boolean;                        // false when fieldsMeta[k].status === ChangedByUser
     }>>;
     logo?: {
       content: { uid: string; url: string } | null;   // candidate logo from TeamEnrichment
-      metadata: { source?: EnrichmentSource; lastModifiedAt?: string };
+      metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
       verification: {
         verdict: string;
         confidence: string;
         reason: string | null;
         verifiedAt: string;                       // TeamLogoVerificationResult.createdAt (ISO)
       } | null;
-      promotable: boolean;                         // false when fieldsMeta.logo.status === ChangedByUser
     };
   }>
 }
 ```
+
+### Admin Team Approval
+
+```
+PATCH /v1/admin/teams/:uid/enrichment-review
+Guard: AdminAuthGuard
+Body: { fields: Array<{ key: FieldMetaKey, content?: string | string[] }> }
+```
+
+Admin reviews a team and approves its enrichment. Body lists per-field decisions (at least one):
+
+- `content` provided → admin edited the value. Final value goes to `Team.<column>` and `fieldsMeta[key].status` flips to `ChangedByUser`.
+- `content` omitted ("Confirm") → admin accepted the current value as-is. The canonical source is read (`Team.<field>` when status is `ChangedByUser`, otherwise the `TeamEnrichment.<field>` candidate) and promoted to Team. `status` is unchanged.
+
+In both cases the per-field judgment is normalized to `{ verdict: 'agrees', confidence: 'high', score: 100, note: '' }` (with `judgedVia` preserved). `note` is cleared because admin approval supersedes the AI's prior justification — keeping stale notes like `"matches-known-..."` would misrepresent why the field is now high-confidence. `lastModifiedAt` is restamped per the value-write invariant.
+
+Value shape per field:
+- Scalars (`website`, `blog`, `contactMethod`, social handles, descriptions, `moreDetails`): `string`.
+- `logo`: `string` (a logo `Image.uid` — `Team.logoUid` is connected to it).
+- `industryTags`: `string[]` of tag titles. Resolved case-insensitively against existing `IndustryTag` records; unmatched titles are silently dropped (same rule as the judge).
+- `investmentFocus`: `string[]`. Written to `InvestorProfile.investmentFocus` (the profile is created if missing).
+
+What happens in one `prisma.$transaction`:
+
+1. **Team writes** per the per-field resolution above. For `ChangedByUser` + confirm-only entries, no Team write is issued (the value is already there); only `fieldsMeta` is normalized.
+2. **`fieldsMeta` normalization** for every approved key — `status` + `judgment` updated per the rules above, `lastModifiedAt` restamped.
+3. **Team-level metadata**:
+   - `dataEnrichment.status` → `Approved`.
+   - `reviewedAt` → now (ISO).
+   - `reviewedBy` → requestor email from the JWT (`req.userEmail`).
+   - Approved keys removed from `dataEnrichment.judgment.fieldsForReview`.
+4. **Logo verification audit** — when `logo` is approved, the latest `TeamLogoVerificationResult` row for the team (any provider, newest by `createdAt`) is updated to `{ verdict: 'verified', confidence: 'high' }`. Other snapshot columns are preserved.
+
+Guards & skip reasons:
+
+- **Concurrency**: if `dataEnrichment.status === 'InProgress'`, returns `{ success: false, ... }` and writes nothing.
+- **Per-field skips** are returned in `skipped: { key, reason }[]` (the call still succeeds for the other fields):
+  - `empty_value` — admin sent an empty `content` (empty string / empty array).
+  - `no_candidate` — no `content` was provided and the canonical source (Team or TeamEnrichment) is empty.
+
+Returns `{ success, approved: FieldMetaKey[], skipped: { key, reason }[], message }`. Does NOT require `IS_TEAM_ENRICHMENT_ENABLED`.
 
 ### Admin Enrichment Status — Single Team
 
@@ -548,46 +579,6 @@ Caveats:
 
 - **`isRunning` is per-pod**. The flag is an in-memory boolean on the cron-job class — accurate within this pod, but if the API runs as multiple replicas, only the pod actually executing the cron will report `true`. Counts come from the DB and are authoritative across pods.
 - **Judge `pending` is the SQL pre-filter only**, before `collectJudgableFieldKeys` weeds out rows with nothing to judge. The true cron-eligible count is `≤ pending` — same shape as the cron's own log line.
-
-### Admin Field-Level Review — Approve
-
-```
-PATCH /v1/admin/teams/:uid/enrichment-review/fields
-Guard: AdminAuthGuard
-Body: { fields: string[] }    // each value ∈ FieldMetaKey ∪ ['logo']
-```
-
-Approve a list of enrichment fields for a single team. Reuses the shared promotion helpers (`team-enrichment-promotion.ts`) so the write path matches the AI judge's `agrees + high` promotion — no logic duplication.
-
-What happens in one `prisma.$transaction`:
-
-1. **Promotion to `Team`** — for each approved field:
-   - **Scalars** (`website`, `blog`, `contactMethod`, `twitterHandler`, `linkedinHandler`, `telegramHandler`, `shortDescription`, `longDescription`, `moreDetails`): `Team.<field>` = `TeamEnrichment.<field>`.
-   - **`industryTags`**: candidate titles → `IndustryTag` rows (case-insensitive, unmatched titles silently dropped) → `Team.industryTags` M2M set.
-   - **`investmentFocus`**: `InvestorProfile.investmentFocus` upsert (creates the profile if absent).
-   - **`logo`**: `Team.logoUid` = `TeamEnrichment.logoUid`.
-2. **Per-field metadata normalization** — for each approved field:
-   - `fieldsMeta[field].judgment` → `{ verdict: 'agrees', confidence: 'high', score: 90, note: <preserved>, judgedVia: <preserved or 'ai' default> }`.
-   - Removed from team-level `dataEnrichment.judgment.fieldsForReview`.
-   - `fieldsMeta[field].lastModifiedAt` is **not** stamped (mirrors judge — `lastModifiedAt` tracks value writes; promotion just moves the value from `TeamEnrichment` to `Team`).
-3. **Team-level metadata** — every successful call:
-   - `dataEnrichment.status` → `Reviewed`.
-   - `reviewedAt` → now (ISO).
-   - `reviewedBy` → requestor email from the JWT (`req.userEmail`).
-4. **Logo verification audit** — when `logo` is approved, the **latest** `TeamLogoVerificationResult` row for the team (any provider, newest by `createdAt`) is updated to `verdict: 'verified'`, `confidence: 'high'`. All snapshot columns (`reason`, `brandSignals`, `rawResponse`, `predictedCompanyName`, `quality`, `hasReadableText`, `model`, `provider`) are preserved verbatim as the model's audit record. `updatedAt` is auto-bumped by Prisma. This is the first (and currently only) `.update()` against `TeamLogoVerificationResult` — every other write is append-only.
-
-Guards & skip reasons:
-
-- **Concurrency**: if `dataEnrichment.status === 'InProgress'`, returns `{ success: false, message: '...already in progress' }` and writes nothing.
-- **Per-field skips** are returned in `skipped: { field, reason }[]` (the call still succeeds for the other fields):
-  - `no_field_meta` — field has no entry in `fieldsMeta` on this team.
-  - `user_owned` — `fieldsMeta[field].status === ChangedByUser`. The user's value on `Team` is preserved; promotion is bypassed.
-  - `not_enriched` — `fieldsMeta[field].status` is neither `Enriched` nor `ChangedByUser` (e.g. `CannotEnrich`).
-  - `empty_candidate` — the candidate value on `TeamEnrichment` is null / empty string / empty array.
-
-Idempotency: re-approving a field that is already at `agrees + high + 90` writes the same value/metadata again — safe.
-
-Returns `{ success, promoted: string[], skipped: { field, reason }[], message }`. Does NOT require `IS_TEAM_ENRICHMENT_ENABLED`.
 
 ### Trigger Enrichment for a Single Team
 


### PR DESCRIPTION
## Summary

Reworked the back-office team-enrichment review APIs so the new admin UI (per-field "Confirm" / "Save changes" flow) can drive both content edits and approval through a single endpoint. The previous split — a separate "promote candidate fields" endpoint plus a status-only "review" endpoint with a `promotable` flag in the list response — has been collapsed into one approval endpoint that accepts per-field decisions.

## API changes

### `GET /v1/admin/teams/enrichment-review`

- Dropped `promotable` from every field entry and from the `logo` block (the UI no longer needs a "this field can be promoted" signal — every entry is reviewable).
- Added top-level `priority` (from `Team.priority`) per team.
- Added top-level `enrichmentAt` per team, sourced from `TeamEnrichment.dataEnrichment.usage.enrichment.lastRunAt`.
- Added top-level `judgedAt` per team, sourced from `TeamEnrichment.dataEnrichment.judgment.judgedAt`.

### `PATCH /v1/admin/teams/:uid/enrichment-review/fields` — removed

The standalone field-level promotion endpoint is gone. Its job is now folded into the reworked endpoint below.

### `PATCH /v1/admin/teams/:uid/enrichment-review` — reworked

Body changed from `{ status: 'Reviewed' | 'Approved' }` to a per-field decision list:

```json
{
  "fields": [
    { "key": "website", "content": "https://acme.com" },
    { "key": "blog" },
    { "key": "linkedinHandler", "content": "linkedin.com/company/acme" }
  ]
}
```

Per-field semantics:

- `content` provided → admin edited the field. Value is written to `Team.<column>` and the `FieldEnrichmentStatus` flips to `ChangedByUser`.
- `content` omitted → admin confirmed the existing value. The canonical source (`Team` for `ChangedByUser`, `TeamEnrichment` otherwise) is read and promoted to Team; `status` is unchanged.
- In both cases, `judgment.score` is bumped to `100` (`verdict: agrees`, `confidence: high`).

Team-level: `dataEnrichment.status` flips to `Approved`, `reviewedAt` / `reviewedBy` are stamped, and approved keys are removed from `judgment.fieldsForReview`. When `logo` is approved, the latest `TeamLogoVerificationResult` row is marked `verified` at high confidence.

The team-lead endpoint `PATCH /v1/teams/:uid/enrichment-review` (different role + UX) is unchanged and keeps the simple `{ status }` body.
