### PR TITLE
feat(team-news): link news items to forum discussions

### DIFF
--- a/apps/web-api/prisma/migrations/20260522120000_add_team_news_forum_link/migration.sql
+++ b/apps/web-api/prisma/migrations/20260522120000_add_team_news_forum_link/migration.sql
@@ -1,0 +1,25 @@
+-- Authoritative link between TeamNewsItem and a forum (NodeBB) topic.
+-- Populated by the home-page "Discuss" flow after a successful topic create.
+
+CREATE TABLE "TeamNewsForumLink" (
+  "id" SERIAL NOT NULL,
+  "uid" TEXT NOT NULL,
+  "newsItemUid" TEXT NOT NULL,
+  "forumTopicId" INTEGER NOT NULL,
+  "forumTopicSlug" TEXT NOT NULL,
+  "forumTopicUrl" TEXT NOT NULL,
+  "createdByUid" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "TeamNewsForumLink_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "TeamNewsForumLink_uid_key" ON "TeamNewsForumLink"("uid");
+CREATE UNIQUE INDEX "TeamNewsForumLink_newsItemUid_forumTopicId_key"
+  ON "TeamNewsForumLink"("newsItemUid", "forumTopicId");
+CREATE INDEX "TeamNewsForumLink_newsItemUid_idx" ON "TeamNewsForumLink"("newsItemUid");
+
+ALTER TABLE "TeamNewsForumLink"
+  ADD CONSTRAINT "TeamNewsForumLink_newsItemUid_fkey"
+  FOREIGN KEY ("newsItemUid") REFERENCES "TeamNewsItem"("uid")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -2143,11 +2143,31 @@ model TeamNewsItem {
   rawPayload   Json?
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
+  forumLinks   TeamNewsForumLink[]
 
   @@index([teamUid])
   @@index([eventDate])
   @@index([eventType])
   @@index([teamUid, eventDate(sort: Desc)])
+}
+
+/// Authoritative link between a TeamNewsItem and a forum (NodeBB) topic
+/// that was created via the "Start a conversation" / "Discuss" affordance
+/// on the home-page news feed. Idempotent on (newsItemUid, forumTopicId)
+/// so the frontend can safely retry the write.
+model TeamNewsForumLink {
+  id             Int          @id @default(autoincrement())
+  uid            String       @unique @default(cuid())
+  newsItemUid    String
+  newsItem       TeamNewsItem @relation(fields: [newsItemUid], references: [uid], onDelete: Cascade)
+  forumTopicId   Int
+  forumTopicSlug String
+  forumTopicUrl  String
+  createdByUid   String?
+  createdAt      DateTime     @default(now())
+
+  @@unique([newsItemUid, forumTopicId])
+  @@index([newsItemUid])
 }
 
 model TeamNewsEnrichment {

--- a/apps/web-api/src/team-news/team-news-enrichment.service.ts
+++ b/apps/web-api/src/team-news/team-news-enrichment.service.ts
@@ -137,6 +137,9 @@ export class TeamNewsEnrichmentService {
           focusAreas: [...new Set(focusAreas)],
           subFocusAreas: [...new Set(subFocusAreas)],
           createdAt: item.createdAt.toISOString(),
+          // The service-side per-team endpoint does not surface forum-link
+          // counts; consumers that need them should use the public list APIs.
+          discussion: { count: 0, latestTopicUrl: null },
         };
       }),
     };

