### PR TITLE
LAB-1907 [Team profile][Back office] Team card data don't show up

### DIFF
--- a/apps/back-office/components/teams/data-quality/EditModal.tsx
+++ b/apps/back-office/components/teams/data-quality/EditModal.tsx
@@ -66,6 +66,7 @@ export function EditModal({ team, authToken, onClose }: Props) {
 
   useEffect(() => {
     if (!team) {
+      isSavingRef.current = false;
       setForm(null);
       setInitialForm(null);
       setConfirmedFields(new Set());

--- a/apps/back-office/hooks/teams/useGetTeam.ts
+++ b/apps/back-office/hooks/teams/useGetTeam.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import publicApi from '../../utils/public-api';
+import api from '../../utils/api';
 
 export type TeamDetail = {
   uid: string;
@@ -15,7 +15,7 @@ export type TeamDetail = {
 };
 
 async function fetchTeam(uid: string): Promise<TeamDetail> {
-  const { data } = await publicApi.get<TeamDetail>(`/v1/teams/${uid}`);
+  const { data } = await api.get<TeamDetail>(`/v1/admin/teams/${uid}`);
   return data;
 }
 

--- a/apps/web-api/src/admin/admin-teams.controller.ts
+++ b/apps/web-api/src/admin/admin-teams.controller.ts
@@ -317,4 +317,15 @@ export class AdminTeamsController {
       pageSize: pageSize ? parseInt(pageSize, 10) : undefined,
     });
   }
+
+  /**
+   * Admin single-team detail for the data-quality review modal. Unlike the public
+   * GET /v1/teams/:uid, this returns inactive (L0) teams too. Declared last so the
+   * static GET routes above (enrichment-review, enrichment-status, ai-report) match first.
+   */
+  @Get('/:uid')
+  @NoCache()
+  async getTeamForReview(@Param('uid') uid: string) {
+    return this.adminTeamsService.getTeamForReview(uid);
+  }
 }

--- a/apps/web-api/src/admin/admin-teams.service.ts
+++ b/apps/web-api/src/admin/admin-teams.service.ts
@@ -210,6 +210,34 @@ export class AdminTeamsService {
     };
   }
 
+  /**
+   * Single-team detail for the data-quality review modal. Unlike the public
+   * teams.service.findTeamByUid, this does NOT gate on accessLevel, so inactive
+   * (L0) teams — which still surface in the enrichment-review list — can be opened
+   * by admins instead of 403-ing ("Team is inactive").
+   */
+  async getTeamForReview(uid: string) {
+    const team = await this.prisma.team.findUnique({
+      where: { uid },
+      select: {
+        uid: true,
+        name: true,
+        website: true,
+        blog: true,
+        contactMethod: true,
+        twitterHandler: true,
+        linkedinHandler: true,
+        shortDescription: true,
+        longDescription: true,
+        logo: { select: { url: true } },
+      },
+    });
+    if (!team) {
+      throw new NotFoundException('Team not found');
+    }
+    return team;
+  }
+
   async updateTeam(uid: string, data: Prisma.TeamUpdateInput) {
     await this.prisma.$transaction(async (tx) => {
       const team = await tx.team.findUnique({ where: { uid } });


### PR DESCRIPTION
## Description

**Issue:** On /teams/data-quality (back-office), clicking Edit on certain teams (e.g. Anjuna) showed "Loading team data…" and then a blank modal with no fields. It appeared random — surfacing after filtering/paginating to different teams.
  
**Cause:** The modal fetched team detail from the public, unauthenticated GET `/v1/teams/:uid`, which returns 403 "Team is inactive" for teams with `accessLevel: 'L0'`. But the admin enrichment-review list (which feeds the table) includes those inactive teams. So opening an L0 team 403'd → the query settled with no data → the form (built only from teamDetail) stayed null → empty body.

 **Fix:**
  - Added an admin endpoint GET `/v1/admin/teams/:uid (AdminAuthGuard)` that returns the detail fields the modal needs without the accessLevel gate, so inactive teams resolve.
  - Repointed the back-office `useGetTeam` hook to that endpoint via the authenticated api instance (token attached automatically).

## Ticket

[LAB-1907](https://linear.app/plrs-labos/issue/LAB-1907/team-profileback-office-team-card-data-dont-show-up-intermittent-issue)


