### PR TITLE
[Team Enrichment] Admin Review API Update

### DIFF
--- a/apps/back-office/components/menu/components/TeamsMenu/TeamsMenu.tsx
+++ b/apps/back-office/components/menu/components/TeamsMenu/TeamsMenu.tsx
@@ -3,13 +3,11 @@ import Link from 'next/link';
 import { clsx } from 'clsx';
 
 import { useOnClickOutside } from '../../../../hooks/useOnClickOutside';
-import { useAuth } from '../../../../context/auth-context';
 import s from './TeamsMenu.module.scss';
 
 export const TeamsMenu = () => {
   const menuRef = useRef(null);
   const [open, setOpen] = useState(false);
-  const { isDirectoryAdmin } = useAuth();
 
   useOnClickOutside([menuRef], () => setOpen(false));
 
@@ -32,6 +30,7 @@ export const TeamsMenu = () => {
           </a>
         </Link>
 
+        {/* Hidden until Team Data Quality is ready
         {isDirectoryAdmin && (
           <Link href="/teams/data-quality" passHref>
             <a className={s.menuItem}>
@@ -41,6 +40,7 @@ export const TeamsMenu = () => {
             </a>
           </Link>
         )}
+        */}
       </div>
     </div>
   );
@@ -55,14 +55,14 @@ const TeamsIcon = () => (
   </svg>
 );
 
-const DataQualityIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path
-      d="M10 2a8 8 0 100 16A8 8 0 0010 2zm-1.5 10.94L5.56 10l1.06-1.06 1.88 1.87 4.44-4.43 1.06 1.06-5.5 5.5z"
-      fill="#3D4A5C"
-    />
-  </svg>
-);
+// const DataQualityIcon = () => (
+//   <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+//     <path
+//       d="M10 2a8 8 0 100 16A8 8 0 0010 2zm-1.5 10.94L5.56 10l1.06-1.06 1.88 1.87 4.44-4.43 1.06 1.06-5.5 5.5z"
+//       fill="#3D4A5C"
+//     />
+//   </svg>
+// );
 
 const ChevronDownIcon = () => (
   <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/apps/back-office/components/menu/components/TeamsMenu/TeamsMenu.tsx
+++ b/apps/back-office/components/menu/components/TeamsMenu/TeamsMenu.tsx
@@ -3,11 +3,13 @@ import Link from 'next/link';
 import { clsx } from 'clsx';
 
 import { useOnClickOutside } from '../../../../hooks/useOnClickOutside';
+import { useAuth } from '../../../../context/auth-context';
 import s from './TeamsMenu.module.scss';
 
 export const TeamsMenu = () => {
   const menuRef = useRef(null);
   const [open, setOpen] = useState(false);
+  const { isDirectoryAdmin } = useAuth();
 
   useOnClickOutside([menuRef], () => setOpen(false));
 
@@ -30,7 +32,6 @@ export const TeamsMenu = () => {
           </a>
         </Link>
 
-        {/* Hidden until Team Data Quality is ready
         {isDirectoryAdmin && (
           <Link href="/teams/data-quality" passHref>
             <a className={s.menuItem}>
@@ -40,7 +41,6 @@ export const TeamsMenu = () => {
             </a>
           </Link>
         )}
-        */}
       </div>
     </div>
   );
@@ -55,14 +55,14 @@ const TeamsIcon = () => (
   </svg>
 );
 
-// const DataQualityIcon = () => (
-//   <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-//     <path
-//       d="M10 2a8 8 0 100 16A8 8 0 0010 2zm-1.5 10.94L5.56 10l1.06-1.06 1.88 1.87 4.44-4.43 1.06 1.06-5.5 5.5z"
-//       fill="#3D4A5C"
-//     />
-//   </svg>
-// );
+const DataQualityIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M10 2a8 8 0 100 16A8 8 0 0010 2zm-1.5 10.94L5.56 10l1.06-1.06 1.88 1.87 4.44-4.43 1.06 1.06-5.5 5.5z"
+      fill="#3D4A5C"
+    />
+  </svg>
+);
 
 const ChevronDownIcon = () => (
   <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -1209,16 +1209,17 @@ export class TeamEnrichmentService {
    * Full list of teams that still have at least one thing needing admin review.
    *
    * Inclusion criteria — a team is included if EITHER of the following holds:
-   *  - at least one non-logo `fieldsMeta[k].judgment` is not fully approved
-   *    (NOT (`confidence === 'high'` AND `score === 100`)). Admin-approved fields are
-   *    normalized to `{ confidence: high, score: 100 }` and stop triggering inclusion.
+   *  - at least one non-logo `fieldsMeta[k].judgment.score` is below 90. Anything `>= 90`
+   *    is treated as high-confidence (the judge auto-promotes at 90 and admin-approved
+   *    fields land at 100), so it doesn't need review.
    *  - the team has a logo (`row.logoUid` set) whose latest `TeamLogoVerificationResult`
-   *    is not at (`verdict === 'verified'` AND `confidence === 'high'`). Logo has no AI
-   *    judgment on `fieldsMeta` — its verdict lives in the VLM verification table.
+   *    is NOT at (`verdict === 'verified'` AND `confidence === 'high'`). Logo verification
+   *    has no `score` column — the equivalent "high-confidence approved" check uses the
+   *    verdict + confidence pair the VLM writes (and admin approval updates to verified+high).
    *
-   * Note: we deliberately do NOT filter on `dataEnrichment.status`. The judgment + logo
-   * verification state already determines whether anything needs review; a status filter
-   * would silently hide teams if a new status is introduced or one is set by mistake.
+   * Statuses excluded at the query level: `PendingEnrichment`, `InProgress`, `FailedToEnrich`.
+   * The remaining statuses (`Enriched`, `Reviewed`, `Approved`, and any future addition) all
+   * surface here as long as the inclusion check above flags something.
    *
    * Per-field rules in the response:
    *  - fields without a `fieldsMeta[k].judgment` entry are skipped (not review-ready)
@@ -1229,6 +1230,15 @@ export class TeamEnrichmentService {
    */
   async listEnrichmentsForReview(): Promise<{ teams: EnrichmentReviewItem[] }> {
     const rows = await this.prisma.teamEnrichment.findMany({
+      where: {
+        NOT: {
+          OR: [
+            { dataEnrichment: { path: ['status'], equals: EnrichmentStatus.PendingEnrichment } },
+            { dataEnrichment: { path: ['status'], equals: EnrichmentStatus.InProgress } },
+            { dataEnrichment: { path: ['status'], equals: EnrichmentStatus.FailedToEnrich } },
+          ],
+        },
+      },
       select: {
         teamUid: true,
         team: {
@@ -1298,12 +1308,12 @@ export class TeamEnrichmentService {
       const meta = this.parseEnrichmentMeta(row.dataEnrichment);
       if (!meta?.fieldsMeta) continue;
 
-      // A team needs review if any non-logo field isn't fully approved (confidence=high
-      // AND score=100), OR its logo verification isn't (verified, high). The logo doesn't
-      // carry an AI judgment — its verdict comes from TeamLogoVerificationResult.
+      // Score >= 90 is treated as high-confidence and doesn't need review.
+      // Logo has no `score` column on its verification row — the equivalent check is
+      // verdict='verified' AND confidence='high' (what admin-approve writes).
       const hasUnapprovedField = Object.entries(meta.fieldsMeta).some(([k, fm]) => {
         if (k === 'logo' || !fm?.judgment) return false;
-        return !(fm.judgment.confidence === FieldConfidence.High && fm.judgment.score === 100);
+        return (fm.judgment.score ?? 0) < 90;
       });
       const latestLogoVerif = latestByTeam.get(row.teamUid);
       const hasUnapprovedLogo =

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -1206,10 +1206,21 @@ export class TeamEnrichmentService {
   }
 
   /**
-   * Full list of teams whose enrichment is in `EnrichmentStatus.Enriched`. Includes every
-   * judged field regardless of confidence so admins can spot-check what the judge produced.
+   * Full list of teams that still have at least one thing needing admin review.
    *
-   * Per-field rules:
+   * Inclusion criteria — a team is included if EITHER of the following holds:
+   *  - at least one non-logo `fieldsMeta[k].judgment` is not fully approved
+   *    (NOT (`confidence === 'high'` AND `score === 100`)). Admin-approved fields are
+   *    normalized to `{ confidence: high, score: 100 }` and stop triggering inclusion.
+   *  - the team has a logo (`row.logoUid` set) whose latest `TeamLogoVerificationResult`
+   *    is not at (`verdict === 'verified'` AND `confidence === 'high'`). Logo has no AI
+   *    judgment on `fieldsMeta` — its verdict lives in the VLM verification table.
+   *
+   * Note: we deliberately do NOT filter on `dataEnrichment.status`. The judgment + logo
+   * verification state already determines whether anything needs review; a status filter
+   * would silently hide teams if a new status is introduced or one is set by mistake.
+   *
+   * Per-field rules in the response:
    *  - fields without a `fieldsMeta[k].judgment` entry are skipped (not review-ready)
    *  - empty candidate values (null / empty string / empty array) are excluded
    *
@@ -1218,7 +1229,6 @@ export class TeamEnrichmentService {
    */
   async listEnrichmentsForReview(): Promise<{ teams: EnrichmentReviewItem[] }> {
     const rows = await this.prisma.teamEnrichment.findMany({
-      where: { dataEnrichment: { path: ['status'], equals: EnrichmentStatus.Enriched } },
       select: {
         teamUid: true,
         team: {
@@ -1288,6 +1298,18 @@ export class TeamEnrichmentService {
       const meta = this.parseEnrichmentMeta(row.dataEnrichment);
       if (!meta?.fieldsMeta) continue;
 
+      // A team needs review if any non-logo field isn't fully approved (confidence=high
+      // AND score=100), OR its logo verification isn't (verified, high). The logo doesn't
+      // carry an AI judgment — its verdict comes from TeamLogoVerificationResult.
+      const hasUnapprovedField = Object.entries(meta.fieldsMeta).some(([k, fm]) => {
+        if (k === 'logo' || !fm?.judgment) return false;
+        return !(fm.judgment.confidence === FieldConfidence.High && fm.judgment.score === 100);
+      });
+      const latestLogoVerif = latestByTeam.get(row.teamUid);
+      const hasUnapprovedLogo =
+        !!row.logoUid && !(latestLogoVerif?.verdict === 'verified' && latestLogoVerif?.confidence === 'high');
+      if (!hasUnapprovedField && !hasUnapprovedLogo) continue;
+
       const fields: EnrichmentReviewItem['fields'] = {};
       for (const [keyStr, fieldMeta] of Object.entries(meta.fieldsMeta) as Array<
         [FieldMetaKey, FieldEnrichmentMeta | undefined]
@@ -1346,7 +1368,6 @@ export class TeamEnrichmentService {
 
       let logo: EnrichmentReviewLogo | undefined;
       const logoMeta = meta.fieldsMeta.logo;
-      const latestLogoVerif = latestByTeam.get(row.teamUid);
       if (row.logoUid) {
         logo = {
           content: row.logo ? { uid: row.logo.uid, url: row.logo.url } : null,
@@ -1656,7 +1677,7 @@ export class TeamEnrichmentService {
       ...meta,
       fieldsMeta: newFieldsMeta,
       judgment: updatedTeamJudgment,
-      status: EnrichmentStatus.Approved,
+      status: EnrichmentStatus.Reviewed,
       reviewedAt: now,
       reviewedBy: reviewerEmail,
     };

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -426,10 +426,10 @@ Guard: AdminAuthGuard
 Full list of teams that still have **at least one thing needing admin review**. Sorted by `team.name` ASC. No pagination — the portal carries ~1K teams and the back-office UI consumes the full set at once.
 
 Inclusion criteria — a team is included if EITHER:
-- At least one non-logo `fieldsMeta[k].judgment` is NOT fully approved — i.e. NOT (`confidence === 'high'` AND `score === 100`). Admin-approved fields are normalized to `{ confidence: high, score: 100 }` and stop triggering inclusion.
-- The team has a logo (`TeamEnrichment.logoUid` set) whose latest `TeamLogoVerificationResult` is NOT at (`verdict === 'verified'` AND `confidence === 'high'`). Logo carries no AI judgment on `fieldsMeta`; its verdict lives in the VLM verification table. Admin-approving a logo updates the latest row to `{ verdict: 'verified', confidence: 'high' }`, which drops it from this filter.
+- At least one non-logo `fieldsMeta[k].judgment.score` is below 90. Anything `>= 90` is treated as high-confidence and is excluded — the judge auto-promotes at score 90 and admin approval normalizes to score 100, so this threshold covers both. Fields without a judgment entry yet are ignored (they're not review-ready).
+- The team has a logo (`TeamEnrichment.logoUid` set) whose latest `TeamLogoVerificationResult` is NOT at (`verdict === 'verified'` AND `confidence === 'high'`). Logo verification has no `score` column, so the high-confidence check uses the verdict + confidence pair (which admin approval updates to verified+high).
 
-The endpoint deliberately does **not** filter on `dataEnrichment.status`. The judgment + logo verification state already determines whether anything needs review, and a status filter would silently hide teams if a new status is introduced or one is set by mistake.
+The endpoint excludes `PendingEnrichment`, `InProgress`, and `FailedToEnrich` at the query level — those teams have nothing review-ready. Remaining statuses (`Enriched`, `Reviewed`, `Approved`, and any future addition) all surface as long as the inclusion check flags something.
 
 Per-field rules in the response:
 - Every field that has a `fieldsMeta[k].judgment` entry is surfaced, including those at `agrees + high + 100` (so admins can see the full picture of what already passed).

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -423,10 +423,16 @@ GET /v1/admin/teams/enrichment-review
 Guard: AdminAuthGuard
 ```
 
-Full list of teams whose top-level `dataEnrichment.status === 'Enriched'`. Reviewed / Approved / PendingEnrichment / InProgress / FailedToEnrich are out of scope. Sorted by `team.name` ASC. No pagination — the portal carries ~1K teams and the back-office UI consumes the full set at once.
+Full list of teams that still have **at least one thing needing admin review**. Sorted by `team.name` ASC. No pagination — the portal carries ~1K teams and the back-office UI consumes the full set at once.
 
-Per-field rules:
-- Every field that has a `fieldsMeta[k].judgment` entry is surfaced, including those at `agrees + high`. Admins use this view to spot-check the AI's output before approving.
+Inclusion criteria — a team is included if EITHER:
+- At least one non-logo `fieldsMeta[k].judgment` is NOT fully approved — i.e. NOT (`confidence === 'high'` AND `score === 100`). Admin-approved fields are normalized to `{ confidence: high, score: 100 }` and stop triggering inclusion.
+- The team has a logo (`TeamEnrichment.logoUid` set) whose latest `TeamLogoVerificationResult` is NOT at (`verdict === 'verified'` AND `confidence === 'high'`). Logo carries no AI judgment on `fieldsMeta`; its verdict lives in the VLM verification table. Admin-approving a logo updates the latest row to `{ verdict: 'verified', confidence: 'high' }`, which drops it from this filter.
+
+The endpoint deliberately does **not** filter on `dataEnrichment.status`. The judgment + logo verification state already determines whether anything needs review, and a status filter would silently hide teams if a new status is introduced or one is set by mistake.
+
+Per-field rules in the response:
+- Every field that has a `fieldsMeta[k].judgment` entry is surfaced, including those at `agrees + high + 100` (so admins can see the full picture of what already passed).
 - `content` source is decided by `fieldsMeta[k].status`:
   - `ChangedByUser` → reads from `Team.<field>` (user's value is the source of truth; the `TeamEnrichment.<field>` candidate, if any, is informational provenance).
   - `Enriched` / `CannotEnrich` → reads from `TeamEnrichment.<field>` (AI candidate not yet promoted).
@@ -490,7 +496,7 @@ What happens in one `prisma.$transaction`:
 1. **Team writes** per the per-field resolution above. For `ChangedByUser` + confirm-only entries, no Team write is issued (the value is already there); only `fieldsMeta` is normalized.
 2. **`fieldsMeta` normalization** for every approved key — `status` + `judgment` updated per the rules above, `lastModifiedAt` restamped.
 3. **Team-level metadata**:
-   - `dataEnrichment.status` → `Approved`.
+   - `dataEnrichment.status` → `Reviewed`. The flip happens whether the admin approved every flagged field or only a subset — partial reviews stay in `Reviewed` and the team remains in the list endpoint until all flagged fields land at `score=100, confidence=high`. `Approved` is reserved for an explicit team-level finalization (not exposed through this endpoint).
    - `reviewedAt` → now (ISO).
    - `reviewedBy` → requestor email from the JWT (`req.userEmail`).
    - Approved keys removed from `dataEnrichment.judgment.fieldsForReview`.


### PR DESCRIPTION
# Team Enrichment Review — Threshold & Status Refinements

## Summary

Refined how `GET /v1/admin/teams/enrichment-review` decides what counts as "needs admin review" and which teams are even candidates.

## Changes

### `GET /v1/admin/teams/enrichment-review`

- **High-confidence threshold is now `score >= 90`** (previously: `confidence === 'high'` AND `score === 100`). The judge already auto-promotes fields at score 90 — those are the equivalent of admin-approved, so they no longer needlessly surface in the review queue. Admin approval still writes score 100, which also falls under the same threshold.
- **Logo** continues to use `verdict === 'verified'` AND `confidence === 'high'` (its verification row has no `score` column) — admin logo approval already writes that combination, so it remains consistent with the new policy.
- **Status filter**: teams in `PendingEnrichment`, `InProgress`, or `FailedToEnrich` are excluded at the query level. Those statuses have nothing review-ready. Every other status (`Enriched`, `Reviewed`, `Approved`, anything added later) still passes through, and the per-team judgment + logo check decides inclusion.