--- a/apps/web-api/src/team-news/team-news-query.service.ts
+++ b/apps/web-api/src/team-news/team-news-query.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Prisma, NewsEventType } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
 import type {
+  TeamNewsDiscussion,
   TeamNewsFiltersResponse,
   TeamNewsGroupedResponse,
   TeamNewsItemDto,
@@ -9,6 +10,8 @@ import type {
   TeamNewsListResponse,
 } from 'libs/contracts/src/schema/team-news';
 import { TEAM_NEWS_EXCLUDED_TEAM_NAMES } from './team-news-public-list.config';
+
+const EMPTY_DISCUSSION: TeamNewsDiscussion = { count: 0, latestTopicUrl: null };
 
 const TOP_LEVEL_FOCUS_AREAS = [
   'Digital Human Rights',
@@ -112,11 +115,13 @@ export class TeamNewsQueryService {
       this.prisma.teamNewsItem.count({ where }),
     ]);
 
+    const discussions = await this.loadDiscussions(rows.map((r) => r.uid));
+
     return {
       page: query.page,
       limit: query.limit,
       total,
-      items: rows.map((row) => this.toDto(row)),
+      items: rows.map((row) => this.toDto(row, discussions.get(row.uid))),
     };
   }
 
@@ -137,15 +142,18 @@ export class TeamNewsQueryService {
       },
     });
 
