### PR TITLE
feat: extend investor db schema and api

### DIFF
--- a/apps/web-api/prisma/migrations/20260518120000_add_investor_db_read_support/migration.sql
+++ b/apps/web-api/prisma/migrations/20260518120000_add_investor_db_read_support/migration.sql
@@ -1,0 +1,55 @@
+-- AlterTable
+ALTER TABLE "InvestorOutreachRecord" ADD COLUMN "tags" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateTable
+CREATE TABLE "InvestorPortfolioOverlap" (
+    "id" SERIAL NOT NULL,
+    "investorOutreachRecordId" INTEGER NOT NULL,
+    "teamUid" TEXT NOT NULL,
+    "dealAmount" DECIMAL(18,2),
+    "dealDate" DATE,
+    "dealStage" TEXT,
+    "isLeadInvestor" BOOLEAN NOT NULL DEFAULT false,
+    "attributionFund" TEXT,
+    "sourceDataset" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "InvestorPortfolioOverlap_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "InvestorPortfolioOverlap_investorOutreachRecordId_idx" ON "InvestorPortfolioOverlap"("investorOutreachRecordId");
+
+-- CreateIndex
+CREATE INDEX "InvestorPortfolioOverlap_teamUid_idx" ON "InvestorPortfolioOverlap"("teamUid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InvestorPortfolioOverlap_investorOutreachRecordId_teamUid_key" ON "InvestorPortfolioOverlap"("investorOutreachRecordId", "teamUid");
+
+-- AddForeignKey
+ALTER TABLE "InvestorPortfolioOverlap" ADD CONSTRAINT "InvestorPortfolioOverlap_investorOutreachRecordId_fkey" FOREIGN KEY ("investorOutreachRecordId") REFERENCES "InvestorOutreachRecord"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvestorPortfolioOverlap" ADD CONSTRAINT "InvestorPortfolioOverlap_teamUid_fkey" FOREIGN KEY ("teamUid") REFERENCES "Team"("uid") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable
+CREATE TABLE "PlPortfolioTeamMeta" (
+    "id" SERIAL NOT NULL,
+    "teamUid" TEXT NOT NULL,
+    "plInvestedAt" DATE,
+    "plInvestedStage" TEXT,
+    "raisingNow" TEXT,
+    "sectors" TEXT,
+    "geo" VARCHAR(120),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PlPortfolioTeamMeta_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlPortfolioTeamMeta_teamUid_key" ON "PlPortfolioTeamMeta"("teamUid");
+
+-- AddForeignKey
+ALTER TABLE "PlPortfolioTeamMeta" ADD CONSTRAINT "PlPortfolioTeamMeta_teamUid_fkey" FOREIGN KEY ("teamUid") REFERENCES "Team"("uid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -87,6 +87,9 @@ model Team {
   jobEnrichment  TeamJobEnrichment?
   newsItems      TeamNewsItem[]
   newsEnrichment TeamNewsEnrichment?
+
+  portfolioOverlaps InvestorPortfolioOverlap[]
+  portfolioMeta     PlPortfolioTeamMeta?
 }
 
 enum AskStatus {
@@ -2199,9 +2202,9 @@ model JobAlertSendRun {
 model InvestorOutreachRecord {
   id Int @id @default(autoincrement())
 
-  investorId  String @unique
+  investorId  String  @unique
   canonicalId String?
-  dedupeKey   String @unique
+  dedupeKey   String  @unique
   source      String
 
   firstName String?
@@ -2219,16 +2222,16 @@ model InvestorOutreachRecord {
   aumRange       String?
   checkSizeRange String?
 
-  stageFocus   String
-  sectorTags   String?
-  geoFocus     String? @db.VarChar(120)
-  recentDeals  String? @db.VarChar(200)
+  stageFocus  String
+  sectorTags  String?
+  geoFocus    String? @db.VarChar(120)
+  recentDeals String? @db.VarChar(200)
 
-  outreachTouches   Int @default(0)
+  outreachTouches   Int     @default(0)
   outreachCampaigns String?
-  opened            Int @default(0)
-  clicked           Int @default(0)
-  registered        Int @default(0)
+  opened            Int     @default(0)
+  clicked           Int     @default(0)
+  registered        Int     @default(0)
 
   firstSentDate  DateTime? @db.Date
   lastSentDate   DateTime? @db.Date
@@ -2241,6 +2244,12 @@ model InvestorOutreachRecord {
   enrichmentNotes String? @db.VarChar(500)
   rawPayload      Json?
 
+  /// User-applied tags. Reserved for the future PATCH /investors/:id/tags endpoint;
+  /// the ingest pipeline will only populate this once the script starts emitting it (Phase 2+).
+  tags String[] @default([])
+
+  portfolioOverlaps InvestorPortfolioOverlap[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -2250,4 +2259,49 @@ model InvestorOutreachRecord {
   @@index([engagementTier])
   @@index([enrichmentStatus])
   @@index([enrichmentDate])
+}
+
+/// Cap-table overlap between an external investor (InvestorOutreachRecord) and a PL portfolio Team.
+/// Populated by the Apps-Script ingest pipeline in Phase 2; empty until then.
+model InvestorPortfolioOverlap {
+  id Int @id @default(autoincrement())
+
+  investorOutreachRecordId Int
+  investorOutreachRecord   InvestorOutreachRecord @relation(fields: [investorOutreachRecordId], references: [id], onDelete: Cascade)
+
+  teamUid String
+  team    Team   @relation(fields: [teamUid], references: [uid], onDelete: Cascade)
+
+  dealAmount      Decimal?  @db.Decimal(18, 2)
+  dealDate        DateTime? @db.Date
+  dealStage       String?
+  isLeadInvestor  Boolean   @default(false)
+  attributionFund String?
+
+  sourceDataset String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@unique([investorOutreachRecordId, teamUid])
+  @@index([investorOutreachRecordId])
+  @@index([teamUid])
+}
+
+/// PL portfolio team metadata used by the Investor DB warm-intros flow.
+/// Sidecar to Team so the core model stays untouched. Populated by the ingest pipeline in Phase 2.
+model PlPortfolioTeamMeta {
+  id Int @id @default(autoincrement())
+
+  teamUid String @unique
+  team    Team   @relation(fields: [teamUid], references: [uid], onDelete: Cascade)
+
+  plInvestedAt    DateTime? @db.Date
+  plInvestedStage String?
+  raisingNow      String?
+  /// Comma-separated sector tags, matching the ingest `sector_tags` convention.
+  sectors         String?
+  geo             String?   @db.VarChar(120)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/apps/web-api/src/investor-outreach/dto/ingest-investor-outreach.dto.ts
+++ b/apps/web-api/src/investor-outreach/dto/ingest-investor-outreach.dto.ts
@@ -1,3 +1,35 @@
+/**
+ * Per-row portfolio overlap edge sent inside an InvestorOutreachIngestItem.
+ *
+ * Each entry maps the investor (the row owner) to a PL portfolio Team they're known to be on the
+ * cap table of. team_uid must refer to an existing Team. Sync semantics: see service docs.
+ */
+export interface InvestorOutreachPortfolioOverlapInput {
+  team_uid: string;
+  deal_amount?: number;
+  /** YYYY-MM-DD */
+  deal_date?: string;
+  deal_stage?: string;
+  is_lead_investor?: boolean;
+  /** Free-form attribution string (e.g. "PL Capital", "PLVS"). Validated against vocab. */
+  attribution_fund?: string;
+}
+
+/**
+ * Top-level entry describing PL portfolio team metadata used by the warm-intros workspace.
+ * Independent of the per-row items array; team_uid must refer to an existing Team.
+ */
+export interface InvestorOutreachPortfolioTeamInput {
+  team_uid: string;
+  /** YYYY-MM-DD */
+  pl_invested_at?: string;
+  pl_invested_stage?: string;
+  raising_now?: string;
+  /** Comma-separated sector tags, matching the row-level sector_tags convention. */
+  sectors?: string;
+  geo?: string;
+}
+
 export interface InvestorOutreachIngestItem {
   investor_id: string;
   canonical_id?: string;
@@ -31,13 +63,15 @@ export interface InvestorOutreachIngestItem {
   enrichment_date?: string;
   last_enrichment_attempt?: string;
   enrichment_notes?: string;
+  tags?: string[];
+  portfolio_overlaps?: InvestorOutreachPortfolioOverlapInput[];
 }
 
 export interface IngestInvestorOutreachDto {
   runId?: string;
-  /** Provenance tag for ingest batch (distinct from row `source`) */
   source?: string;
   items: InvestorOutreachIngestItem[];
+  portfolio_teams?: InvestorOutreachPortfolioTeamInput[];
 }
 
 export interface IngestInvestorOutreachResponse {
@@ -46,5 +80,7 @@ export interface IngestInvestorOutreachResponse {
   created: number;
   updated: number;
   failed: number;
+  overlaps_synced?: number;
+  portfolio_teams_upserted?: number;
   errors?: string[];
 }

--- a/apps/web-api/src/investor-outreach/dto/investor.dto.ts
+++ b/apps/web-api/src/investor-outreach/dto/investor.dto.ts
@@ -1,0 +1,64 @@
+export interface LabOsProfileDto {
+  type: 'member';
+  uid: string;
+  slug: string;
+  name: string;
+  email: string | null;
+  lastActiveAt: string | null;
+}
+
+export interface InvestorDto {
+  investorId: string;
+  canonicalId: string | null;
+  dedupeKey: string;
+  source: string;
+
+  firstName: string | null;
+  lastName: string | null;
+  email: string;
+  emailStatus: string;
+  linkedinUrl: string | null;
+
+  firm: string | null;
+  firmDomain: string | null;
+  title: string | null;
+
+  investorType: string;
+  fundThesis: string | null;
+  aumRange: string | null;
+  checkSizeRange: string | null;
+
+  stageFocus: string;
+  sectorTags: string[];
+  geoFocus: string | null;
+  recentDeals: string[];
+
+  outreachTouches: number;
+  outreachCampaigns: string[];
+  opened: number;
+  clicked: number;
+  registered: number;
+
+  firstSentDate: string | null;
+  lastSentDate: string | null;
+  engagementTier: string;
+
+  enrichmentStatus: string;
+  enrichmentDate: string | null;
+  lastEnrichmentAttempt: string | null;
+  enrichmentNotes: string | null;
+
+  tags: string[];
+  labOsProfile: LabOsProfileDto | null;
+  coInvestedTeamIds: string[];
+
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PaginatedInvestorsDto {
+  page: number;
+  limit: number;
+  total: number;
+  items: InvestorDto[];
+}

--- a/apps/web-api/src/investor-outreach/dto/list-investors.query.dto.ts
+++ b/apps/web-api/src/investor-outreach/dto/list-investors.query.dto.ts
@@ -1,0 +1,29 @@
+/**
+ * Query params for GET /v1/investor-outreach/investors.
+ *
+ * Multi-value filters are sent as CSV strings (e.g. `source=W26,OpenVC`) to match the frontend
+ * service layer in `pln-directory-portal-v2/services/investors/investors.service.ts`.
+ * Parsing/validation happens in the service.
+ */
+export class ListInvestorsQueryDto {
+  q?: string;
+
+  source?: string;
+  investorType?: string;
+  stageFocus?: string;
+  sectorTags?: string;
+  geoFocus?: string;
+  emailStatus?: string;
+  engagementTier?: string;
+  enrichmentStatus?: string;
+
+  inLabOs?: string;
+  isCoInvestor?: string;
+  coInvestedTeamId?: string;
+  tags?: string;
+
+  /** `field:asc|desc` — whitelist enforced server-side */
+  sort?: string;
+  page?: string;
+  limit?: string;
+}

--- a/apps/web-api/src/investor-outreach/dto/pl-portfolio-team.dto.ts
+++ b/apps/web-api/src/investor-outreach/dto/pl-portfolio-team.dto.ts
@@ -1,0 +1,17 @@
+export interface PlPortfolioTeamCoInvestorDto {
+  investorId: string;
+  dealAmount: number | null;
+  dealDate: string | null;
+}
+
+export interface PlPortfolioTeamDto {
+  teamUid: string;
+  teamName: string;
+  logoUrl: string | null;
+  plInvestedAt: string | null;
+  plInvestedStage: string | null;
+  raisingNow: string | null;
+  sectors: string[];
+  geo: string | null;
+  coInvestors: PlPortfolioTeamCoInvestorDto[];
+}

--- a/apps/web-api/src/investor-outreach/dto/warm-intros.dto.ts
+++ b/apps/web-api/src/investor-outreach/dto/warm-intros.dto.ts
@@ -1,0 +1,22 @@
+import { InvestorDto } from './investor.dto';
+import { PlPortfolioTeamDto } from './pl-portfolio-team.dto';
+
+export type WarmIntroTier = 'co_invested' | 'engaged' | 'cold_match';
+
+export interface WarmIntroCandidateDto {
+  investor: InvestorDto;
+  tier: WarmIntroTier;
+  /** Human-readable explanation for the ranking. */
+  reason: string;
+  /** 0–100 score. Higher = better fit. */
+  fitScore: number;
+  /** Short evidence chips for the row. */
+  evidence: string[];
+}
+
+export interface WarmIntrosResponseDto {
+  /** Populated when a teamId was provided. */
+  team?: PlPortfolioTeamDto;
+  total: number;
+  candidates: WarmIntroCandidateDto[];
+}

--- a/apps/web-api/src/investor-outreach/dto/warm-intros.query.dto.ts
+++ b/apps/web-api/src/investor-outreach/dto/warm-intros.query.dto.ts
@@ -1,0 +1,12 @@
+/**
+ * Query params for GET /v1/investor-outreach/warm-intros.
+ * teamId auto-fills stage/sectors/geo from PlPortfolioTeamMeta if present; explicit params override.
+ */
+export class WarmIntrosQueryDto {
+  teamId?: string;
+  stageFocus?: string;
+  /** CSV of sector tag tokens */
+  sectorTags?: string;
+  checkSizeRange?: string;
+  geoFocus?: string;
+}

--- a/apps/web-api/src/investor-outreach/investor-outreach-query.service.ts
+++ b/apps/web-api/src/investor-outreach/investor-outreach-query.service.ts
@@ -1,0 +1,354 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../shared/prisma.service';
+import { InvestorDto, PaginatedInvestorsDto } from './dto/investor.dto';
+import { ListInvestorsQueryDto } from './dto/list-investors.query.dto';
+import { PlPortfolioTeamDto } from './dto/pl-portfolio-team.dto';
+import { WarmIntrosQueryDto } from './dto/warm-intros.query.dto';
+import { WarmIntroCandidateDto, WarmIntrosResponseDto } from './dto/warm-intros.dto';
+import {
+  MemberByEmail,
+  OverlapsByInvestorId,
+  toInvestorDto,
+  toPlPortfolioTeamDto,
+} from './investor-outreach.mapper';
+import { scoreCandidate } from './warm-intros.scorer';
+import {
+  isAllowedEmailStatus,
+  isAllowedEngagementTier,
+  isAllowedEnrichmentStatus,
+  isAllowedInvestorSource,
+  isAllowedInvestorType,
+  isAllowedStageFocus,
+  INVESTOR_OUTREACH_SECTOR_TAGS,
+} from './investor-outreach.vocab';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+const SORT_FIELDS = ['engagementTier', 'lastSentDate', 'lastName', 'firm', 'createdAt', 'enrichmentDate'] as const;
+type SortField = typeof SORT_FIELDS[number];
+
+const SECTOR_TAG_SET = new Set<string>(INVESTOR_OUTREACH_SECTOR_TAGS);
+
+@Injectable()
+export class InvestorOutreachQueryService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listInvestors(query: ListInvestorsQueryDto): Promise<PaginatedInvestorsDto> {
+    const page = clampPage(query.page);
+    const limit = clampLimit(query.limit);
+
+    const where = await this.buildWhere(query);
+    const orderBy = this.buildOrderBy(query.sort);
+
+    const [total, records] = await this.prisma.$transaction([
+      this.prisma.investorOutreachRecord.count({ where }),
+      this.prisma.investorOutreachRecord.findMany({
+        where,
+        orderBy,
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+    ]);
+
+    const items = await this.attachJoins(records);
+    return { page, limit, total, items };
+  }
+
+  async findInvestorById(investorId: string): Promise<InvestorDto> {
+    const record = await this.prisma.investorOutreachRecord.findUnique({ where: { investorId } });
+    if (!record) {
+      throw new NotFoundException(`Investor not found: ${investorId}`);
+    }
+    const [item] = await this.attachJoins([record]);
+    return item;
+  }
+
+  async findCoInvestorsByTeam(): Promise<PlPortfolioTeamDto[]> {
+    const teams = await this.prisma.team.findMany({
+      where: { portfolioOverlaps: { some: {} } },
+      include: {
+        logo: true,
+        portfolioMeta: true,
+        portfolioOverlaps: {
+          include: { investorOutreachRecord: { select: { investorId: true } } },
+        },
+      },
+      orderBy: { name: 'asc' },
+    });
+    return teams.map(toPlPortfolioTeamDto);
+  }
+
+  async findWarmIntros(query: WarmIntrosQueryDto): Promise<WarmIntrosResponseDto> {
+    // Resolve the target team (if any) and derive auto-filled criteria from its meta sidecar.
+    let targetTeamUid: string | undefined;
+    let targetTeamDto: PlPortfolioTeamDto | undefined;
+    let targetTeamName: string | undefined;
+    let teamSectors: string[] = [];
+    let teamStage: string | undefined;
+
+    if (query.teamId && query.teamId.trim()) {
+      const team = await this.prisma.team.findUnique({
+        where: { uid: query.teamId.trim() },
+        include: {
+          logo: true,
+          portfolioMeta: true,
+          portfolioOverlaps: {
+            include: { investorOutreachRecord: { select: { investorId: true } } },
+          },
+        },
+      });
+      if (team) {
+        targetTeamUid = team.uid;
+        targetTeamName = team.name;
+        targetTeamDto = toPlPortfolioTeamDto(team);
+        teamSectors = targetTeamDto.sectors;
+        teamStage = targetTeamDto.raisingNow ?? targetTeamDto.plInvestedStage ?? undefined;
+      }
+    }
+
+    // Explicit query params override the team auto-fill.
+    const explicitSectors = parseCsv(query.sectorTags).filter((t) => SECTOR_TAG_SET.has(t));
+    const targetSectors = explicitSectors.length ? explicitSectors : teamSectors;
+
+    const explicitStage =
+      query.stageFocus && query.stageFocus.trim() && isAllowedStageFocus(query.stageFocus.trim())
+        ? query.stageFocus.trim()
+        : undefined;
+    const targetStage = explicitStage ?? teamStage;
+
+    // Candidate superset: any signal that could plausibly score > 0.
+    // - Co-investors (warm)
+    // - T1/T2/T3 engagement (engaged)
+    // - When target sectors are set, also any investor whose sectorTags column is populated (cold-match)
+    const candidateWhere: Prisma.InvestorOutreachRecordWhereInput = {
+      OR: [
+        { portfolioOverlaps: { some: {} } },
+        { engagementTier: { in: ['T1_registered', 'T2_clicked', 'T3_opened'] } },
+        ...(targetSectors.length > 0 ? [{ NOT: { sectorTags: null } }] : []),
+      ],
+    };
+
+    const records = await this.prisma.investorOutreachRecord.findMany({ where: candidateWhere });
+    const investors = await this.attachJoins(records);
+
+    // Build a uid→name map for portfolio teams referenced by any candidate's overlaps.
+    // Used by the scorer to produce "Co-invested on <team>" reason strings for any-team matches.
+    const allReferencedTeamUids = Array.from(new Set(investors.flatMap((i) => i.coInvestedTeamIds)));
+    const referencedTeams = allReferencedTeamUids.length
+      ? await this.prisma.team.findMany({
+          where: { uid: { in: allReferencedTeamUids } },
+          select: { uid: true, name: true },
+        })
+      : [];
+    const portfolioTeamsByUid = new Map<string, string>(referencedTeams.map((t) => [t.uid, t.name]));
+
+    const candidates: WarmIntroCandidateDto[] = investors
+      .map((investor) => {
+        const { tier, score, reason, evidence } = scoreCandidate({
+          investor,
+          targetTeamUid,
+          targetTeamName,
+          targetSectors,
+          targetStage,
+          portfolioTeamsByUid,
+        });
+        return { investor, tier, fitScore: score, reason, evidence };
+      })
+      .filter((c) => c.fitScore > 0)
+      .sort((a, b) => b.fitScore - a.fitScore);
+
+    return {
+      team: targetTeamDto,
+      total: candidates.length,
+      candidates,
+    };
+  }
+
+  private async buildWhere(query: ListInvestorsQueryDto): Promise<Prisma.InvestorOutreachRecordWhereInput> {
+    const conditions: Prisma.InvestorOutreachRecordWhereInput[] = [];
+
+    if (query.q && query.q.trim()) {
+      const q = query.q.trim();
+      conditions.push({
+        OR: [
+          { firstName: { contains: q, mode: 'insensitive' } },
+          { lastName: { contains: q, mode: 'insensitive' } },
+          { email: { contains: q, mode: 'insensitive' } },
+          { firm: { contains: q, mode: 'insensitive' } },
+        ],
+      });
+    }
+
+    const enumFilter = (raw: string | undefined, isAllowed: (v: string) => boolean) => {
+      const values = parseCsv(raw).filter(isAllowed);
+      return values.length ? values : undefined;
+    };
+
+    const source = enumFilter(query.source, isAllowedInvestorSource);
+    if (source) conditions.push({ source: { in: source } });
+
+    const investorType = enumFilter(query.investorType, isAllowedInvestorType);
+    if (investorType) conditions.push({ investorType: { in: investorType } });
+
+    const stageFocus = enumFilter(query.stageFocus, isAllowedStageFocus);
+    if (stageFocus) conditions.push({ stageFocus: { in: stageFocus } });
+
+    const emailStatus = enumFilter(query.emailStatus, isAllowedEmailStatus);
+    if (emailStatus) conditions.push({ emailStatus: { in: emailStatus } });
+
+    const engagementTier = enumFilter(query.engagementTier, isAllowedEngagementTier);
+    if (engagementTier) conditions.push({ engagementTier: { in: engagementTier } });
+
+    const enrichmentStatus = enumFilter(query.enrichmentStatus, isAllowedEnrichmentStatus);
+    if (enrichmentStatus) conditions.push({ enrichmentStatus: { in: enrichmentStatus } });
+
+    // sectorTags is stored as a comma-separated string. Match each requested tag as a discrete token
+    // (delimited by commas or string edges) to avoid substring collisions inside the CSV value.
+    const sectorTags = parseCsv(query.sectorTags).filter((t) => SECTOR_TAG_SET.has(t));
+    if (sectorTags.length) {
+      conditions.push({
+        OR: sectorTags.flatMap((tag) => [
+          { sectorTags: tag },
+          { sectorTags: { startsWith: `${tag},` } },
+          { sectorTags: { endsWith: `,${tag}` } },
+          { sectorTags: { contains: `,${tag},` } },
+        ]),
+      });
+    }
+
+    if (query.geoFocus && query.geoFocus.trim()) {
+      conditions.push({ geoFocus: { contains: query.geoFocus.trim(), mode: 'insensitive' } });
+    }
+
+    const inLabOs = parseBool(query.inLabOs);
+    if (inLabOs !== undefined) {
+      const cond = await this.buildInLabOsCondition(inLabOs);
+      if (cond) conditions.push(cond);
+    }
+
+    const isCoInvestor = parseBool(query.isCoInvestor);
+    if (isCoInvestor === true) {
+      conditions.push({ portfolioOverlaps: { some: {} } });
+    } else if (isCoInvestor === false) {
+      conditions.push({ portfolioOverlaps: { none: {} } });
+    }
+
+    if (query.coInvestedTeamId && query.coInvestedTeamId.trim()) {
+      conditions.push({ portfolioOverlaps: { some: { teamUid: query.coInvestedTeamId.trim() } } });
+    }
+
+    const tags = parseCsv(query.tags);
+    if (tags.length) {
+      conditions.push({ tags: { hasSome: tags } });
+    }
+
+    return conditions.length ? { AND: conditions } : {};
+  }
+
+  /**
+   * Resolves "investor email is a LabOS Member" via a Member-email lookup. Done as an explicit
+   * email IN (...) clause because InvestorOutreachRecord has no relation to Member.
+   */
+  private async buildInLabOsCondition(inLabOs: boolean): Promise<Prisma.InvestorOutreachRecordWhereInput | null> {
+    const members = await this.prisma.member.findMany({
+      where: { email: { not: null } },
+      select: { email: true },
+    });
+    const emails = members.map((m) => m.email).filter((e): e is string => !!e);
+    if (inLabOs) {
+      return { email: { in: emails.length ? emails : [''], mode: 'insensitive' } };
+    }
+    if (emails.length === 0) return null;
+    return { NOT: { email: { in: emails, mode: 'insensitive' } } };
+  }
+
+  private buildOrderBy(sort: string | undefined): Prisma.InvestorOutreachRecordOrderByWithRelationInput[] {
+    if (sort && sort.trim()) {
+      const [field, direction] = sort.split(':').map((s) => s.trim());
+      if (this.isSortField(field) && (direction === 'asc' || direction === 'desc')) {
+        return [{ [field]: direction } as Prisma.InvestorOutreachRecordOrderByWithRelationInput];
+      }
+    }
+    return [{ engagementTier: 'asc' }, { lastSentDate: 'desc' }];
+  }
+
+  private isSortField(s: string): s is SortField {
+    return (SORT_FIELDS as readonly string[]).includes(s);
+  }
+
+  private async attachJoins(
+    records: Prisma.InvestorOutreachRecordGetPayload<Record<string, never>>[]
+  ): Promise<InvestorDto[]> {
+    if (records.length === 0) return [];
+
+    const emails = Array.from(
+      new Set(
+        records
+          .map((r) => r.email)
+          .filter((e): e is string => !!e)
+          .map((e) => e.toLowerCase())
+      )
+    );
+    const ids = records.map((r) => r.id);
+
+    const [members, overlaps] = await Promise.all([
+      emails.length
+        ? this.prisma.member.findMany({
+            where: { email: { in: emails, mode: 'insensitive' } },
+            include: { image: true },
+          })
+        : Promise.resolve([]),
+      ids.length
+        ? this.prisma.investorPortfolioOverlap.findMany({
+            where: { investorOutreachRecordId: { in: ids } },
+            select: { investorOutreachRecordId: true, teamUid: true },
+          })
+        : Promise.resolve([]),
+    ]);
+
+    const membersByEmail: MemberByEmail = new Map();
+    for (const member of members) {
+      if (member.email) membersByEmail.set(member.email.toLowerCase(), member);
+    }
+
+    const overlapsByInvestorId: OverlapsByInvestorId = new Map();
+    for (const overlap of overlaps) {
+      const list = overlapsByInvestorId.get(overlap.investorOutreachRecordId) ?? [];
+      list.push(overlap.teamUid);
+      overlapsByInvestorId.set(overlap.investorOutreachRecordId, list);
+    }
+
+    return records.map((record) => toInvestorDto(record, membersByEmail, overlapsByInvestorId));
+  }
+}
+
+function clampPage(raw: string | undefined): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_PAGE;
+  return Math.floor(n);
+}
+
+function clampLimit(raw: string | undefined): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.floor(n));
+}
+
+function parseCsv(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseBool(raw: string | undefined): boolean | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  const v = String(raw).toLowerCase();
+  if (v === 'true' || v === '1') return true;
+  if (v === 'false' || v === '0') return false;
+  return undefined;
+}

--- a/apps/web-api/src/investor-outreach/investor-outreach-service.controller.spec.ts
+++ b/apps/web-api/src/investor-outreach/investor-outreach-service.controller.spec.ts
@@ -61,4 +61,67 @@ describe('InvestorOutreachServiceController', () => {
     expect(ingest).toHaveBeenCalledWith(body);
     expect(out.created).toBe(1);
   });
+
+  it('rejects portfolio_overlaps without team_uid', async () => {
+    await expect(
+      controller.ingest({
+        items: [
+          {
+            investor_id: 'INV-1',
+            dedupe_key: 'a@b.com',
+            source: 'Manual',
+            email: 'a@b.com',
+            email_status: 'verified',
+            investor_type: 'fund',
+            stage_focus: 'seed',
+            engagement_tier: 'T4_cold',
+            enrichment_status: 'pending',
+            portfolio_overlaps: [{} as never],
+          },
+        ],
+      })
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects portfolio_overlaps deal_date that is not YYYY-MM-DD', async () => {
+    await expect(
+      controller.ingest({
+        items: [
+          {
+            investor_id: 'INV-1',
+            dedupe_key: 'a@b.com',
+            source: 'Manual',
+            email: 'a@b.com',
+            email_status: 'verified',
+            investor_type: 'fund',
+            stage_focus: 'seed',
+            engagement_tier: 'T4_cold',
+            enrichment_status: 'pending',
+            portfolio_overlaps: [{ team_uid: 'team-a', deal_date: '2025/06/01' }],
+          },
+        ],
+      })
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects top-level portfolio_teams entries without team_uid', async () => {
+    await expect(
+      controller.ingest({
+        items: [
+          {
+            investor_id: 'INV-1',
+            dedupe_key: 'a@b.com',
+            source: 'Manual',
+            email: 'a@b.com',
+            email_status: 'verified',
+            investor_type: 'fund',
+            stage_focus: 'seed',
+            engagement_tier: 'T4_cold',
+            enrichment_status: 'pending',
+          },
+        ],
+        portfolio_teams: [{ pl_invested_at: '2024-12-01' } as never],
+      })
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
 });

--- a/apps/web-api/src/investor-outreach/investor-outreach-service.controller.ts
+++ b/apps/web-api/src/investor-outreach/investor-outreach-service.controller.ts
@@ -20,6 +20,8 @@ const REQUIRED_SCALAR: Array<keyof InvestorOutreachIngestItem> = [
   'enrichment_status',
 ];
 
+const YMD = /^\d{4}-\d{2}-\d{2}$/;
+
 @ApiTags('Investor Outreach - Service')
 @Controller('v1/service')
 @UseGuards(ServiceAuthGuard)
@@ -53,7 +55,7 @@ export class InvestorOutreachServiceController {
       ] as const;
       for (const [name, val] of dateFields) {
         if (val !== undefined && val !== null && String(val).trim() !== '') {
-          if (!/^\d{4}-\d{2}-\d{2}$/.test(String(val).trim())) {
+          if (!YMD.test(String(val).trim())) {
             throw new BadRequestException(`Item ${i}: ${name} must be YYYY-MM-DD when provided`);
           }
         }
@@ -64,12 +66,63 @@ export class InvestorOutreachServiceController {
           throw new BadRequestException(`Item ${i}: last_enrichment_attempt must be valid ISO datetime when provided`);
         }
       }
+
+      if (item.tags !== undefined && item.tags !== null) {
+        if (!Array.isArray(item.tags)) {
+          throw new BadRequestException(`Item ${i}: tags must be an array of strings when provided`);
+        }
+        for (const t of item.tags) {
+          if (typeof t !== 'string') {
+            throw new BadRequestException(`Item ${i}: tags entries must be strings`);
+          }
+        }
+      }
+
+      if (item.portfolio_overlaps !== undefined && item.portfolio_overlaps !== null) {
+        if (!Array.isArray(item.portfolio_overlaps)) {
+          throw new BadRequestException(`Item ${i}: portfolio_overlaps must be an array when provided`);
+        }
+        for (let j = 0; j < item.portfolio_overlaps.length; j++) {
+          const o = item.portfolio_overlaps[j];
+          if (!o || typeof o !== 'object') {
+            throw new BadRequestException(`Item ${i}: portfolio_overlaps[${j}] must be an object`);
+          }
+          if (typeof o.team_uid !== 'string' || o.team_uid.trim() === '') {
+            throw new BadRequestException(`Item ${i}: portfolio_overlaps[${j}].team_uid is required`);
+          }
+          if (o.deal_date != null && String(o.deal_date).trim() !== '' && !YMD.test(String(o.deal_date).trim())) {
+            throw new BadRequestException(`Item ${i}: portfolio_overlaps[${j}].deal_date must be YYYY-MM-DD`);
+          }
+        }
+      }
+    }
+
+    if (dto.portfolio_teams !== undefined && dto.portfolio_teams !== null) {
+      if (!Array.isArray(dto.portfolio_teams)) {
+        throw new BadRequestException('portfolio_teams must be an array when provided');
+      }
+      for (let i = 0; i < dto.portfolio_teams.length; i++) {
+        const t = dto.portfolio_teams[i];
+        if (!t || typeof t !== 'object') {
+          throw new BadRequestException(`portfolio_teams[${i}] must be an object`);
+        }
+        if (typeof t.team_uid !== 'string' || t.team_uid.trim() === '') {
+          throw new BadRequestException(`portfolio_teams[${i}].team_uid is required`);
+        }
+        if (
+          t.pl_invested_at != null &&
+          String(t.pl_invested_at).trim() !== '' &&
+          !YMD.test(String(t.pl_invested_at).trim())
+        ) {
+          throw new BadRequestException(`portfolio_teams[${i}].pl_invested_at must be YYYY-MM-DD when provided`);
+        }
+      }
     }
 
     this.logger.log(
       `Received investor-outreach ingest: items=${dto.items.length} runId=${dto.runId ?? 'none'} source=${
         dto.source ?? 'none'
-      }`
+      } portfolio_teams=${dto.portfolio_teams?.length ?? 0}`
     );
     return this.investorOutreachService.ingest(dto);
   }

--- a/apps/web-api/src/investor-outreach/investor-outreach.controller.ts
+++ b/apps/web-api/src/investor-outreach/investor-outreach.controller.ts
@@ -1,0 +1,50 @@
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { NoCache } from '../decorators/no-cache.decorator';
+import { UserTokenCheckGuard } from '../guards/user-token-check.guard';
+import { RbacGuard } from '../rbac/rbac.guard';
+import { RequirePermissions } from '../rbac/rbac.decorator';
+import { RBAC_PERMISSION_CODES } from '../rbac/rbac.constants';
+import { ADMIN_PERMISSIONS } from '../access-control-v2/access-control-v2.constants';
+import { ListInvestorsQueryDto } from './dto/list-investors.query.dto';
+import { WarmIntrosQueryDto } from './dto/warm-intros.query.dto';
+import { InvestorOutreachQueryService } from './investor-outreach-query.service';
+
+const READ_PERMS = {
+  anyOf: [RBAC_PERMISSION_CODES.INVESTOR_DB_VIEW, ADMIN_PERMISSIONS.DIRECTORY_FULL],
+};
+
+@ApiTags('Investor Outreach')
+@Controller('v1/investor-outreach')
+@UseGuards(UserTokenCheckGuard, RbacGuard)
+export class InvestorOutreachController {
+  constructor(private readonly queryService: InvestorOutreachQueryService) {}
+
+  @NoCache()
+  @Get('investors')
+  @RequirePermissions(READ_PERMS)
+  async listInvestors(@Query() query: ListInvestorsQueryDto) {
+    return this.queryService.listInvestors(query);
+  }
+
+  @NoCache()
+  @Get('co-investors/by-team')
+  @RequirePermissions(READ_PERMS)
+  async coInvestorsByTeam() {
+    return this.queryService.findCoInvestorsByTeam();
+  }
+
+  @NoCache()
+  @Get('warm-intros')
+  @RequirePermissions(READ_PERMS)
+  async warmIntros(@Query() query: WarmIntrosQueryDto) {
+    return this.queryService.findWarmIntros(query);
+  }
+
+  @NoCache()
+  @Get('investors/:id')
+  @RequirePermissions(READ_PERMS)
+  async getInvestor(@Param('id') id: string) {
+    return this.queryService.findInvestorById(id);
+  }
+}

--- a/apps/web-api/src/investor-outreach/investor-outreach.mapper.ts
+++ b/apps/web-api/src/investor-outreach/investor-outreach.mapper.ts
@@ -1,0 +1,131 @@
+import type {
+  Image,
+  InvestorOutreachRecord,
+  InvestorPortfolioOverlap,
+  Member,
+  PlPortfolioTeamMeta,
+  Team,
+} from '@prisma/client';
+import { InvestorDto, LabOsProfileDto } from './dto/investor.dto';
+import { PlPortfolioTeamCoInvestorDto, PlPortfolioTeamDto } from './dto/pl-portfolio-team.dto';
+
+type MemberWithImage = Member & { image: Image | null };
+
+/** Member-keyed lookup by lowercase email; the email column on Member is unique and case-insensitive in practice. */
+export type MemberByEmail = Map<string, MemberWithImage>;
+
+/** Overlap rows grouped by investor record id → list of teamUids. */
+export type OverlapsByInvestorId = Map<number, string[]>;
+
+const dateToYmd = (d: Date | null | undefined): string | null =>
+  d == null ? null : d.toISOString().slice(0, 10);
+
+const dateToIso = (d: Date | null | undefined): string | null => (d == null ? null : d.toISOString());
+
+export const splitCsv = (raw: string | null | undefined): string[] => {
+  if (raw == null || raw.trim() === '') return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+};
+
+const buildLabOsProfile = (member: MemberWithImage | undefined): LabOsProfileDto | null => {
+  if (!member) return null;
+  return {
+    type: 'member',
+    uid: member.uid,
+    /** Member has no dedicated slug column today; uid is the stable, URL-safe identifier. */
+    slug: member.uid,
+    name: member.name,
+    email: member.email,
+    lastActiveAt: dateToIso(member.updatedAt),
+  };
+};
+
+export function toInvestorDto(
+  record: InvestorOutreachRecord,
+  membersByEmail: MemberByEmail,
+  overlapsByInvestorId: OverlapsByInvestorId
+): InvestorDto {
+  const member = record.email ? membersByEmail.get(record.email.toLowerCase()) : undefined;
+  const teamUids = overlapsByInvestorId.get(record.id) ?? [];
+
+  return {
+    investorId: record.investorId,
+    canonicalId: record.canonicalId,
+    dedupeKey: record.dedupeKey,
+    source: record.source,
+
+    firstName: record.firstName,
+    lastName: record.lastName,
+    email: record.email,
+    emailStatus: record.emailStatus,
+    linkedinUrl: record.linkedinUrl,
+
+    firm: record.firm,
+    firmDomain: record.firmDomain,
+    title: record.title,
+
+    investorType: record.investorType,
+    fundThesis: record.fundThesis,
+    aumRange: record.aumRange,
+    checkSizeRange: record.checkSizeRange,
+
+    stageFocus: record.stageFocus,
+    sectorTags: splitCsv(record.sectorTags),
+    geoFocus: record.geoFocus,
+    recentDeals: splitCsv(record.recentDeals),
+
+    outreachTouches: record.outreachTouches,
+    outreachCampaigns: splitCsv(record.outreachCampaigns),
+    opened: record.opened,
+    clicked: record.clicked,
+    registered: record.registered,
+
+    firstSentDate: dateToYmd(record.firstSentDate),
+    lastSentDate: dateToYmd(record.lastSentDate),
+    engagementTier: record.engagementTier,
+
+    enrichmentStatus: record.enrichmentStatus,
+    enrichmentDate: dateToYmd(record.enrichmentDate),
+    lastEnrichmentAttempt: dateToIso(record.lastEnrichmentAttempt),
+    enrichmentNotes: record.enrichmentNotes,
+
+    tags: record.tags ?? [],
+    labOsProfile: buildLabOsProfile(member),
+    coInvestedTeamIds: teamUids,
+
+    createdAt: dateToIso(record.createdAt) ?? '',
+    updatedAt: dateToIso(record.updatedAt) ?? '',
+  };
+}
+
+type TeamWithMetaAndOverlaps = Team & {
+  logo: Image | null;
+  portfolioMeta: PlPortfolioTeamMeta | null;
+  portfolioOverlaps: Array<InvestorPortfolioOverlap & { investorOutreachRecord: { investorId: string } }>;
+};
+
+const toCoInvestor = (
+  overlap: InvestorPortfolioOverlap & { investorOutreachRecord: { investorId: string } }
+): PlPortfolioTeamCoInvestorDto => ({
+  investorId: overlap.investorOutreachRecord.investorId,
+  dealAmount: overlap.dealAmount == null ? null : Number(overlap.dealAmount),
+  dealDate: dateToYmd(overlap.dealDate),
+});
+
+export function toPlPortfolioTeamDto(team: TeamWithMetaAndOverlaps): PlPortfolioTeamDto {
+  const meta = team.portfolioMeta;
+  return {
+    teamUid: team.uid,
+    teamName: team.name,
+    logoUrl: team.logo?.url ?? null,
+    plInvestedAt: dateToYmd(meta?.plInvestedAt ?? null),
+    plInvestedStage: meta?.plInvestedStage ?? null,
+    raisingNow: meta?.raisingNow ?? null,
+    sectors: splitCsv(meta?.sectors ?? null),
+    geo: meta?.geo ?? null,
+    coInvestors: team.portfolioOverlaps.map(toCoInvestor),
+  };
+}

--- a/apps/web-api/src/investor-outreach/investor-outreach.module.ts
+++ b/apps/web-api/src/investor-outreach/investor-outreach.module.ts
@@ -1,12 +1,16 @@
 import { Module } from '@nestjs/common';
 import { InvestorOutreachService } from './investor-outreach.service';
 import { InvestorOutreachServiceController } from './investor-outreach-service.controller';
+import { InvestorOutreachController } from './investor-outreach.controller';
+import { InvestorOutreachQueryService } from './investor-outreach-query.service';
 import { SharedModule } from '../shared/shared.module';
+import { RbacModule } from '../rbac/rbac.module';
+import { AccessControlV2Module } from '../access-control-v2/access-control-v2.module';
 
 @Module({
-  imports: [SharedModule],
-  controllers: [InvestorOutreachServiceController],
-  providers: [InvestorOutreachService],
+  imports: [SharedModule, RbacModule, AccessControlV2Module],
+  controllers: [InvestorOutreachServiceController, InvestorOutreachController],
+  providers: [InvestorOutreachService, InvestorOutreachQueryService],
   exports: [InvestorOutreachService],
 })
 export class InvestorOutreachModule {}

--- a/apps/web-api/src/investor-outreach/investor-outreach.service.spec.ts
+++ b/apps/web-api/src/investor-outreach/investor-outreach.service.spec.ts
@@ -36,18 +36,35 @@ describe('InvestorOutreachService', () => {
   let service: InvestorOutreachService;
   const findUnique = jest.fn();
   const upsert = jest.fn();
+  const teamFindMany = jest.fn();
+  const teamFindUnique = jest.fn();
+  const overlapUpsert = jest.fn();
+  const overlapDeleteMany = jest.fn();
+  const teamMetaUpsert = jest.fn();
 
   const prismaMock = {
     investorOutreachRecord: {
       findUnique,
       upsert,
     },
+    team: {
+      findMany: teamFindMany,
+      findUnique: teamFindUnique,
+    },
+    investorPortfolioOverlap: {
+      upsert: overlapUpsert,
+      deleteMany: overlapDeleteMany,
+    },
+    plPortfolioTeamMeta: {
+      upsert: teamMetaUpsert,
+    },
   } as unknown as PrismaService;
 
   beforeEach(() => {
     jest.clearAllMocks();
     service = new InvestorOutreachService(prismaMock);
-    upsert.mockResolvedValue({});
+    upsert.mockResolvedValue({ id: 42 });
+    overlapDeleteMany.mockResolvedValue({ count: 0 });
   });
 
   it('creates when no existing rows', async () => {
@@ -149,5 +166,178 @@ describe('InvestorOutreachService', () => {
     expect(res.created).toBe(1);
     expect(res.failed).toBe(1);
     expect(upsert).toHaveBeenCalledTimes(1);
+  });
+
+  describe('Phase 2 — tags', () => {
+    beforeEach(() => {
+      findUnique.mockResolvedValue(null);
+    });
+
+    it('omits tags from upsert input when the field is absent (protects user-applied tags)', async () => {
+      await service.ingest({ items: [minimalItem()] });
+      const args = upsert.mock.calls[0][0];
+      expect(args.create).not.toHaveProperty('tags');
+      expect(args.update).not.toHaveProperty('tags');
+    });
+
+    it('includes tags in upsert input when supplied', async () => {
+      await service.ingest({ items: [minimalItem({ tags: ['fund-of-interest', 'q3-target'] })] });
+      const args = upsert.mock.calls[0][0];
+      expect(args.create.tags).toEqual(['fund-of-interest', 'q3-target']);
+      expect(args.update.tags).toEqual(['fund-of-interest', 'q3-target']);
+    });
+
+    it('explicit empty tags array overwrites the column', async () => {
+      await service.ingest({ items: [minimalItem({ tags: [] })] });
+      const args = upsert.mock.calls[0][0];
+      expect(args.create.tags).toEqual([]);
+      expect(args.update.tags).toEqual([]);
+    });
+  });
+
+  describe('Phase 2 — portfolio_overlaps sync', () => {
+    beforeEach(() => {
+      findUnique.mockResolvedValue(null);
+      overlapUpsert.mockResolvedValue({});
+    });
+
+    it('skips overlap touchpoints entirely when portfolio_overlaps is absent', async () => {
+      await service.ingest({ items: [minimalItem()] });
+      expect(overlapUpsert).not.toHaveBeenCalled();
+      expect(overlapDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it('upserts each provided overlap and deletes rows outside the provided set', async () => {
+      teamFindMany.mockResolvedValue([{ uid: 'team-a' }, { uid: 'team-b' }]);
+      overlapDeleteMany.mockResolvedValue({ count: 3 });
+
+      const res = await service.ingest({
+        items: [
+          minimalItem({
+            portfolio_overlaps: [
+              { team_uid: 'team-a', deal_amount: 250000, deal_date: '2025-06-01', is_lead_investor: true },
+              { team_uid: 'team-b', attribution_fund: 'PLVS' },
+            ],
+          }),
+        ],
+      });
+
+      expect(overlapUpsert).toHaveBeenCalledTimes(2);
+      expect(overlapDeleteMany).toHaveBeenCalledWith({
+        where: { investorOutreachRecordId: 42, teamUid: { notIn: ['team-a', 'team-b'] } },
+      });
+      expect(res.overlaps_synced).toBe(5); // 2 upserts + 3 deletes
+      expect(res.failed).toBe(0);
+    });
+
+    it('empty portfolio_overlaps wipes all existing rows for the investor', async () => {
+      overlapDeleteMany.mockResolvedValue({ count: 4 });
+
+      const res = await service.ingest({
+        items: [minimalItem({ portfolio_overlaps: [] })],
+      });
+
+      expect(overlapUpsert).not.toHaveBeenCalled();
+      expect(overlapDeleteMany).toHaveBeenCalledWith({ where: { investorOutreachRecordId: 42 } });
+      expect(res.overlaps_synced).toBe(4);
+    });
+
+    it('records an error for unknown team_uid but continues with the rest', async () => {
+      teamFindMany.mockResolvedValue([{ uid: 'team-real' }]);
+
+      const res = await service.ingest({
+        items: [
+          minimalItem({
+            portfolio_overlaps: [
+              { team_uid: 'team-real' },
+              { team_uid: 'team-missing' },
+            ],
+          }),
+        ],
+      });
+
+      expect(overlapUpsert).toHaveBeenCalledTimes(1);
+      expect(overlapUpsert.mock.calls[0][0].create.teamUid).toBe('team-real');
+      expect(res.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('team-missing')])
+      );
+      expect(res.failed).toBe(0); // overlap errors don't fail the row
+    });
+
+    it('rejects invalid attribution_fund and skips that entry', async () => {
+      teamFindMany.mockResolvedValue([{ uid: 'team-a' }]);
+
+      const res = await service.ingest({
+        items: [
+          minimalItem({
+            portfolio_overlaps: [{ team_uid: 'team-a', attribution_fund: 'BadFund' }],
+          }),
+        ],
+      });
+
+      expect(overlapUpsert).not.toHaveBeenCalled();
+      expect(res.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('attribution_fund invalid')])
+      );
+    });
+  });
+
+  describe('Phase 2 — top-level portfolio_teams', () => {
+    beforeEach(() => {
+      findUnique.mockResolvedValue(null);
+    });
+
+    it('upserts known portfolio_teams entries', async () => {
+      teamFindUnique.mockResolvedValue({ uid: 'team-a' });
+
+      const res = await service.ingest({
+        items: [minimalItem()],
+        portfolio_teams: [
+          {
+            team_uid: 'team-a',
+            pl_invested_at: '2024-12-01',
+            pl_invested_stage: 'seed',
+            raising_now: 'series-a',
+            sectors: 'ai,crypto',
+            geo: 'US',
+          },
+        ],
+      });
+
+      expect(teamMetaUpsert).toHaveBeenCalledTimes(1);
+      const args = teamMetaUpsert.mock.calls[0][0];
+      expect(args.where).toEqual({ teamUid: 'team-a' });
+      expect(args.create.plInvestedStage).toBe('seed');
+      expect(args.create.raisingNow).toBe('series-a');
+      expect(args.create.sectors).toBe('ai,crypto');
+      expect(res.portfolio_teams_upserted).toBe(1);
+    });
+
+    it('records an error for unknown team_uid without aborting the batch', async () => {
+      teamFindUnique.mockResolvedValue(null);
+
+      const res = await service.ingest({
+        items: [minimalItem()],
+        portfolio_teams: [{ team_uid: 'team-missing' }],
+      });
+
+      expect(teamMetaUpsert).not.toHaveBeenCalled();
+      expect(res.portfolio_teams_upserted).toBe(0);
+      expect(res.errors).toEqual(expect.arrayContaining([expect.stringContaining('team-missing')]));
+    });
+
+    it('rejects invalid pl_invested_stage via vocab check', async () => {
+      teamFindUnique.mockResolvedValue({ uid: 'team-a' });
+
+      const res = await service.ingest({
+        items: [minimalItem()],
+        portfolio_teams: [{ team_uid: 'team-a', pl_invested_stage: 'not-a-stage' }],
+      });
+
+      expect(teamMetaUpsert).not.toHaveBeenCalled();
+      expect(res.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('pl_invested_stage invalid')])
+      );
+    });
   });
 });

--- a/apps/web-api/src/investor-outreach/investor-outreach.service.ts
+++ b/apps/web-api/src/investor-outreach/investor-outreach.service.ts
@@ -3,10 +3,13 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
 import {
   InvestorOutreachIngestItem,
+  InvestorOutreachPortfolioOverlapInput,
+  InvestorOutreachPortfolioTeamInput,
   IngestInvestorOutreachDto,
   IngestInvestorOutreachResponse,
 } from './dto/ingest-investor-outreach.dto';
 import {
+  isAllowedAttributionFund,
   isAllowedAumRange,
   isAllowedCheckSizeRange,
   isAllowedEmailStatus,
@@ -58,6 +61,8 @@ export class InvestorOutreachService {
       created: 0,
       updated: 0,
       failed: 0,
+      overlaps_synced: 0,
+      portfolio_teams_upserted: 0,
       errors: [],
     };
 
@@ -88,7 +93,7 @@ export class InvestorOutreachService {
 
         const wasCreate = !byDedupe;
 
-        await this.prisma.investorOutreachRecord.upsert({
+        const upserted = await this.prisma.investorOutreachRecord.upsert({
           where: { dedupeKey: data.dedupeKey },
           create: data,
           update: this.stripKeysForUpdate(data),
@@ -97,6 +102,17 @@ export class InvestorOutreachService {
         result.ingested++;
         if (wasCreate) result.created++;
         else result.updated++;
+
+        if (item.portfolio_overlaps !== undefined) {
+          const recordId = upserted?.id ?? byDedupe?.id ?? byInvestor?.id;
+          if (recordId === undefined) {
+            result.errors?.push(`Item ${i}: could not resolve record id for overlap sync`);
+          } else {
+            const sync = await this.syncOverlapsForRecord(recordId, item.portfolio_overlaps, i);
+            for (const err of sync.errors) result.errors?.push(err);
+            result.overlaps_synced = (result.overlaps_synced ?? 0) + sync.synced;
+          }
+        }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         result.failed++;
@@ -105,9 +121,30 @@ export class InvestorOutreachService {
       }
     }
 
+    if (dto.portfolio_teams && dto.portfolio_teams.length) {
+      let upserted = 0;
+      for (let i = 0; i < dto.portfolio_teams.length; i++) {
+        const entry = dto.portfolio_teams[i];
+        try {
+          const ok = await this.upsertPortfolioTeam(entry);
+          if (ok) {
+            upserted++;
+          } else {
+            result.errors?.push(`portfolio_teams[${i}] team_uid=${entry.team_uid}: team not found`);
+          }
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          result.errors?.push(`portfolio_teams[${i}] team_uid=${entry.team_uid}: ${msg}`);
+        }
+      }
+      result.portfolio_teams_upserted = upserted;
+    }
+
     this.logger.log(
       `Investor outreach ingest done (runId=${dto.runId ?? 'none'}, batchSource=${dto.source ?? 'none'}): ` +
-        `received=${result.received} ingested=${result.ingested} created=${result.created} updated=${result.updated} failed=${result.failed}`
+        `received=${result.received} ingested=${result.ingested} created=${result.created} updated=${result.updated} ` +
+        `failed=${result.failed} overlaps_synced=${result.overlaps_synced ?? 0} ` +
+        `portfolio_teams_upserted=${result.portfolio_teams_upserted ?? 0}`
     );
 
     return result;
@@ -118,7 +155,170 @@ export class InvestorOutreachService {
     return rest;
   }
 
-  /** Build prisma input; validates vocab + lengths; throws on invalid row. */
+  /**
+   * Sync overlap rows for a single investor. Semantics:
+   *  - Each provided entry is upserted on the (investorOutreachRecordId, teamUid) unique key.
+   *  - Rows whose teamUid is NOT in the provided set are deleted (so an empty array wipes the investor's overlaps).
+   *  - Entries with unknown team_uid or invalid attribution_fund go into errors[] and are skipped (the rest still sync).
+   */
+  private async syncOverlapsForRecord(
+    recordId: number,
+    overlaps: InvestorOutreachPortfolioOverlapInput[],
+    itemIndex: number
+  ): Promise<{ synced: number; errors: string[] }> {
+    const errors: string[] = [];
+    let synced = 0;
+
+    const providedTeamUids = Array.from(new Set(overlaps.map((o) => o.team_uid.trim()).filter(Boolean)));
+
+    const knownTeamUids = providedTeamUids.length
+      ? new Set(
+          (
+            await this.prisma.team.findMany({
+              where: { uid: { in: providedTeamUids } },
+              select: { uid: true },
+            })
+          ).map((t) => t.uid)
+        )
+      : new Set<string>();
+
+    for (let j = 0; j < overlaps.length; j++) {
+      const o = overlaps[j];
+      const teamUid = o.team_uid.trim();
+      if (!knownTeamUids.has(teamUid)) {
+        errors.push(`Item ${itemIndex}: portfolio_overlaps[${j}] team_uid=${teamUid} not found`);
+        continue;
+      }
+
+      const attributionFund =
+        o.attribution_fund == null || o.attribution_fund.trim() === '' ? null : o.attribution_fund.trim();
+      if (attributionFund !== null && !isAllowedAttributionFund(attributionFund)) {
+        errors.push(
+          `Item ${itemIndex}: portfolio_overlaps[${j}].attribution_fund invalid: ${attributionFund}`
+        );
+        continue;
+      }
+
+      let dealDate: Date | undefined;
+      try {
+        dealDate = parseIsoDateOnly(o.deal_date, `portfolio_overlaps[${j}].deal_date`);
+      } catch (e) {
+        errors.push(`Item ${itemIndex}: ${(e as Error).message}`);
+        continue;
+      }
+
+      const dealStage = o.deal_stage == null || o.deal_stage.trim() === '' ? null : o.deal_stage.trim();
+      const dealAmount = o.deal_amount;
+      if (dealAmount !== undefined && dealAmount !== null) {
+        if (typeof dealAmount !== 'number' || !Number.isFinite(dealAmount) || dealAmount < 0) {
+          errors.push(`Item ${itemIndex}: portfolio_overlaps[${j}].deal_amount must be a non-negative number`);
+          continue;
+        }
+      }
+
+      await this.prisma.investorPortfolioOverlap.upsert({
+        where: { investorOutreachRecordId_teamUid: { investorOutreachRecordId: recordId, teamUid } },
+        create: {
+          investorOutreachRecordId: recordId,
+          teamUid,
+          dealAmount: dealAmount ?? null,
+          dealDate: dealDate ?? null,
+          dealStage,
+          isLeadInvestor: o.is_lead_investor ?? false,
+          attributionFund,
+        },
+        update: {
+          dealAmount: dealAmount ?? null,
+          dealDate: dealDate ?? null,
+          dealStage,
+          isLeadInvestor: o.is_lead_investor ?? false,
+          attributionFund,
+        },
+      });
+      synced++;
+    }
+
+    // Empty array → wipe all overlaps for this investor. Otherwise delete only rows outside the provided set.
+    if (providedTeamUids.length === 0) {
+      const deleted = await this.prisma.investorPortfolioOverlap.deleteMany({
+        where: { investorOutreachRecordId: recordId },
+      });
+      synced += deleted.count;
+    } else {
+      const deleted = await this.prisma.investorPortfolioOverlap.deleteMany({
+        where: {
+          investorOutreachRecordId: recordId,
+          teamUid: { notIn: providedTeamUids },
+        },
+      });
+      synced += deleted.count;
+    }
+
+    return { synced, errors };
+  }
+
+  /** Returns true if the team was found and the meta row was upserted; false if team_uid is unknown. */
+  private async upsertPortfolioTeam(entry: InvestorOutreachPortfolioTeamInput): Promise<boolean> {
+    const teamUid = entry.team_uid.trim();
+    const team = await this.prisma.team.findUnique({ where: { uid: teamUid }, select: { uid: true } });
+    if (!team) return false;
+
+    const plInvestedAt = parseIsoDateOnly(entry.pl_invested_at, 'pl_invested_at');
+
+    const stage = entry.pl_invested_stage == null || entry.pl_invested_stage.trim() === ''
+      ? null
+      : entry.pl_invested_stage.trim();
+    if (stage !== null && !isAllowedStageFocus(stage)) {
+      throw new Error(`pl_invested_stage invalid: ${stage}`);
+    }
+
+    const raisingNow = entry.raising_now == null || entry.raising_now.trim() === ''
+      ? null
+      : entry.raising_now.trim();
+    if (raisingNow !== null && !isAllowedStageFocus(raisingNow)) {
+      throw new Error(`raising_now invalid: ${raisingNow}`);
+    }
+
+    let sectors: string | null = null;
+    if (entry.sectors != null && entry.sectors.trim() !== '') {
+      const parsed = parseSectorTagsList(entry.sectors);
+      if (!parsed.ok) throw new Error(parsed.reason);
+      sectors = parsed.value || null;
+    }
+
+    const geo = entry.geo == null || entry.geo.trim() === '' ? null : entry.geo.trim();
+    if (geo !== null && geo.length > 120) {
+      throw new Error('geo exceeds 120 characters');
+    }
+
+    await this.prisma.plPortfolioTeamMeta.upsert({
+      where: { teamUid },
+      create: {
+        teamUid,
+        plInvestedAt: plInvestedAt ?? null,
+        plInvestedStage: stage,
+        raisingNow,
+        sectors,
+        geo,
+      },
+      update: {
+        plInvestedAt: plInvestedAt ?? null,
+        plInvestedStage: stage,
+        raisingNow,
+        sectors,
+        geo,
+      },
+    });
+    return true;
+  }
+
+  /**
+   * Build prisma input; validates vocab + lengths; throws on invalid row.
+   *
+   * Tag-skip rule: if `item.tags` is undefined, omit `tags` from the input so the existing column
+   * value is preserved on update (and the schema default `[]` is used on create). Supplying an
+   * empty array `[]` explicitly overwrites the column to empty.
+   */
   buildRecordInput(item: InvestorOutreachIngestItem): Prisma.InvestorOutreachRecordUncheckedCreateInput {
     const investorId = item.investor_id.trim();
     const dedupeKey = item.dedupe_key.trim().toLowerCase();
@@ -175,7 +375,7 @@ export class InvestorOutreachService {
     const firmDomain =
       item.firm_domain == null || item.firm_domain.trim() === '' ? undefined : item.firm_domain.trim().toLowerCase();
 
-    return {
+    const input: Prisma.InvestorOutreachRecordUncheckedCreateInput = {
       investorId,
       canonicalId: emptyToUndefined(item.canonical_id?.trim()),
       dedupeKey,
@@ -210,6 +410,15 @@ export class InvestorOutreachService {
       enrichmentNotes,
       rawPayload: item as unknown as Prisma.InputJsonValue,
     };
+
+    if (item.tags !== undefined) {
+      if (!Array.isArray(item.tags)) {
+        throw new Error('tags must be an array of strings');
+      }
+      input.tags = item.tags.map((t) => String(t));
+    }
+
+    return input;
   }
 }
 

--- a/apps/web-api/src/investor-outreach/investor-outreach.vocab.ts
+++ b/apps/web-api/src/investor-outreach/investor-outreach.vocab.ts
@@ -47,6 +47,8 @@ export const INVESTOR_OUTREACH_ENRICHMENT_STATUS = [
   'skipped',
 ] as const;
 
+export const INVESTOR_OUTREACH_ATTRIBUTION_FUNDS = ['PL Capital', 'PLVS'] as const;
+
 export const INVESTOR_OUTREACH_SECTOR_TAGS = [
   'ai',
   'crypto',
@@ -78,6 +80,7 @@ const STAGE_SET = toStringSet(INVESTOR_OUTREACH_STAGE_FOCUS);
 const ENGAGEMENT_SET = toStringSet(INVESTOR_OUTREACH_ENGAGEMENT_TIER);
 const ENRICHMENT_SET = toStringSet(INVESTOR_OUTREACH_ENRICHMENT_STATUS);
 const SECTOR_TAG_SET = toStringSet(INVESTOR_OUTREACH_SECTOR_TAGS);
+const ATTRIBUTION_FUND_SET = toStringSet(INVESTOR_OUTREACH_ATTRIBUTION_FUNDS);
 
 export function isAllowedInvestorSource(v: string): boolean {
   return SOURCE_SET.has(v);
@@ -109,6 +112,10 @@ export function isAllowedEngagementTier(v: string): boolean {
 
 export function isAllowedEnrichmentStatus(v: string): boolean {
   return ENRICHMENT_SET.has(v);
+}
+
+export function isAllowedAttributionFund(v: string): boolean {
+  return ATTRIBUTION_FUND_SET.has(v);
 }
 
 export function parseSectorTagsList(

--- a/apps/web-api/src/investor-outreach/warm-intros.scorer.spec.ts
+++ b/apps/web-api/src/investor-outreach/warm-intros.scorer.spec.ts
@@ -1,0 +1,212 @@
+import { InvestorDto } from './dto/investor.dto';
+import { scoreCandidate } from './warm-intros.scorer';
+
+function investor(overrides: Partial<InvestorDto> = {}): InvestorDto {
+  return {
+    investorId: 'INV-1',
+    canonicalId: null,
+    dedupeKey: 'a@b.com',
+    source: 'Manual',
+    firstName: 'A',
+    lastName: 'B',
+    email: 'a@b.com',
+    emailStatus: 'unknown',
+    linkedinUrl: null,
+    firm: null,
+    firmDomain: null,
+    title: null,
+    investorType: 'fund',
+    fundThesis: null,
+    aumRange: null,
+    checkSizeRange: null,
+    stageFocus: 'seed',
+    sectorTags: [],
+    geoFocus: null,
+    recentDeals: [],
+    outreachTouches: 0,
+    outreachCampaigns: [],
+    opened: 0,
+    clicked: 0,
+    registered: 0,
+    firstSentDate: null,
+    lastSentDate: null,
+    engagementTier: 'T4_cold',
+    enrichmentStatus: 'pending',
+    enrichmentDate: null,
+    lastEnrichmentAttempt: null,
+    enrichmentNotes: null,
+    tags: [],
+    labOsProfile: null,
+    coInvestedTeamIds: [],
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+
+const emptyMap = new Map<string, string>();
+
+describe('scoreCandidate', () => {
+  it('co_invested with same team scores 50 + sector + stage + email', () => {
+    const out = scoreCandidate({
+      investor: investor({
+        coInvestedTeamIds: ['team-a'],
+        sectorTags: ['ai', 'crypto'],
+        stageFocus: 'seed',
+        emailStatus: 'verified',
+      }),
+      targetTeamUid: 'team-a',
+      targetTeamName: 'Apex',
+      targetSectors: ['ai', 'crypto'],
+      targetStage: 'seed',
+      portfolioTeamsByUid: new Map([['team-a', 'Apex']]),
+    });
+    // 50 (same team) + 20 (2 sector matches) + 10 (stage) + 5 (verified) = 85
+    expect(out.tier).toBe('co_invested');
+    expect(out.score).toBe(85);
+    expect(out.reason).toBe('Co-invested on Apex');
+    expect(out.evidence).toContain('Same team: Apex');
+    expect(out.evidence).toContain('Sector match: ai, crypto');
+  });
+
+  it('co_invested with different team scores 35 and lists "+N more"', () => {
+    const out = scoreCandidate({
+      investor: investor({ coInvestedTeamIds: ['team-x', 'team-y', 'team-z'] }),
+      targetTeamUid: 'team-a',
+      targetSectors: [],
+      portfolioTeamsByUid: new Map([['team-x', 'Lattice Labs']]),
+    });
+    expect(out.tier).toBe('co_invested');
+    expect(out.score).toBe(35);
+    expect(out.reason).toBe('Co-invested on Lattice Labs');
+    expect(out.evidence).toContain('+ 2 more');
+  });
+
+  it('falls back to "PL portfolio team" when first uid has no name in map', () => {
+    const out = scoreCandidate({
+      investor: investor({ coInvestedTeamIds: ['team-unknown'] }),
+      targetSectors: [],
+      portfolioTeamsByUid: emptyMap,
+    });
+    expect(out.reason).toBe('Co-invested on PL portfolio team');
+  });
+
+  it('T1 registered scores 30, tier engaged', () => {
+    const out = scoreCandidate({
+      investor: investor({ engagementTier: 'T1_registered' }),
+      targetSectors: [],
+      portfolioTeamsByUid: emptyMap,
+    });
+    expect(out.tier).toBe('engaged');
+    expect(out.score).toBe(30);
+    expect(out.reason).toBe('Registered for last Demo Day');
+    expect(out.evidence).toContain('T1 registered');
+  });
+
+  it('T2 clicked scores 22, tier engaged', () => {
+    const out = scoreCandidate({
+      investor: investor({ engagementTier: 'T2_clicked' }),
+      targetSectors: [],
+      portfolioTeamsByUid: emptyMap,
+    });
+    expect(out.tier).toBe('engaged');
+    expect(out.score).toBe(22);
+    expect(out.reason).toBe('Clicked recent outreach');
+  });
+
+  it('T3 opened scores 14, tier engaged', () => {
+    const out = scoreCandidate({
+      investor: investor({ engagementTier: 'T3_opened' }),
+      targetSectors: [],
+      portfolioTeamsByUid: emptyMap,
+    });
+    expect(out.tier).toBe('engaged');
+    expect(out.score).toBe(14);
+    expect(out.reason).toBe('Opened recent outreach');
+    expect(out.evidence).toContain('T3 Opened');
+  });
+
+  it('drops cold_match with target sectors and zero overlap', () => {
+    const out = scoreCandidate({
+      investor: investor({ sectorTags: ['fintech'] }),
+      targetSectors: ['ai'],
+      portfolioTeamsByUid: emptyMap,
+    });
+    expect(out.tier).toBe('cold_match');
+    expect(out.score).toBe(0);
+  });
+
+  it('keeps cold_match when no target sectors are specified', () => {
+    const out = scoreCandidate({
+      investor: investor({ stageFocus: 'all', emailStatus: 'verified' }),
+      targetSectors: [],
+      targetStage: 'seed',
+      portfolioTeamsByUid: emptyMap,
+    });
+    // No sector criteria → no zero-out. +10 stage (all matches anything) + +5 email = 15.
+    expect(out.tier).toBe('cold_match');
+    expect(out.score).toBe(15);
+    expect(out.reason).toBe('Stage + sector match · no prior touch');
+  });
+
+  it('stage match awards +10 when investor stage matches target', () => {
+    const out = scoreCandidate({
+      investor: investor({ stageFocus: 'series-a', engagementTier: 'T2_clicked' }),
+      targetSectors: [],
+      targetStage: 'series-a',
+      portfolioTeamsByUid: emptyMap,
+    });
+    expect(out.score).toBe(32); // 22 (T2) + 10 (stage)
+  });
+
+  it('stage match awards +10 when investor is stage-agnostic ("all")', () => {
+    const out = scoreCandidate({
+      investor: investor({ stageFocus: 'all', engagementTier: 'T2_clicked' }),
+      targetSectors: [],
+      targetStage: 'seed',
+      portfolioTeamsByUid: emptyMap,
+    });
+    expect(out.score).toBe(32);
+  });
+
+  it('verified email adds +5', () => {
+    const out = scoreCandidate({
+      investor: investor({ engagementTier: 'T3_opened', emailStatus: 'verified' }),
+      targetSectors: [],
+      portfolioTeamsByUid: emptyMap,
+    });
+    expect(out.score).toBe(19); // 14 (T3) + 5
+  });
+
+  it('caps score at 100', () => {
+    const out = scoreCandidate({
+      investor: investor({
+        coInvestedTeamIds: ['team-a'],
+        sectorTags: ['ai', 'crypto', 'defi', 'infrastructure', 'fintech'],
+        stageFocus: 'seed',
+        emailStatus: 'verified',
+      }),
+      targetTeamUid: 'team-a',
+      targetTeamName: 'Apex',
+      targetSectors: ['ai', 'crypto', 'defi', 'infrastructure', 'fintech'],
+      targetStage: 'seed',
+      portfolioTeamsByUid: new Map([['team-a', 'Apex']]),
+    });
+    // 50 + 50 (5 sectors) + 10 + 5 = 115 → capped at 100
+    expect(out.score).toBe(100);
+  });
+
+  it('warmth signal wins over engagement tier', () => {
+    const out = scoreCandidate({
+      investor: investor({
+        coInvestedTeamIds: ['team-x'],
+        engagementTier: 'T1_registered',
+      }),
+      targetSectors: [],
+      portfolioTeamsByUid: new Map([['team-x', 'Modular Globe']]),
+    });
+    // Co-invested branch fires first; T1 doesn't add anything on top.
+    expect(out.tier).toBe('co_invested');
+    expect(out.score).toBe(35);
+  });
+});

--- a/apps/web-api/src/investor-outreach/warm-intros.scorer.ts
+++ b/apps/web-api/src/investor-outreach/warm-intros.scorer.ts
@@ -1,0 +1,101 @@
+import { InvestorDto } from './dto/investor.dto';
+import { WarmIntroTier } from './dto/warm-intros.dto';
+
+/**
+ * Pure scoring function ported from the frontend mock at
+ * `pln-directory-portal-v2/services/investors/investors.mock.ts:115-178` (the `scoreCandidate` fn).
+ * Backend is the single source of truth — keep this file behaviourally identical to that mock so
+ * the parity tests in `warm-intros.scorer.spec.ts` continue to validate the contract.
+ *
+ * Point table (cap at 100, drops cold rows with zero sector overlap):
+ *   Same-team co-invest                                              +50  (tier=co_invested)
+ *   Any other PL portfolio team co-invest                            +35  (tier=co_invested)
+ *   T1 Registered for last Demo Day                                  +30  (tier=engaged)
+ *   T2 Clicked recent outreach                                       +22  (tier=engaged)
+ *   T3 Opened recent outreach                                        +14  (tier=engaged)
+ *   Each sector overlap (target ∩ investor.sectorTags)               +10 each
+ *   Stage matches target (or investor.stageFocus === 'all')          +10
+ *   Email status === 'verified'                                      +5
+ */
+
+export interface ScoreInputs {
+  investor: InvestorDto;
+  targetTeamUid?: string;
+  targetTeamName?: string;
+  targetSectors: string[];
+  targetStage?: string;
+  /** uid → display name; used to format "Co-invested on <team>" reason text for any-team matches. */
+  portfolioTeamsByUid: Map<string, string>;
+}
+
+export interface ScoreResult {
+  tier: WarmIntroTier;
+  score: number;
+  reason: string;
+  evidence: string[];
+}
+
+export function scoreCandidate(inputs: ScoreInputs): ScoreResult {
+  const { investor, targetTeamUid, targetTeamName, targetSectors, targetStage, portfolioTeamsByUid } = inputs;
+
+  let score = 0;
+  const evidence: string[] = [];
+  let tier: WarmIntroTier = 'cold_match';
+  let reason = '';
+
+  // ---- Warmth signal ----
+  if (targetTeamUid && investor.coInvestedTeamIds.includes(targetTeamUid)) {
+    tier = 'co_invested';
+    score += 50;
+    reason = `Co-invested on ${targetTeamName ?? targetTeamUid}`;
+    evidence.push(`Same team: ${targetTeamName ?? targetTeamUid}`);
+  } else if (investor.coInvestedTeamIds.length > 0) {
+    tier = 'co_invested';
+    score += 35;
+    const firstUid = investor.coInvestedTeamIds[0];
+    const otherName = portfolioTeamsByUid.get(firstUid) ?? 'PL portfolio team';
+    reason = `Co-invested on ${otherName}`;
+    if (investor.coInvestedTeamIds.length > 1) {
+      evidence.push(`+ ${investor.coInvestedTeamIds.length - 1} more`);
+    }
+  } else if (investor.engagementTier === 'T1_registered' || investor.engagementTier === 'T2_clicked') {
+    tier = 'engaged';
+    score += investor.engagementTier === 'T1_registered' ? 30 : 22;
+    reason = investor.engagementTier === 'T1_registered' ? 'Registered for last Demo Day' : 'Clicked recent outreach';
+    evidence.push(investor.engagementTier.replace('_', ' '));
+  } else if (investor.engagementTier === 'T3_opened') {
+    tier = 'engaged';
+    score += 14;
+    reason = 'Opened recent outreach';
+    evidence.push('T3 Opened');
+  } else {
+    tier = 'cold_match';
+    reason = 'Stage + sector match · no prior touch';
+  }
+
+  // ---- Sector match ----
+  if (targetSectors.length > 0) {
+    const overlap = investor.sectorTags.filter((s) => targetSectors.includes(s));
+    if (overlap.length > 0) {
+      score += 10 * overlap.length;
+      evidence.push(`Sector match: ${overlap.join(', ')}`);
+    } else if (tier === 'cold_match') {
+      // No sector overlap and no warm path: drop from results
+      score = 0;
+    }
+  }
+
+  // ---- Stage match ----
+  if (targetStage && (investor.stageFocus === targetStage || investor.stageFocus === 'all')) {
+    score += 10;
+  }
+
+  // ---- Email deliverability bonus ----
+  if (investor.emailStatus === 'verified') {
+    score += 5;
+  }
+
+  if (score > 100) score = 100;
+
+  return { tier, score, reason, evidence };
+}


### PR DESCRIPTION
## Investor DB — backend read endpoints

  Backend for the Investor DB module. Four read endpoints under `/v1/investor-outreach/` that map 1:1 to the calls in
  `services/investors/investors.service.ts`. Frontend can drop the mock.

  ### Endpoints

  All four are gated by `UserTokenCheckGuard + RbacGuard` and require `investor_db.view` (or `directory.admin.full`). 401 when the bearer
   token is invalid, 403 when the user lacks the permission.

  | Method | Path | Notes |
  |---|---|---|
  | `GET` | `/v1/investor-outreach/investors` | Paginated list |
  | `GET` | `/v1/investor-outreach/investors/:id` | `:id` is the business id (`INV-000001`), not the int PK |
  | `GET` | `/v1/investor-outreach/co-investors/by-team` | PL portfolio teams + their cap-table edges |
  | `GET` | `/v1/investor-outreach/warm-intros` | Tiered, scored candidates |

  ### List filters (`GET /investors`)

  All query params are optional. Multi-value filters are CSV strings (e.g. `source=W26,OpenVC`); booleans as `true` / `false`.

  `q`, `source`, `investorType`, `stageFocus`, `sectorTags`, `geoFocus`, `emailStatus`, `engagementTier`, `enrichmentStatus`, `inLabOs`,
  `isCoInvestor`, `coInvestedTeamId`, `tags`, `sort` (`field:asc|desc`), `page`, `limit`.

  Sort whitelist: `engagementTier`, `lastSentDate`, `lastName`, `firm`, `createdAt`, `enrichmentDate`. Default sort: `engagementTier ASC,
   lastSentDate DESC`. Max `limit` is 200; default 50.

  Response envelope:

  ```json
  { "page": 1, "limit": 50, "total": 1234, "items": [InvestorDto, ...] }

  Warm-intros (GET /warm-intros)

  Optional params: teamId, stageFocus, sectorTags (CSV), checkSizeRange, geoFocus. When teamId is set, stage and sectors are auto-filled
  from the team's metadata; explicit params override. Scoring is the same point table as the mock at investors.mock.ts:115-178 —
  parity-tested.

  Response:

  {
    "team": PlPortfolioTeamDto | null,
    "total": 12,
    "candidates": [
      {
        "investor": InvestorDto,
        "tier": "co_invested" | "engaged" | "cold_match",
        "reason": "Co-invested on Modular Globe",
        "fitScore": 75,
        "evidence": ["Same team: Modular Globe", "Sector match: ai"]
      }
    ]
  }

  ⚠️  Wire format — camelCase

  Read endpoints emit camelCase (firstName, engagementTier, labOsProfile, coInvestedTeamIds, …) to match the rest of the v1 user-JWT
  surface.

  The frontend's OutreachInvestor type in services/investors/types.ts is snake_case, so the swap from mock to real backend is two steps,
  not one:

  1. Set NEXT_PUBLIC_INVESTOR_DB_USE_MOCK=0
  2. Add a thin response transformer in services/investors/investors.service.ts to map keys camelCase → snake_case before returning. Hook
   signatures and React Query keys stay the same.

  Notes

  - labOsProfile is only populated when the investor's email matches a Member.email. type is always 'member' in v1 (no Team-as-investor
  fallback yet).
  - coInvestedTeamIds and the Co-investors tab will be empty until the ingest pipeline starts emitting cap-table overlaps. Won't block
  frontend integration on the All Investors tab + drawer.
  - sort=<bad-field> is silently ignored (falls back to default). Worth knowing for debugging.
  - Server-side CSV columns (sectorTags, recentDeals, outreachCampaigns) are split into arrays in the response — frontend gets string[].
  - Dates: YYYY-MM-DD for date-only fields, full ISO datetime for lastEnrichmentAttempt, createdAt, updatedAt, labOsProfile.lastActiveAt.

  Local testing

  Backend on localhost:3000. Need a JWT for a user who has the investor_db.view permission (or any admin policy with
  directory.admin.full). Ping me if you need a token.

  curl -H "Authorization: Bearer $TOKEN" \
    'http://localhost:3000/v1/investor-outreach/investors?engagementTier=T1_registered&sectorTags=ai&limit=10'