### PR TITLE
[Team Enrichment][Back office] Fix approve team fields

### DIFF
--- a/apps/back-office/components/teams/data-quality/DataQualityTable.tsx
+++ b/apps/back-office/components/teams/data-quality/DataQualityTable.tsx
@@ -15,7 +15,7 @@ import { EnrichmentTeam, LogoEntry } from '../../../hooks/teams/useTeamsEnrichme
 import { WEB_UI_BASE_URL } from '../../../utils/constants';
 import PaginationControls from '../../../screens/members/components/PaginationControls/PaginationControls';
 import { TeamLogoCell } from './TeamLogoCell';
-import { FIELD_KEYS, FIELD_LABELS, UNJUDGED_SCORE, getEntry, isAIEnriched } from './constants';
+import { FIELD_KEYS, FIELD_LABELS, getEntry, isAIEnriched, needsReview } from './constants';
 import s from '../../../pages/teams/data-quality.module.scss';
 
 interface Props {
@@ -74,8 +74,7 @@ export function DataQualityTable({ teams, isLoading, hasActiveFilters, onEdit }:
           const team = info.row.original;
           const chips = FIELD_KEYS.flatMap((key) => {
             const entry = getEntry(team, key);
-            if (!entry) return [];
-            if ((entry.judgment?.score ?? UNJUDGED_SCORE) > 90) return [];
+            if (!entry || !needsReview(team, key)) return [];
             return [
               <span key={key} className={clsx(s.reviewChip, isAIEnriched(entry) ? s.reviewChipAI : s.reviewChipUser)}>
                 {FIELD_LABELS[key]}

--- a/apps/back-office/components/teams/data-quality/EditModal.tsx
+++ b/apps/back-office/components/teams/data-quality/EditModal.tsx
@@ -7,7 +7,7 @@ import { EnrichmentTeam, FieldKey } from '../../../hooks/teams/useTeamsEnrichmen
 import { useGetTeam, TeamDetail } from '../../../hooks/teams/useGetTeam';
 import { useUpdateAdminTeam, TeamUpdatePayload } from '../../../hooks/teams/useUpdateAdminTeam';
 import { useApproveEnrichmentFields } from '../../../hooks/teams/useApproveEnrichmentFields';
-import { FIELD_KEYS, FIELD_LABELS, UNJUDGED_SCORE, getEntry, isAIEnriched } from './constants';
+import { FIELD_KEYS, FIELD_LABELS, getEntry, isAIEnriched, needsReview } from './constants';
 import { WEB_UI_BASE_URL } from '../../../utils/constants';
 import api from '../../../utils/api';
 import s from '../../../pages/teams/data-quality.module.scss';
@@ -152,16 +152,13 @@ export function EditModal({ team, authToken, onClose }: Props) {
     onClose();
   };
 
-  const lowScoreEditableKeys: EditableFieldKey[] = team
-    ? EDITABLE_KEYS.filter((key) => {
-        const entry = getEntry(team, key);
-        return !!entry && (entry.judgment?.score ?? UNJUDGED_SCORE) <= 90;
-      })
+  const reviewableEditableKeys: EditableFieldKey[] = team
+    ? EDITABLE_KEYS.filter((key) => !!getEntry(team, key) && needsReview(team, key))
     : [];
 
-  const showLogoRow = Boolean(team?.logo && (team.logo.judgment?.score ?? UNJUDGED_SCORE) <= 90);
+  const showLogoRow = Boolean(team && needsReview(team, 'logo'));
 
-  const hasNoLowFields = !detailLoading && form && lowScoreEditableKeys.length === 0 && !showLogoRow;
+  const hasNoLowFields = !detailLoading && form && reviewableEditableKeys.length === 0 && !showLogoRow;
 
   return (
     <AnimatePresence>
@@ -225,7 +222,7 @@ export function EditModal({ team, authToken, onClose }: Props) {
                     />
                   )}
 
-                  {lowScoreEditableKeys.map((key) => {
+                  {reviewableEditableKeys.map((key) => {
                     const enrichmentEntry = team.fields[key];
                     const isConfirmed = confirmedFields.has(key);
                     const isAI = enrichmentEntry ? isAIEnriched(enrichmentEntry) : false;

--- a/apps/back-office/components/teams/data-quality/EditModal.tsx
+++ b/apps/back-office/components/teams/data-quality/EditModal.tsx
@@ -47,6 +47,7 @@ function teamToForm(teamDetail: TeamDetail, enrichmentTeam: EnrichmentTeam): Tea
 
 export function EditModal({ team, authToken, onClose }: Props) {
   const [form, setForm] = useState<TeamUpdatePayload | null>(null);
+  const [initialForm, setInitialForm] = useState<TeamUpdatePayload | null>(null);
   const [confirmedFields, setConfirmedFields] = useState<Set<FieldKey>>(new Set());
   const [selectedLogoFile, setSelectedLogoFile] = useState<File | null>(null);
   const isSavingRef = useRef(false);
@@ -56,12 +57,17 @@ export function EditModal({ team, authToken, onClose }: Props) {
   const approveMutation = useApproveEnrichmentFields();
 
   useEffect(() => {
-    if (teamDetail && team && !isSavingRef.current) setForm(teamToForm(teamDetail, team));
+    if (teamDetail && team && !isSavingRef.current) {
+      const initial = teamToForm(teamDetail, team);
+      setForm(initial);
+      setInitialForm(initial);
+    }
   }, [teamDetail, team]);
 
   useEffect(() => {
     if (!team) {
       setForm(null);
+      setInitialForm(null);
       setConfirmedFields(new Set());
       setSelectedLogoFile(null);
     }
@@ -84,15 +90,14 @@ export function EditModal({ team, authToken, onClose }: Props) {
   };
 
   const handleSave = async () => {
-    if (!team || !form || !authToken || !teamDetail) return;
+    if (!team || !form || !authToken || !teamDetail || !initialForm) return;
     isSavingRef.current = true;
 
     const fieldsToApprove = [...confirmedFields];
 
     const changedData: TeamUpdatePayload = {};
     (Object.keys(form) as (keyof TeamUpdatePayload)[]).forEach((key) => {
-      const original = String(teamDetail[key as keyof TeamDetail] ?? '');
-      if ((form[key] ?? '') !== original) changedData[key] = form[key];
+      if ((form[key] ?? '') !== (initialForm[key] ?? '')) changedData[key] = form[key];
     });
 
     if (Object.keys(changedData).length === 0 && fieldsToApprove.length === 0) {

--- a/apps/back-office/components/teams/data-quality/constants.ts
+++ b/apps/back-office/components/teams/data-quality/constants.ts
@@ -24,9 +24,6 @@ export const FIELD_LABELS: Record<FieldKey, string> = {
 
 export const AI_SOURCES = ['ai', 'open-graph', 'scrapingdog'] as const;
 
-// Unjudged fields default — treated as high-quality so they're excluded from the low-score filter
-export const UNJUDGED_SCORE = 100;
-
 // Eliminates the repeated `key === 'logo' ? team.logo : team.fields[key]` ternary
 export function getEntry(team: EnrichmentTeam, key: FieldKey): FieldEntry | undefined {
   return key === 'logo' ? team.logo : team.fields[key];
@@ -36,4 +33,27 @@ export function getEntry(team: EnrichmentTeam, key: FieldKey): FieldEntry | unde
 export function isAIEnriched(entry: FieldEntry): boolean {
   return (AI_SOURCES as ReadonlyArray<string>).includes(entry.metadata.source ?? '') &&
     entry.metadata.status !== 'ChangedByUser';
+}
+
+// Mirrors the API's inclusion rule (apps/web-api .../team-enrichment.service.ts listEnrichmentsForReview).
+// A field/logo needs review iff it has NOT been auto-approved at verdict=agrees + confidence=high
+// — the same pair the judge promotes on and admin approval normalizes to. Score is intentionally
+// NOT consulted (ScrapingDog/AI can emit score=90 at medium confidence — not promoted — and
+// score=85 at high — promoted).
+//
+//  - Non-logo fields: read fields[key].judgment. If absent, the field hasn't been judged yet
+//    and isn't review-ready (matches the API, which skips unjudged entries).
+//  - Logo: there is no field-level judgment; the equivalent signal is the latest
+//    TeamLogoVerificationResult exposed as logo.verification. A team's logo needs review when
+//    it has content and verification is missing or not (verified + high).
+export function needsReview(team: EnrichmentTeam, key: FieldKey): boolean {
+  if (key === 'logo') {
+    const logo = team.logo;
+    if (!logo?.content) return false;
+    const v = logo.verification;
+    return !(v?.verdict === 'verified' && v?.confidence === 'high');
+  }
+  const entry = team.fields[key];
+  if (!entry?.judgment) return false;
+  return !(entry.judgment.verdict === 'agrees' && entry.judgment.confidence === 'high');
 }

--- a/apps/back-office/components/teams/data-quality/constants.ts
+++ b/apps/back-office/components/teams/data-quality/constants.ts
@@ -50,8 +50,11 @@ export function needsReview(team: EnrichmentTeam, key: FieldKey): boolean {
   if (key === 'logo') {
     const logo = team.logo;
     if (!logo?.content) return false;
+    const j = logo.judgment;
+    if (j?.verdict === 'agrees' && j?.confidence === 'high') return false;
     const v = logo.verification;
-    return !(v?.verdict === 'verified' && v?.confidence === 'high');
+    if (v?.verdict === 'verified' && v?.confidence === 'high') return false;
+    return true;
   }
   const entry = team.fields[key];
   if (!entry?.judgment) return false;

--- a/apps/back-office/hooks/teams/useTeamsEnrichmentReview.ts
+++ b/apps/back-office/hooks/teams/useTeamsEnrichmentReview.ts
@@ -15,6 +15,7 @@ export type FieldKey =
 // Mirrors EnrichmentSource and FieldEnrichmentStatus enums from backend
 export type FieldMetadataSource = 'ai' | 'open-graph' | 'scrapingdog';
 export type FieldMetadataStatus = 'Enriched' | 'ChangedByUser' | 'CannotEnrich';
+export type JudgmentVerdict = 'agrees' | 'disagrees' | 'uncertain';
 
 export type FieldEntry = {
   content: string | string[] | { uid: string; url: string } | null;
@@ -23,7 +24,7 @@ export type FieldEntry = {
     status?: FieldMetadataStatus;
     lastModifiedAt?: string;
   };
-  judgment?: { note?: string; score?: number };
+  judgment?: { note?: string; score?: number; verdict?: JudgmentVerdict };
 };
 
 export type LogoEntry = FieldEntry & {

--- a/apps/back-office/hooks/teams/useTeamsEnrichmentReview.ts
+++ b/apps/back-office/hooks/teams/useTeamsEnrichmentReview.ts
@@ -16,6 +16,7 @@ export type FieldKey =
 export type FieldMetadataSource = 'ai' | 'open-graph' | 'scrapingdog';
 export type FieldMetadataStatus = 'Enriched' | 'ChangedByUser' | 'CannotEnrich';
 export type JudgmentVerdict = 'agrees' | 'disagrees' | 'uncertain';
+export type JudgmentConfidence = 'high' | 'medium' | 'low';
 
 export type FieldEntry = {
   content: string | string[] | { uid: string; url: string } | null;
@@ -24,7 +25,7 @@ export type FieldEntry = {
     status?: FieldMetadataStatus;
     lastModifiedAt?: string;
   };
-  judgment?: { note?: string; score?: number; verdict?: JudgmentVerdict };
+  judgment?: { note?: string; score?: number; verdict?: JudgmentVerdict; confidence?: JudgmentConfidence };
 };
 
 export type LogoEntry = FieldEntry & {

--- a/apps/back-office/pages/teams/data-quality.tsx
+++ b/apps/back-office/pages/teams/data-quality.tsx
@@ -9,7 +9,7 @@ import Select, { StylesConfig } from 'react-select';
 import { ApprovalLayout } from '../../layout/approval-layout';
 import { useAuth } from '../../context/auth-context';
 import { useTeamsEnrichmentReview, EnrichmentTeam } from '../../hooks/teams/useTeamsEnrichmentReview';
-import { FIELD_KEYS, getEntry, isAIEnriched, UNJUDGED_SCORE } from '../../components/teams/data-quality/constants';
+import { FIELD_KEYS, getEntry, isAIEnriched, needsReview } from '../../components/teams/data-quality/constants';
 import { DataQualityTable } from '../../components/teams/data-quality/DataQualityTable';
 import { EditModal } from '../../components/teams/data-quality/EditModal';
 import s from './data-quality.module.scss';
@@ -80,12 +80,9 @@ const DataQualityPage: React.FC = () => {
     return teams.filter((t) => {
       if (q && !t.name.toLowerCase().includes(q)) return false;
 
-      // Only show teams with at least one low-score field
-      const hasLowField = FIELD_KEYS.some((key) => {
-        const entry = getEntry(t, key);
-        return entry && (entry.judgment?.score ?? UNJUDGED_SCORE) <= 90;
-      });
-      if (!hasLowField) return false;
+      // Only show teams with at least one field still pending admin review
+      // (not auto-approved at verdict=agrees + confidence=high — same rule the API applies).
+      if (!FIELD_KEYS.some((key) => needsReview(t, key))) return false;
 
       // Priority
       if (priorityFilter !== 'all' && t.priority !== priorityFilter) return false;

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -32,6 +32,10 @@ export type EnrichmentReviewFieldEntry = {
 export type EnrichmentReviewLogo = {
   content: { uid: string; url: string } | null;
   metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
+  // Admin-approval judgment lives on fieldsMeta.logo.judgment (PATCH /enrichment-review writes
+  // {verdict: agrees, confidence: high, score: 100} here). The VLM cron never writes here —
+  // it writes to verification below.
+  judgment?: { note?: string; score?: number; verdict?: JudgmentVerdict; confidence?: FieldConfidence };
   verification: {
     verdict: string;
     confidence: string;
@@ -1360,8 +1364,13 @@ export class TeamEnrichmentService {
         return !(fm.judgment.verdict === JudgmentVerdict.Agrees && fm.judgment.confidence === FieldConfidence.High);
       });
       const latestLogoVerif = latestByTeam.get(row.teamUid);
-      const hasUnapprovedLogo =
-        !!row.logoUid && !(latestLogoVerif?.verdict === 'verified' && latestLogoVerif?.confidence === 'high');
+      const logoFieldMeta = meta.fieldsMeta.logo;
+      const logoApprovedByAdmin =
+        logoFieldMeta?.judgment?.verdict === JudgmentVerdict.Agrees &&
+        logoFieldMeta?.judgment?.confidence === FieldConfidence.High;
+      const logoApprovedByVLM =
+        latestLogoVerif?.verdict === 'verified' && latestLogoVerif?.confidence === 'high';
+      const hasUnapprovedLogo = !!row.logoUid && !logoApprovedByAdmin && !logoApprovedByVLM;
       if (!hasUnapprovedField && !hasUnapprovedLogo) continue;
 
       const fields: EnrichmentReviewItem['fields'] = {};
@@ -1435,6 +1444,16 @@ export class TeamEnrichmentService {
             source: logoMeta?.source,
             lastModifiedAt: logoMeta?.lastModifiedAt,
           },
+          ...(logoMeta?.judgment
+            ? {
+                judgment: {
+                  note: logoMeta.judgment.note,
+                  score: logoMeta.judgment.score,
+                  verdict: logoMeta.judgment.verdict,
+                  confidence: logoMeta.judgment.confidence,
+                },
+              }
+            : {}),
           verification: latestLogoVerif
             ? {
                 verdict: latestLogoVerif.verdict,

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -26,7 +26,7 @@ import {
 export type EnrichmentReviewFieldEntry = {
   content: string | string[];
   metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
-  judgment: { note?: string; score?: number };
+  judgment: { note?: string; score?: number; verdict?: JudgmentVerdict };
 };
 
 export type EnrichmentReviewLogo = {
@@ -1412,7 +1412,11 @@ export class TeamEnrichmentService {
             source: fieldMeta.source,
             lastModifiedAt: fieldMeta.lastModifiedAt,
           },
-          judgment: { note: fieldMeta.judgment.note, score: fieldMeta.judgment.score },
+          judgment: {
+            note: fieldMeta.judgment.note,
+            score: fieldMeta.judgment.score,
+            verdict: fieldMeta.judgment.verdict,
+          },
         };
       }
 

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -26,7 +26,7 @@ import {
 export type EnrichmentReviewFieldEntry = {
   content: string | string[];
   metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
-  judgment: { note?: string; score?: number; verdict?: JudgmentVerdict };
+  judgment: { note?: string; score?: number; verdict?: JudgmentVerdict; confidence?: FieldConfidence };
 };
 
 export type EnrichmentReviewLogo = {
@@ -1249,13 +1249,13 @@ export class TeamEnrichmentService {
    * Full list of teams that still have at least one thing needing admin review.
    *
    * Inclusion criteria — a team is included if EITHER of the following holds:
-   *  - at least one non-logo `fieldsMeta[k].judgment.score` is below 90. Anything `>= 90`
-   *    is treated as high-confidence (the judge auto-promotes at 90 and admin-approved
-   *    fields land at 100), so it doesn't need review.
+   *  - at least one non-logo `fieldsMeta[k].judgment` is NOT (`verdict='agrees'` AND
+   *    `confidence='high'`). That pair is the exact criterion the judge uses to auto-promote
+   *    a field to `Team`, and admin approval normalizes to the same pair — so anything else
+   *    (disagrees, uncertain, or medium/low confidence) is still pending review.
    *  - the team has a logo (`row.logoUid` set) whose latest `TeamLogoVerificationResult`
    *    is NOT at (`verdict === 'verified'` AND `confidence === 'high'`). Logo verification
-   *    has no `score` column — the equivalent "high-confidence approved" check uses the
-   *    verdict + confidence pair the VLM writes (and admin approval updates to verified+high).
+   *    uses verdict+confidence directly (no score column), mirroring the field-level check.
    *
    * Statuses excluded at the query level: `PendingEnrichment`, `InProgress`, `FailedToEnrich`.
    * The remaining statuses (`Enriched`, `Reviewed`, `Approved`, and any future addition) all
@@ -1348,12 +1348,16 @@ export class TeamEnrichmentService {
       const meta = this.parseEnrichmentMeta(row.dataEnrichment);
       if (!meta?.fieldsMeta) continue;
 
-      // Score >= 90 is treated as high-confidence and doesn't need review.
-      // Logo has no `score` column on its verification row — the equivalent check is
+      // A field is "auto-approved" iff the judge would have promoted it, i.e.
+      // verdict=agrees AND confidence=high (admin approval also normalizes to this).
+      // Score is intentionally NOT the gate — ScrapingDog/AI can emit score=90
+      // at medium confidence (not promoted) or score=85 at high (promoted),
+      // so score-thresholding produces both false negatives and false positives.
+      // Logo has no judgment.score on its verification row — the equivalent check is
       // verdict='verified' AND confidence='high' (what admin-approve writes).
       const hasUnapprovedField = Object.entries(meta.fieldsMeta).some(([k, fm]) => {
         if (k === 'logo' || !fm?.judgment) return false;
-        return (fm.judgment.score ?? 0) < 90;
+        return !(fm.judgment.verdict === JudgmentVerdict.Agrees && fm.judgment.confidence === FieldConfidence.High);
       });
       const latestLogoVerif = latestByTeam.get(row.teamUid);
       const hasUnapprovedLogo =
@@ -1416,6 +1420,7 @@ export class TeamEnrichmentService {
             note: fieldMeta.judgment.note,
             score: fieldMeta.judgment.score,
             verdict: fieldMeta.judgment.verdict,
+            confidence: fieldMeta.judgment.confidence,
           },
         };
       }

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -449,7 +449,7 @@ Full list of teams that still have **at least one thing needing admin review**. 
 
 Inclusion criteria — a team is included if EITHER:
 - At least one non-logo `fieldsMeta[k].judgment` is NOT (`verdict === 'agrees'` AND `confidence === 'high'`). That pair is the exact criterion the judge uses to auto-promote a field from `TeamEnrichment` to `Team`, and admin approval normalizes to the same pair — so anything else (`disagrees`, `uncertain`, or `medium`/`low` confidence) is still pending review and surfaces here. Fields without a `judgment` entry yet are ignored (they're not review-ready). Score is **not** the gate: ScrapingDog can legitimately emit `score=90` at `medium` confidence (e.g. partial nameMatch + website corroboration — not promoted) and `score=85` at `high` (e.g. tagline-overlap with exact name match — promoted), so score-thresholding produces both false negatives and false positives relative to what the judge actually did.
-- The team has a logo (`TeamEnrichment.logoUid` set) whose latest `TeamLogoVerificationResult` is NOT at (`verdict === 'verified'` AND `confidence === 'high'`). Logo uses the same verdict + confidence pair (no score column).
+- The team has a logo (`TeamEnrichment.logoUid` set) and NEITHER of the two approval sources is at high confidence. Logo has two independent approval sources, EITHER is sufficient: (a) admin approval via PATCH `/enrichment-review` writes `agrees + high` to `fieldsMeta.logo.judgment`; (b) the VLM cron writes `verified + high` to the latest `TeamLogoVerificationResult` row. The union is required because admin approval only **updates** an existing VLM row — it does not **create** one — so a logo approved by an admin before the VLM cron ever ran would otherwise keep surfacing in the review list forever.
 
 The endpoint excludes `PendingEnrichment`, `InProgress`, and `FailedToEnrich` at the query level — those teams have nothing review-ready. Remaining statuses (`Enriched`, `Reviewed`, `Approved`, and any future addition) all surface as long as the inclusion check flags something.
 
@@ -481,6 +481,7 @@ Response shape:
     logo?: {
       content: { uid: string; url: string } | null;   // candidate logo from TeamEnrichment
       metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
+      judgment?: { note?: string; score?: number; verdict?: 'agrees' | 'disagrees' | 'uncertain'; confidence?: 'high' | 'medium' | 'low' };  // admin-approval judgment from fieldsMeta.logo.judgment; absent until admin approves
       verification: {
         verdict: string;
         confidence: string;

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -476,7 +476,7 @@ Response shape:
     fields: Partial<Record<FieldMetaKey, {
       content: string | string[];                // candidate value from TeamEnrichment
       metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
-      judgment: { note?: string; score?: number };
+      judgment: { note?: string; score?: number; verdict?: 'agrees' | 'disagrees' | 'uncertain' };
     }>>;
     logo?: {
       content: { uid: string; url: string } | null;   // candidate logo from TeamEnrichment

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -448,8 +448,8 @@ Guard: AdminAuthGuard
 Full list of teams that still have **at least one thing needing admin review**. Sorted by `team.name` ASC. No pagination — the portal carries ~1K teams and the back-office UI consumes the full set at once.
 
 Inclusion criteria — a team is included if EITHER:
-- At least one non-logo `fieldsMeta[k].judgment.score` is below 90. Anything `>= 90` is treated as high-confidence and is excluded — the judge auto-promotes at score 90 and admin approval normalizes to score 100, so this threshold covers both. Fields without a judgment entry yet are ignored (they're not review-ready).
-- The team has a logo (`TeamEnrichment.logoUid` set) whose latest `TeamLogoVerificationResult` is NOT at (`verdict === 'verified'` AND `confidence === 'high'`). Logo verification has no `score` column, so the high-confidence check uses the verdict + confidence pair (which admin approval updates to verified+high).
+- At least one non-logo `fieldsMeta[k].judgment` is NOT (`verdict === 'agrees'` AND `confidence === 'high'`). That pair is the exact criterion the judge uses to auto-promote a field from `TeamEnrichment` to `Team`, and admin approval normalizes to the same pair — so anything else (`disagrees`, `uncertain`, or `medium`/`low` confidence) is still pending review and surfaces here. Fields without a `judgment` entry yet are ignored (they're not review-ready). Score is **not** the gate: ScrapingDog can legitimately emit `score=90` at `medium` confidence (e.g. partial nameMatch + website corroboration — not promoted) and `score=85` at `high` (e.g. tagline-overlap with exact name match — promoted), so score-thresholding produces both false negatives and false positives relative to what the judge actually did.
+- The team has a logo (`TeamEnrichment.logoUid` set) whose latest `TeamLogoVerificationResult` is NOT at (`verdict === 'verified'` AND `confidence === 'high'`). Logo uses the same verdict + confidence pair (no score column).
 
 The endpoint excludes `PendingEnrichment`, `InProgress`, and `FailedToEnrich` at the query level — those teams have nothing review-ready. Remaining statuses (`Enriched`, `Reviewed`, `Approved`, and any future addition) all surface as long as the inclusion check flags something.
 
@@ -476,7 +476,7 @@ Response shape:
     fields: Partial<Record<FieldMetaKey, {
       content: string | string[];                // candidate value from TeamEnrichment
       metadata: { status?: FieldEnrichmentStatus; source?: EnrichmentSource; lastModifiedAt?: string };
-      judgment: { note?: string; score?: number; verdict?: 'agrees' | 'disagrees' | 'uncertain' };
+      judgment: { note?: string; score?: number; verdict?: 'agrees' | 'disagrees' | 'uncertain'; confidence?: 'high' | 'medium' | 'low' };
     }>>;
     logo?: {
       content: { uid: string; url: string } | null;   // candidate logo from TeamEnrichment
@@ -518,7 +518,7 @@ What happens in one `prisma.$transaction`:
 1. **Team writes** per the per-field resolution above. For `ChangedByUser` + confirm-only entries, no Team write is issued (the value is already there); only `fieldsMeta` is normalized.
 2. **`fieldsMeta` normalization** for every approved key — `status` + `judgment` updated per the rules above, `lastModifiedAt` restamped.
 3. **Team-level metadata**:
-   - `dataEnrichment.status` → `Reviewed`. The flip happens whether the admin approved every flagged field or only a subset — partial reviews stay in `Reviewed` and the team remains in the list endpoint until all flagged fields land at `score=100, confidence=high`. `Approved` is reserved for an explicit team-level finalization (not exposed through this endpoint).
+   - `dataEnrichment.status` → `Reviewed`. The flip happens whether the admin approved every flagged field or only a subset — partial reviews stay in `Reviewed` and the team remains in the list endpoint until all flagged fields land at `verdict=agrees, confidence=high` (the same pair the judge uses to auto-promote; admin approval normalizes to this with `score=100`). `Approved` is reserved for an explicit team-level finalization (not exposed through this endpoint).
    - `reviewedAt` → now (ISO).
    - `reviewedBy` → requestor email from the JWT (`req.userEmail`).
    - Approved keys removed from `dataEnrichment.judgment.fieldsForReview`.


### PR DESCRIPTION
## Description

* Fix issue on the team's modal window to prevent auto approve non edited fields.
* Add `judge.verdict` property to the GET `v1/admin/teams/enrichment-review` endpoint

## Tickets

- [LAB-1904](https://linear.app/plrs-labos/issue/LAB-1904/team-profileback-office-confirming-one-user-provided-field-leads-to)
- [LAB-1903](https://linear.app/plrs-labos/issue/LAB-1903/team-profileback-office-confirming-one-ai-suggested-field-leads-to)
- [LAB-1902](https://linear.app/plrs-labos/issue/LAB-1902/team-profileback-office-ai-suggested-fields-are-automatically-applied)