-    const focusAreas = await this.prisma.focusArea.findMany({
-      where: { parentUid: null },
-      select: { uid: true, title: true },
-    });
+    const [focusAreas, discussions] = await Promise.all([
+      this.prisma.focusArea.findMany({
+        where: { parentUid: null },
+        select: { uid: true, title: true },
+      }),
+      this.loadDiscussions(rows.map((r) => r.uid)),
+    ]);
     const focusByTitle = new Map(focusAreas.map((fa) => [fa.title, fa]));
 
     const groups = new Map<string, TeamNewsItemDto[]>();
     for (const row of rows) {
-      const dto = this.toDto(row);
+      const dto = this.toDto(row, discussions.get(row.uid));
       if (dto.focusAreas.length === 0) continue;
       for (const title of dto.focusAreas) {
         if (!focusByTitle.has(title)) continue;
@@ -230,27 +238,55 @@ export class TeamNewsQueryService {
       .sort((a, b) => a.value.localeCompare(b.value));
   }
 
-  private toDto(row: {
-    uid: string;
-    teamUid: string;
-    eventType: NewsEventType;
-    eventDate: Date;
-    title: string;
-    summary: string | null;
-    sourceUrl: string;
-    sourceDomain: string | null;
-    tags: string[];
-    createdAt: Date;
-    team: {
+  /**
+   * Batch-load forum discussion summaries for a set of news items.
+   * Returns a map keyed by news-item UID. Items absent from the map have
+   * zero linked discussions.
+   */
+  private async loadDiscussions(itemUids: string[]): Promise<Map<string, TeamNewsDiscussion>> {
+    if (itemUids.length === 0) return new Map();
+    const links = await this.prisma.teamNewsForumLink.findMany({
+      where: { newsItemUid: { in: itemUids } },
+      orderBy: { createdAt: 'desc' },
+      select: { newsItemUid: true, forumTopicUrl: true },
+    });
+
+    const out = new Map<string, TeamNewsDiscussion>();
+    for (const link of links) {
+      const current = out.get(link.newsItemUid);
+      if (current) {
+        current.count += 1;
+      } else {
+        out.set(link.newsItemUid, { count: 1, latestTopicUrl: link.forumTopicUrl });
+      }
+    }
+    return out;
+  }
+
+  private toDto(
+    row: {
       uid: string;
-      name: string;
-      logo: { url: string } | null;
-      teamFocusAreas: Array<{
-        focusArea: { title: string; parentUid: string | null };
-        ancestorArea: { title: string };
-      }>;
-    };
-  }): TeamNewsItemDto {
+      teamUid: string;
+      eventType: NewsEventType;
+      eventDate: Date;
+      title: string;
+      summary: string | null;
+      sourceUrl: string;
+      sourceDomain: string | null;
+      tags: string[];
+      createdAt: Date;
+      team: {
+        uid: string;
+        name: string;
+        logo: { url: string } | null;
+        teamFocusAreas: Array<{
+          focusArea: { title: string; parentUid: string | null };
+          ancestorArea: { title: string };
+        }>;
+      };
+    },
+    discussion: TeamNewsDiscussion | undefined
+  ): TeamNewsItemDto {
     const focusAreas: string[] = [];
     const subFocusAreas: string[] = [];
     for (const tfa of row.team.teamFocusAreas) {
@@ -275,6 +311,7 @@ export class TeamNewsQueryService {
       focusAreas: [...new Set(focusAreas)],
       subFocusAreas: [...new Set(subFocusAreas)],
       createdAt: row.createdAt.toISOString(),
+      discussion: discussion ?? EMPTY_DISCUSSION,
     };
   }
 }

--- a/apps/web-api/src/team-news/team-news.controller.ts
+++ b/apps/web-api/src/team-news/team-news.controller.ts
@@ -1,16 +1,31 @@
-import { Controller, Req } from '@nestjs/common';
+import { Body, Controller, ForbiddenException, Logger, Param, Req, UseGuards } from '@nestjs/common';
 import { Api, initNestServer } from '@ts-rest/nest';
 import { Request } from 'express';
 import { apiTeamNews } from 'libs/contracts/src/lib/contract-team-news';
-import { TeamNewsListQueryParams } from 'libs/contracts/src/schema/team-news';
+import {
+  CreateTeamNewsDiscussionRequestSchema,
+  TeamNewsListQueryParams,
+} from 'libs/contracts/src/schema/team-news';
 import { NoCache } from '../decorators/no-cache.decorator';
+import { UserTokenValidation } from '../guards/user-token-validation.guard';
+import { MembersService } from '../members/members.service';
+import { AccessControlV2Service } from '../access-control-v2/services/access-control-v2.service';
+import { FORUM_PERMISSIONS } from '../access-control-v2/access-control-v2.constants';
 import { TeamNewsQueryService } from './team-news-query.service';
+import { TeamNewsService } from './team-news.service';
 
 const server = initNestServer(apiTeamNews);
 
 @Controller()
 export class TeamNewsController {
-  constructor(private readonly teamNewsQueryService: TeamNewsQueryService) {}
+  private readonly logger = new Logger(TeamNewsController.name);
+
+  constructor(
+    private readonly teamNewsQueryService: TeamNewsQueryService,
+    private readonly teamNewsService: TeamNewsService,
+    private readonly membersService: MembersService,
+    private readonly accessControl: AccessControlV2Service,
+  ) {}
 
   @Api(server.route.getTeamNews)
   @NoCache()
@@ -31,5 +46,35 @@ export class TeamNewsController {
   async getTeamNewsFilters(@Req() request: Request) {
     const params = TeamNewsListQueryParams.parse(request.query);
     return this.teamNewsQueryService.getFilters(params);
+  }
+
+  @Api(server.route.createTeamNewsDiscussion)
+  @UseGuards(UserTokenValidation)
+  async createTeamNewsDiscussion(
+    @Param('newsItemUid') newsItemUid: string,
+    @Body() body: unknown,
+    @Req() req: Request & { userEmail?: string },
+  ) {
+    const validated = CreateTeamNewsDiscussionRequestSchema.parse(body);
+
+    if (!req.userEmail) {
+      throw new ForbiddenException('Authenticated user required to create a news-discussion link');
+    }
+    const member = await this.membersService.findMemberByEmail(req.userEmail);
+    if (!member) {
+      this.logger.warn(`createTeamNewsDiscussion: authenticated email ${req.userEmail} not found as a member`);
+      throw new ForbiddenException('Member not found');
+    }
+
+    // Gate the write on forum.write. The forum-post create that produced
+    // this link is itself gated on forum.write upstream, so any honest
+    // caller already has it; the check here defends against malicious
+    // callers attempting to attach arbitrary forum topics to news items.
+    const access = await this.accessControl.hasPermission(member.uid, FORUM_PERMISSIONS.WRITE);
+    if (!access.allowed) {
+      throw new ForbiddenException(`forum.write permission required to link a news item to a forum topic`);
+    }
+
+    return this.teamNewsService.createForumLink(newsItemUid, validated, member.uid);
   }
 }

--- a/apps/web-api/src/team-news/team-news.module.ts
+++ b/apps/web-api/src/team-news/team-news.module.ts
@@ -1,5 +1,7 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { SharedModule } from '../shared/shared.module';
+import { MembersModule } from '../members/members.module';
+import { AccessControlV2Module } from '../access-control-v2/access-control-v2.module';
 import { TeamNewsController } from './team-news.controller';
 import { TeamNewsServiceController } from './team-news-service.controller';
 import { TeamNewsService } from './team-news.service';
@@ -7,7 +9,7 @@ import { TeamNewsQueryService } from './team-news-query.service';
 import { TeamNewsEnrichmentService } from './team-news-enrichment.service';
 
 @Module({
-  imports: [SharedModule],
+  imports: [SharedModule, forwardRef(() => MembersModule), AccessControlV2Module],
   controllers: [TeamNewsController, TeamNewsServiceController],
   providers: [TeamNewsService, TeamNewsQueryService, TeamNewsEnrichmentService],
   exports: [TeamNewsService, TeamNewsQueryService, TeamNewsEnrichmentService],

--- a/apps/web-api/src/team-news/team-news.service.spec.ts
+++ b/apps/web-api/src/team-news/team-news.service.spec.ts
@@ -1,0 +1,115 @@
+import { NotFoundException } from '@nestjs/common';
+import type { PrismaService } from '../shared/prisma.service';
+import { TeamNewsService } from './team-news.service';
+
+type PrismaMock = {
+  teamNewsItem: { findUnique: jest.Mock };
+  teamNewsForumLink: { findUnique: jest.Mock; upsert: jest.Mock };
+};
+
+const buildPrismaMock = (): PrismaMock => ({
+  teamNewsItem: { findUnique: jest.fn() },
+  teamNewsForumLink: { findUnique: jest.fn(), upsert: jest.fn() },
+});
+
+const makeRow = (overrides: Record<string, unknown> = {}) => ({
+  uid: 'link-1',
+  newsItemUid: 'news-1',
+  forumTopicId: 42,
+  forumTopicSlug: '42/some-slug',
+  forumTopicUrl: '/forum/topics/1/42',
+  createdByUid: 'member-1',
+  createdAt: new Date('2026-05-21T12:00:00.000Z'),
+  ...overrides,
+});
+
+describe('TeamNewsService.createForumLink', () => {
+  let service: TeamNewsService;
+  let prisma: PrismaMock;
+
+  beforeEach(() => {
+    prisma = buildPrismaMock();
+    service = new TeamNewsService(prisma as unknown as PrismaService);
+  });
+
+  it('throws NotFound when the news item does not exist', async () => {
+    prisma.teamNewsItem.findUnique.mockResolvedValue(null);
+    await expect(
+      service.createForumLink(
+        'news-missing',
+        { forumTopicId: 42, forumTopicSlug: '42/x', forumTopicUrl: '/forum/topics/1/42' },
+        'member-1',
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(prisma.teamNewsForumLink.upsert).not.toHaveBeenCalled();
+  });
+
+  it('creates a new link and returns created=true when no row exists', async () => {
+    prisma.teamNewsItem.findUnique.mockResolvedValue({ uid: 'news-1' });
+    prisma.teamNewsForumLink.findUnique.mockResolvedValue(null);
+    prisma.teamNewsForumLink.upsert.mockResolvedValue(makeRow());
+
+    const result = await service.createForumLink(
+      'news-1',
+      { forumTopicId: 42, forumTopicSlug: '42/some-slug', forumTopicUrl: '/forum/topics/1/42' },
+      'member-1',
+    );
+
+    expect(result.created).toBe(true);
+    expect(result.link.uid).toBe('link-1');
+    expect(result.link.forumTopicId).toBe(42);
+    expect(result.link.forumTopicUrl).toBe('/forum/topics/1/42');
+  });
+
+  it('returns the existing link with created=false when the row already exists', async () => {
+    prisma.teamNewsItem.findUnique.mockResolvedValue({ uid: 'news-1' });
+    prisma.teamNewsForumLink.findUnique.mockResolvedValue({ id: 7 });
+    prisma.teamNewsForumLink.upsert.mockResolvedValue(makeRow({ uid: 'link-existing' }));
+
+    const result = await service.createForumLink(
+      'news-1',
+      { forumTopicId: 42, forumTopicSlug: '42/x', forumTopicUrl: '/forum/topics/1/42' },
+      'member-1',
+    );
+
+    expect(result.created).toBe(false);
+    expect(result.link.uid).toBe('link-existing');
+  });
+
+  it('forwards createdByUid to the upsert create payload', async () => {
+    prisma.teamNewsItem.findUnique.mockResolvedValue({ uid: 'news-1' });
+    prisma.teamNewsForumLink.findUnique.mockResolvedValue(null);
+    prisma.teamNewsForumLink.upsert.mockResolvedValue(makeRow({ createdByUid: 'member-7' }));
+
+    await service.createForumLink(
+      'news-1',
+      { forumTopicId: 99, forumTopicSlug: '99/x', forumTopicUrl: '/forum/topics/1/99' },
+      'member-7',
+    );
+
+    expect(prisma.teamNewsForumLink.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          newsItemUid: 'news-1',
+          forumTopicId: 99,
+          createdByUid: 'member-7',
+        }),
+        update: {},
+      }),
+    );
+  });
+
+  it('allows a null createdByUid for unattributed calls', async () => {
+    prisma.teamNewsItem.findUnique.mockResolvedValue({ uid: 'news-1' });
+    prisma.teamNewsForumLink.findUnique.mockResolvedValue(null);
+    prisma.teamNewsForumLink.upsert.mockResolvedValue(makeRow({ createdByUid: null }));
+
+    const result = await service.createForumLink(
+      'news-1',
+      { forumTopicId: 42, forumTopicSlug: '42/x', forumTopicUrl: '/forum/topics/1/42' },
+      null,
+    );
+
+    expect(result.link.createdByUid).toBeNull();
+  });
+});

--- a/apps/web-api/src/team-news/team-news.service.ts
+++ b/apps/web-api/src/team-news/team-news.service.ts
@@ -1,7 +1,12 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
 import { IngestTeamNewsDto, IngestTeamNewsResponse, TeamNewsIngestItem } from './dto/ingest-team-news.dto';
+import type {
+  CreateTeamNewsDiscussionRequest,
+  CreateTeamNewsDiscussionResponse,
+  TeamNewsForumLinkDto,
+} from 'libs/contracts/src/schema/team-news';
 import { computeCanonicalKey } from './utils/canonical-key';
 import { extractDomain } from './utils/url-normalize';
 
@@ -179,5 +184,71 @@ export class TeamNewsService {
         update: { recentNewsCount },
       });
     }
+  }
+
+  /**
+   * Record that a forum topic was created in response to a news item.
+   * Idempotent on (newsItemUid, forumTopicId) — replaying the same call
+   * returns the existing link with `created: false`. Used by the home-page
+   * "Discuss" flow, called by the frontend after a successful topic create.
+   *
+   * Throws NotFound when the news item does not exist (e.g. stale link
+   * attempt against a deleted item).
+   */
+  async createForumLink(
+    newsItemUid: string,
+    body: CreateTeamNewsDiscussionRequest,
+    actorUid: string | null,
+  ): Promise<CreateTeamNewsDiscussionResponse> {
+    const item = await this.prisma.teamNewsItem.findUnique({
+      where: { uid: newsItemUid },
+      select: { uid: true },
+    });
+    if (!item) {
+      throw new NotFoundException(`TeamNewsItem ${newsItemUid} not found`);
+    }
+
+    // Upsert keeps the call idempotent under concurrent submits (two clients
+    // racing to link the same news item to the same topic would otherwise
+    // produce a 500 from the unique-constraint violation on the second
+    // caller). `created` is inferred from whether the existing row's
+    // createdAt was just stamped — we treat any pre-existing link as "not
+    // created by this call".
+    const before = await this.prisma.teamNewsForumLink.findUnique({
+      where: { newsItemUid_forumTopicId: { newsItemUid, forumTopicId: body.forumTopicId } },
+      select: { id: true },
+    });
+    const row = await this.prisma.teamNewsForumLink.upsert({
+      where: { newsItemUid_forumTopicId: { newsItemUid, forumTopicId: body.forumTopicId } },
+      create: {
+        newsItemUid,
+        forumTopicId: body.forumTopicId,
+        forumTopicSlug: body.forumTopicSlug,
+        forumTopicUrl: body.forumTopicUrl,
+        createdByUid: actorUid,
+      },
+      update: {},
+    });
+    return { link: this.toForumLinkDto(row), created: !before };
+  }
+
+  private toForumLinkDto(row: {
+    uid: string;
+    newsItemUid: string;
+    forumTopicId: number;
+    forumTopicSlug: string;
+    forumTopicUrl: string;
+    createdByUid: string | null;
+    createdAt: Date;
+  }): TeamNewsForumLinkDto {
+    return {
+      uid: row.uid,
+      newsItemUid: row.newsItemUid,
+      forumTopicId: row.forumTopicId,
+      forumTopicSlug: row.forumTopicSlug,
+      forumTopicUrl: row.forumTopicUrl,
+      createdByUid: row.createdByUid,
+      createdAt: row.createdAt.toISOString(),
+    };
   }
 }

--- a/libs/contracts/src/lib/contract-team-news.ts
+++ b/libs/contracts/src/lib/contract-team-news.ts
@@ -1,5 +1,8 @@
 import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
 import {
+  CreateTeamNewsDiscussionRequestSchema,
+  CreateTeamNewsDiscussionResponseSchema,
   TeamNewsFiltersResponseSchema,
   TeamNewsGroupedResponseSchema,
   TeamNewsListQueryParams,
@@ -36,5 +39,15 @@ export const apiTeamNews = contract.router({
       200: TeamNewsFiltersResponseSchema,
     },
     summary: 'Facet counts for the Team News list',
+  },
+  createTeamNewsDiscussion: {
+    method: 'POST',
+    path: `${getAPIVersionAsPath('1')}/team-news/:newsItemUid/discussions`,
+    pathParams: z.object({ newsItemUid: z.string() }),
+    body: CreateTeamNewsDiscussionRequestSchema,
+    responses: {
+      201: CreateTeamNewsDiscussionResponseSchema,
+    },
+    summary: 'Record that a forum topic was created in response to a news item',
   },
 });

--- a/libs/contracts/src/schema/team-news.ts
+++ b/libs/contracts/src/schema/team-news.ts
@@ -49,6 +49,15 @@ export const TeamNewsListQueryParams = z.object({
 
 export type TeamNewsListQuery = z.infer<typeof TeamNewsListQueryParams>;
 
+// Per-item summary of forum discussions linked to this news item.
+// `count` is the number of TeamNewsForumLink rows; `latestTopicUrl` is the
+// most recently-linked topic's URL (used by the frontend to render
+// "Join discussion ›" linking straight to that thread when count === 1).
+export const TeamNewsDiscussionSchema = z.object({
+  count: z.number().int().min(0),
+  latestTopicUrl: z.string().nullable(),
+});
+
 export const TeamNewsItemSchema = z.object({
   uid: z.string(),
   teamUid: z.string(),
@@ -64,6 +73,31 @@ export const TeamNewsItemSchema = z.object({
   focusAreas: z.array(z.string()),
   subFocusAreas: z.array(z.string()),
   createdAt: z.string(),
+  discussion: TeamNewsDiscussionSchema,
+});
+
+// POST /v1/team-news/{newsItemUid}/discussions — links a TeamNewsItem to a
+// forum topic that was just created via the home-page "Discuss" flow.
+// Idempotent on (newsItemUid, forumTopicId).
+export const CreateTeamNewsDiscussionRequestSchema = z.object({
+  forumTopicId: z.number().int().positive(),
+  forumTopicSlug: z.string().min(1),
+  forumTopicUrl: z.string().min(1),
+});
+
+export const TeamNewsForumLinkSchema = z.object({
+  uid: z.string(),
+  newsItemUid: z.string(),
+  forumTopicId: z.number().int(),
+  forumTopicSlug: z.string(),
+  forumTopicUrl: z.string(),
+  createdByUid: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+export const CreateTeamNewsDiscussionResponseSchema = z.object({
+  link: TeamNewsForumLinkSchema,
+  created: z.boolean(),
 });
 
 export const TeamNewsListResponseSchema = z.object({
@@ -203,3 +237,7 @@ export type TeamNewsEnrichmentResponseItem = z.infer<typeof TeamNewsEnrichmentSc
 export type TeamWithNewsEnrichment = z.infer<typeof TeamWithNewsEnrichmentSchema>;
 export type TeamsWithNewsEnrichmentResponse = z.infer<typeof TeamsWithNewsEnrichmentResponseSchema>;
 export type TeamNewsPerTeamResponse = z.infer<typeof TeamNewsPerTeamResponseSchema>;
+export type TeamNewsDiscussion = z.infer<typeof TeamNewsDiscussionSchema>;
+export type CreateTeamNewsDiscussionRequest = z.infer<typeof CreateTeamNewsDiscussionRequestSchema>;
+export type CreateTeamNewsDiscussionResponse = z.infer<typeof CreateTeamNewsDiscussionResponseSchema>;
+export type TeamNewsForumLinkDto = z.infer<typeof TeamNewsForumLinkSchema>;


### PR DESCRIPTION
## Summary

- Adds a `TeamNewsForumLink` table (compound unique on `newsItemUid, forumTopicId`, race-safe upsert) so the home-page news cards can show a "Discuss" affordance the first time and a "Join discussion" link to the existing thread for every later visitor. NodeBB has no search plugin, so the directory owns the mapping.
- New endpoint `POST /v1/team-news/:newsItemUid/discussions`, gated on `UserTokenValidation` + `forum.write` via `AccessControlV2Service`. The forum-post create that produces the link is already gated on `forum.write` upstream — the gate here defends against malicious callers attaching arbitrary topics to news items.
- `TeamNewsQueryService.loadDiscussions(itemUids)` batch-fetcher to keep the list endpoint O(1) queries.
- 5 new unit tests in `team-news.service.spec.ts` covering NotFound, create (created=true), idempotent existing (created=false), `createdByUid` forwarding, and null actor.

Pairs with frontend PR on `pln-directory-portal-v2` (same branch name).

## Test plan

- [ ] `yarn nx test web-api --testPathPattern=team-news` passes (20+ specs)
- [ ] Migration `20260522120000_add_team_news_forum_link` applies cleanly against develop
- [ ] `POST /v1/team-news/:uid/discussions` requires a valid token (401 without, 403 without `forum.write`)
- [ ] First call returns `{ created: true, link: ... }`; replay returns `{ created: false }` with the same link
- [ ] Two concurrent submits do not produce a 500 (upsert keeps it safe)
- [ ] List endpoints surface the `discussion: { count, latestTopicUrl }` field on each item
- [ ] NotFound thrown when posting against a stale `newsItemUid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)