### PR TITLE
[Team Enrichment] Better descriptions & force re-judge

### DIFF
--- a/apps/web-api/src/admin/admin-teams.controller.ts
+++ b/apps/web-api/src/admin/admin-teams.controller.ts
@@ -295,6 +295,13 @@ export class AdminTeamsController {
     return { success: true, message: `Force-judgment triggered for team ${uid}` };
   }
 
+  @Post('trigger-force-judgment')
+  @NoCache()
+  async triggerForceJudgmentAll() {
+    const result = await this.teamEnrichmentJudgeService.forceJudgeAllEnrichedTeams('manually');
+    return { success: true, ...result, message: 'Force-judgment triggered in background' };
+  }
+
   /**
    * Manually run the VLM logo verification job over every eligible team
    * right now, instead of waiting for the next `LOGO_VERIFICATION_CRON`

--- a/apps/web-api/src/team-enrichment/team-enrichment-ai.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-ai.service.ts
@@ -37,6 +37,7 @@ CRITICAL REQUIREMENTS:
 2. Never fabricate URLs - only return URLs you found in search results
 3. LinkedIn handlers should be in format "company/name" (without full URL)
 4. Pay close attention to the EXACT entity name provided. If multiple entities with similar names exist, choose the one that EXACTLY matches the provided name.
+5. If you cannot find credible information for a field, return null for it. NEVER narrate the search itself. Text such as "No specific … was found", "I could not find …", "the name is generic", "unfortunately …", or any explanation of what you couldn't find is NOT a valid value — it is junk. This applies especially to shortDescription / longDescription / moreDetails: a description must describe the team, never the search. When in doubt, return null.
 
 WEBSITE DISCOVERY:
 - The company may have its own standalone domain OR a dedicated page on a parent organization's website
@@ -78,7 +79,7 @@ FIELDS TO POPULATE:
    - Key features or differentiators
    - Portfolio companies (if investment fund)
    - Partnerships or integrations
-   NEVER leave this empty if any additional information was found.
+   NEVER leave this empty if any additional information was found. But if you found NO additional information, return null — do NOT write a sentence explaining that nothing was found.
 
 10. industryTags: Array of 2-6 SHORT industry/sector tags (1-3 words each) describing the industry or sector the company operates in.
    Examples: ["Blockchain", "DeFi", "AI", "Cloud Infrastructure", "Developer Tools", "Data Analytics", "Gaming", "NFT", "Privacy", "Fintech", "SaaS", "IoT", "Cybersecurity"]

--- a/apps/web-api/src/team-enrichment/team-enrichment-field-shape.util.spec.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-field-shape.util.spec.ts
@@ -1,4 +1,4 @@
-import { isLikelyValueForField } from './team-enrichment-field-shape.util';
+import { isLikelyValueForField, looksLikeAiNonAnswer } from './team-enrichment-field-shape.util';
 
 describe('isLikelyValueForField', () => {
   describe('website / blog', () => {
@@ -137,16 +137,57 @@ describe('isLikelyValueForField', () => {
     });
   });
 
-  describe('fields without a shape gate', () => {
-    it('shortDescription / longDescription / moreDetails always pass non-empty values', () => {
+  describe('free-text fields (descriptions)', () => {
+    it('passes genuine prose', () => {
       expect(isLikelyValueForField('shortDescription', 'A short blurb about the company.')).toBe(true);
       expect(isLikelyValueForField('longDescription', 'A long blurb.')).toBe(true);
       expect(isLikelyValueForField('moreDetails', 'Founded 2010 in Cambridge.')).toBe(true);
     });
 
+    it('does not trip on legitimate prose that resembles narration vocabulary', () => {
+      expect(isLikelyValueForField('moreDetails', 'Acme was founded in 2019 by Jane Doe.')).toBe(true);
+      expect(
+        isLikelyValueForField('shortDescription', 'Its embedded wallets are widely used across consumer crypto apps.')
+      ).toBe(true);
+      expect(
+        isLikelyValueForField('longDescription', 'A non-profit library of millions of free books, movies, and websites.')
+      ).toBe(true);
+    });
+
+    it('rejects AI search-failure narration in place of a description', () => {
+      expect(
+        isLikelyValueForField(
+          'shortDescription',
+          'No specific investment fund named "Angel Fund" was found that exactly matches the provided name. The term "angel fund" is widely used generically to describe a type of early-stage investment vehicle.'
+        )
+      ).toBe(false);
+      expect(isLikelyValueForField('longDescription', 'I could not find any information about this company.')).toBe(false);
+      expect(isLikelyValueForField('moreDetails', 'Unfortunately, no official website was found for this entity.')).toBe(
+        false
+      );
+    });
+
     it('rejects empty values uniformly', () => {
       expect(isLikelyValueForField('shortDescription', '')).toBe(false);
       expect(isLikelyValueForField('moreDetails', '   ')).toBe(false);
+    });
+  });
+
+  describe('looksLikeAiNonAnswer', () => {
+    it('flags search-failure narration', () => {
+      expect(looksLikeAiNonAnswer('No specific company was found matching that name.')).toBe(true);
+      expect(looksLikeAiNonAnswer('Could not locate a verifiable LinkedIn page for the team.')).toBe(true);
+      expect(looksLikeAiNonAnswer('The name appears to be a generic term and does not match a specific company.')).toBe(
+        true
+      );
+    });
+
+    it('does not flag genuine descriptions or empty input', () => {
+      expect(looksLikeAiNonAnswer('Filecoin Foundation supports the growth of the Filecoin ecosystem.')).toBe(false);
+      expect(looksLikeAiNonAnswer('The fund invests in early-stage Web3 infrastructure startups.')).toBe(false);
+      expect(looksLikeAiNonAnswer('')).toBe(false);
+      expect(looksLikeAiNonAnswer(null)).toBe(false);
+      expect(looksLikeAiNonAnswer(undefined)).toBe(false);
     });
   });
 });

--- a/apps/web-api/src/team-enrichment/team-enrichment-field-shape.util.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-field-shape.util.ts
@@ -24,6 +24,40 @@ const TELEGRAM_HANDLE_BARE = /^[A-Za-z0-9_]{3,32}$/;
 // LinkedIn: `company/<slug>`, `school/<slug>`, `in/<slug>`, or bare `<slug>`.
 const LINKEDIN_SLUG = /^(?:company|school|in)\/[A-Za-z0-9_.-]{2,100}$|^[A-Za-z0-9_.-]{2,100}$/;
 
+// Free-text fields where the AI is supposed to return PROSE about the team.
+const FREE_TEXT_FIELDS = new Set<FieldMetaKey>(['shortDescription', 'longDescription', 'moreDetails']);
+
+// Narration the model emits when it found nothing instead of returning null —
+// e.g. `No specific investment fund named "Angel Fund" was found that exactly
+// matches the provided name. The term "angel fund" is widely used generically…`.
+// These are failures disguised as content; a real description never talks about
+// the search itself. Patterns are deliberately anchored on search-meta phrasing
+// ("no X was found", "could not find", "the name is generic") so they don't trip
+// on legitimate prose (e.g. "Acme was founded in 2019" — "founded", not "found").
+const AI_NON_ANSWER_PATTERNS: RegExp[] = [
+  /\b(?:could ?n['’]?t|could not|cannot|can ?not|unable to|was(?:n['’]?t| not) able to|were(?:n['’]?t| not) able to|failed to)\s+(?:find|locate|identify|verify|confirm|determine|establish)\b/i,
+  /\bno\b[^.?!]{0,80}?\b(?:was|were|is|are|could be)\b[^.?!]{0,20}?\bfound\b/i,
+  /\bno\s+(?:specific|exact|official|public|verifiable|reliable|credible|additional|further|relevant|matching)\b[^.?!]{0,80}?\b(?:information|details|data|company|fund|organization|organisation|entity|website|profile|match|results?)\b/i,
+  /\bno\s+(?:information|details|data|results?)\b[^.?!]{0,40}?\b(?:available|found|exist)/i,
+  /\b(?:does|did|do)\s+not\s+(?:appear\s+to\s+)?(?:exist|match|correspond)\b/i,
+  /\bwidely\s+used\s+(?:generic|generically)\b/i,
+  /\b(?:is|are|term|name|phrase)\b[^.?!]{0,40}?\bgeneric(?:ally)?\b[^.?!]{0,40}?\b(?:term|name|phrase|descript|used)/i,
+  /\bI\s+(?:was unable|could not|could ?n['’]?t|cannot|can ?not|don['’]?t have|do not have)\b/i,
+  /\b(?:unfortunately|regrettably)\b/i,
+  /\bbased on (?:my|the available) (?:search|research|sources)\b[^.?!]{0,40}?\b(?:no|could ?n['’]?t|unable)\b/i,
+];
+
+/**
+ * True when a free-text value reads like the model narrating a failed search
+ * rather than describing the team. Used to reject "I couldn't find…" text from
+ * description fields. Only meaningful for `FREE_TEXT_FIELDS`.
+ */
+export function looksLikeAiNonAnswer(raw: string | null | undefined): boolean {
+  const v = raw?.trim();
+  if (!v) return false;
+  return AI_NON_ANSWER_PATTERNS.some((re) => re.test(v));
+}
+
 export function isLikelyValueForField(field: FieldMetaKey, raw: string): boolean {
   const v = raw.trim();
   if (!v) return false;
@@ -68,9 +102,16 @@ export function isLikelyValueForField(field: FieldMetaKey, raw: string): boolean
       return TELEGRAM_HANDLE_BARE.test(handle);
     }
 
+    case 'shortDescription':
+    case 'longDescription':
+    case 'moreDetails':
+      // Free text has no structural shape, but reject search-failure narration
+      // the AI sometimes emits in place of null ("No specific … was found …").
+      return !looksLikeAiNonAnswer(v);
+
     default:
-      // Descriptions, moreDetails, industry/investment arrays — no structural
-      // gate. Empty already filtered by the trim() above.
+      // Industry/investment arrays — no structural gate. Empty already filtered
+      // by the trim() above.
       return true;
   }
 }

--- a/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-judge.service.ts
@@ -39,6 +39,7 @@ import {
   FieldEnrichmentStatus,
   FieldJudgment,
   FieldMetaKey,
+  FIELD_JUDGMENT_NOTE_MAX_LENGTH,
   JudgmentSource,
   JudgmentStatus,
   JudgmentVerdict,
@@ -104,6 +105,21 @@ type TeamEnrichmentSnapshot = {
 };
 
 type FieldsMetaMap = Partial<Record<FieldMetaKey, FieldEnrichmentMeta>>;
+
+/**
+ * Free-text fields that paraphrase the team's own LinkedIn / website copy. They
+ * are judged on CONTENT, and fuzzy methods (text overlap, AI core-facts check)
+ * intentionally start them at `medium`. See the identity-corroborated upshift in
+ * `runJudgmentPipeline`.
+ */
+const DESCRIPTION_FIELD_KEYS: readonly FieldMetaKey[] = ['shortDescription', 'longDescription', 'moreDetails'];
+
+/**
+ * Identity anchors. Confirming any one at `agrees+high` means we know WHICH
+ * real-world entity this team is — which is what licenses trusting an
+ * already-`agrees` description without an admin double-check.
+ */
+const IDENTITY_ANCHOR_FIELDS: readonly FieldMetaKey[] = ['website', 'linkedinHandler', 'twitterHandler'];
 
 export type JudgeTeamResult =
   | { status: 'started' | 'already_judged' | 'in_progress' | 'not_found' | 'not_eligible' };
@@ -214,6 +230,40 @@ export class TeamEnrichmentJudgeService {
   }
 
   /**
+   * Force-judge population: eligible teams whose enrichment is `Enriched` and
+   * that have ≥1 judgable field — REGARDLESS of current judgment status. Unlike
+   * {@link findTeamsPendingJudgment}, this deliberately INCLUDES already-`Judged`
+   * teams so a full re-judge re-runs them (the force analog of the pending
+   * trigger). `InProgress` teams are excluded here and also guarded per-team by
+   * {@link forceJudgeTeam}. Admin-finalized states (Reviewed/Approved) are left
+   * out of the bulk path — re-judging a settled team is done one-off via the
+   * single-team `trigger-force-judgment` endpoint.
+   */
+  async findTeamsForForceJudgment(): Promise<TeamRecord[]> {
+    await this.resetStaleInProgressJudgment();
+
+    const candidates = (await this.prisma.team.findMany({
+      where: {
+        AND: [
+          buildTeamEnrichmentEligibilityFilter(),
+          {
+            teamEnrichment: {
+              dataEnrichment: { path: ['status'], equals: EnrichmentStatus.Enriched },
+            },
+          },
+        ],
+      },
+      select: TEAM_RECORD_SELECT,
+    })) as unknown as TeamRecord[];
+
+    return candidates.filter((t) => {
+      const meta = this.parseEnrichmentMeta(t.teamEnrichment?.dataEnrichment);
+      if (meta?.judgment?.status === JudgmentStatus.InProgress) return false;
+      return this.collectJudgableFieldKeys(t, meta?.fieldsMeta ?? {}).length > 0;
+    });
+  }
+
+  /**
    * Self-heals rows whose `dataEnrichment.judgment.status = 'InProgress'` and `updatedAt`
    * is older than the stuck-TTL — the pod was killed mid-judge. Drops the `judgment` block
    * so the team is judgable again on this same call.
@@ -314,6 +364,28 @@ export class TeamEnrichmentJudgeService {
     let skipped = 0;
     for (const team of teams) {
       const { status } = await this.judgeTeam(team.uid, judgedBy);
+      if (status === 'started') started++;
+      else skipped++;
+    }
+    return { total: teams.length, started, skipped };
+  }
+
+  /**
+   * Force re-judge of every eligible Enriched team, INCLUDING already-judged
+   * ones — the bulk analog of `forceJudgeTeam`, mirroring
+   * `TeamEnrichmentService.forceEnrichAllCompletedTeams`. Each per-team judge is
+   * fire-and-forget (see `forceJudgeTeam`), so this kicks off the population in
+   * the background and returns counts immediately.
+   */
+  async forceJudgeAllEnrichedTeams(
+    judgedBy = 'manually'
+  ): Promise<{ total: number; started: number; skipped: number }> {
+    const teams = await this.findTeamsForForceJudgment();
+    this.logger.log(`Force judge all: found ${teams.length} enriched teams to re-judge`);
+    let started = 0;
+    let skipped = 0;
+    for (const team of teams) {
+      const { status } = await this.forceJudgeTeam(team.uid, judgedBy);
       if (status === 'started') started++;
       else skipped++;
     }
@@ -527,6 +599,38 @@ export class TeamEnrichmentJudgeService {
       const refreshedMeta = await this.readEnrichmentMeta(teamUid);
       const baseFieldsMeta = refreshedMeta?.fieldsMeta ?? existingMeta.fieldsMeta ?? {};
       const mergedFieldsMeta: FieldsMetaMap = { ...baseFieldsMeta };
+
+      // Identity-corroborated description upshift.
+      // A description verdict that is already `agrees` but only `medium` was
+      // hedged over PHRASING variance, not a factual disagreement — descriptions
+      // are paraphrases of the team's own LinkedIn / website copy, and both the
+      // ScrapingDog text-overlap comparator and the AI judge deliberately start
+      // them at `medium` because the method is fuzzy. Once the team's IDENTITY is
+      // independently confirmed (a website / LinkedIn / Twitter anchor verified at
+      // `agrees+high` this run or on a prior run), that `medium` is the only thing
+      // keeping a correct description in the admin queue — the review endpoint
+      // flags anything below `agrees+high`. Lift it to `high` so it auto-promotes.
+      //
+      // Scope is deliberately narrow: only `agrees` is lifted (genuine
+      // `uncertain`/`disagrees` content doubt still surfaces for review), and only
+      // description fields (Enriched identity/social candidates still require their
+      // own independent verification — trust-transfer doctrine forbids riding one
+      // anchor to promote another identity field).
+      const resolveAnchorJudgment = (f: FieldMetaKey): FieldJudgment | undefined =>
+        allVerdicts[f] ?? baseFieldsMeta[f]?.judgment;
+      const identityCorroborated = IDENTITY_ANCHOR_FIELDS.some((f) => isAgreesHigh(resolveAnchorJudgment(f)));
+      if (identityCorroborated) {
+        for (const f of DESCRIPTION_FIELD_KEYS) {
+          const v = allVerdicts[f];
+          if (v?.verdict === JudgmentVerdict.Agrees && v.confidence === FieldConfidence.Medium) {
+            const note = (v.note ? `${v.note} + identity corroborated` : 'identity corroborated').slice(
+              0,
+              FIELD_JUDGMENT_NOTE_MAX_LENGTH
+            );
+            allVerdicts[f] = { ...v, confidence: FieldConfidence.High, note };
+          }
+        }
+      }
 
       // Non-destructive: only writes a judgment sub-object; never touches status/value/source on
       // Team or TeamEnrichment. ChangedByUser fields are evaluated for review but the user's

--- a/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.spec.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.spec.ts
@@ -1,9 +1,12 @@
 import {
   extractSupersedingTwitterHandle,
+  ScrapingDogCompanyProfile,
   ScrapingDogTwitterProfile,
   TeamEnrichmentScrapingDogService,
+  TeamSnapshotForCompare,
   verifyTwitterProfileMatchesTeam,
 } from './team-enrichment-scrapingdog.service';
+import { FieldConfidence, JudgmentVerdict } from './team-enrichment.types';
 
 /**
  * Unit-tests the small bits of `TeamEnrichmentScrapingDogService` that are
@@ -328,5 +331,70 @@ describe('extractSupersedingTwitterHandle', () => {
     expect(
       extractSupersedingTwitterHandle('Old handle of @oldco-team', 'oldco')
     ).toBeNull();
+  });
+});
+
+describe('compareProfileToTeam — description fields are positive-only', () => {
+  const service = new TeamEnrichmentScrapingDogService();
+
+  const baseProfile = (over: Partial<ScrapingDogCompanyProfile> = {}): ScrapingDogCompanyProfile => ({
+    universalNameId: 'acme',
+    companyName: 'Acme',
+    profilePhoto: null,
+    website: null,
+    tagline: null,
+    about: null,
+    industries: [],
+    specialties: [],
+    founded: null,
+    headquarters: null,
+    linkedinInternalId: null,
+    ...over,
+  });
+  const team = (over: Partial<TeamSnapshotForCompare> = {}): TeamSnapshotForCompare => ({ name: 'Acme', ...over });
+
+  it('emits agrees+high when the tagline overlaps shortDescription', () => {
+    const r = service.compareProfileToTeam(
+      team({ shortDescription: 'Decentralized storage for the web' }),
+      baseProfile({ tagline: 'Decentralized storage for the web' }),
+      'exact'
+    );
+    expect(r.shortDescription?.verdict).toBe(JudgmentVerdict.Agrees);
+    expect(r.shortDescription?.confidence).toBe(FieldConfidence.High);
+  });
+
+  it('emits NO verdict (defers to AI) when the tagline does not overlap — never uncertain', () => {
+    const r = service.compareProfileToTeam(
+      team({ shortDescription: 'Decentralized storage for the web' }),
+      baseProfile({ tagline: 'We sell artisanal coffee beans' }),
+      'exact'
+    );
+    expect(r.shortDescription).toBeUndefined();
+  });
+
+  it('emits NO verdict when the about text does not overlap longDescription', () => {
+    const r = service.compareProfileToTeam(
+      team({ longDescription: 'Acme builds peer-to-peer storage infrastructure for developers.' }),
+      baseProfile({ about: 'A completely unrelated paragraph about coffee roasting and cafes.' }),
+      'exact'
+    );
+    expect(r.longDescription).toBeUndefined();
+  });
+
+  it('emits agrees+medium for moreDetails on a founded-year hit, and nothing on a miss', () => {
+    const hit = service.compareProfileToTeam(
+      team({ moreDetails: 'Acme was founded in 2019 in Berlin.' }),
+      baseProfile({ founded: '2019' }),
+      'exact'
+    );
+    expect(hit.moreDetails?.verdict).toBe(JudgmentVerdict.Agrees);
+    expect(hit.moreDetails?.confidence).toBe(FieldConfidence.Medium);
+
+    const miss = service.compareProfileToTeam(
+      team({ moreDetails: 'Acme builds developer tools.' }),
+      baseProfile({ founded: '2019', headquarters: 'Berlin, Germany' }),
+      'exact'
+    );
+    expect(miss.moreDetails).toBeUndefined();
   });
 });

--- a/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment-scrapingdog.service.ts
@@ -416,20 +416,27 @@ export class TeamEnrichmentScrapingDogService {
       }
     }
 
-    if (team.shortDescription && profile.tagline) {
-      if (textsOverlap(team.shortDescription, profile.tagline, TAGLINE_LEVENSHTEIN_RATIO)) {
-        result.shortDescription = mkVerdict(FieldConfidence.High, JudgmentVerdict.Agrees, 85, 'tagline overlap');
-      } else {
-        result.shortDescription = mkVerdict(FieldConfidence.Medium, JudgmentVerdict.Uncertain, 50, 'tagline differs');
-      }
+    // Description fields: emit a verdict ONLY on a positive overlap. A failed
+    // fuzzy text-overlap is too weak a signal to park the field at `uncertain`
+    // (doctrine: skip rather than guess a negative from one anchor) — the AI's
+    // description content is usually drawn from the website rather than the
+    // LinkedIn tagline/about, so a non-overlap is expected and not a defect.
+    // Returning no verdict here lets the AI judge (Stage 2) be the arbiter
+    // instead of this comparator silently overriding the AI at merge time.
+    if (
+      team.shortDescription &&
+      profile.tagline &&
+      textsOverlap(team.shortDescription, profile.tagline, TAGLINE_LEVENSHTEIN_RATIO)
+    ) {
+      result.shortDescription = mkVerdict(FieldConfidence.High, JudgmentVerdict.Agrees, 85, 'tagline overlap');
     }
 
-    if (team.longDescription && profile.about) {
-      if (sentenceOverlap(team.longDescription, profile.about, ABOUT_SENTENCE_OVERLAP_RATIO)) {
-        result.longDescription = mkVerdict(FieldConfidence.High, JudgmentVerdict.Agrees, 85, 'about overlap');
-      } else {
-        result.longDescription = mkVerdict(FieldConfidence.Medium, JudgmentVerdict.Uncertain, 50, 'about low overlap');
-      }
+    if (
+      team.longDescription &&
+      profile.about &&
+      sentenceOverlap(team.longDescription, profile.about, ABOUT_SENTENCE_OVERLAP_RATIO)
+    ) {
+      result.longDescription = mkVerdict(FieldConfidence.High, JudgmentVerdict.Agrees, 85, 'about overlap');
     }
 
     if (team.industryTags && team.industryTags.length > 0) {
@@ -451,10 +458,11 @@ export class TeamEnrichmentScrapingDogService {
       const text = team.moreDetails.toLowerCase();
       const foundedHit = !!profile.founded && text.includes(profile.founded.toLowerCase());
       const hqHit = !!profile.headquarters && this.extractCity(profile.headquarters).some((c) => text.includes(c));
+      // Positive-only (same reasoning as the description fields above): a missing
+      // founded-year / HQ substring doesn't mean the details are wrong, so defer
+      // the negative to the AI judge rather than emitting `uncertain`.
       if (foundedHit || hqHit) {
         result.moreDetails = mkVerdict(FieldConfidence.Medium, JudgmentVerdict.Agrees, 70, 'details match');
-      } else {
-        result.moreDetails = mkVerdict(FieldConfidence.Medium, JudgmentVerdict.Uncertain, 50, 'details no match');
       }
     }
 

--- a/apps/web-api/src/team-enrichment/team-enrichment.service.ts
+++ b/apps/web-api/src/team-enrichment/team-enrichment.service.ts
@@ -11,7 +11,7 @@ import {
   verifyTwitterProfileMatchesTeam,
 } from './team-enrichment-scrapingdog.service';
 import { deriveTeamFieldsFromLeads } from './team-enrichment-lead-backfill';
-import { isLikelyValueForField } from './team-enrichment-field-shape.util';
+import { isLikelyValueForField, looksLikeAiNonAnswer } from './team-enrichment-field-shape.util';
 import {
   ENRICHABLE_TEAM_FIELDS,
   EnrichableTeamField,
@@ -999,6 +999,7 @@ export class TeamEnrichmentService {
         aiReturnedNull: [],
         aiCannotEnrich: [],
         userJunkOverridden: [],
+        aiNarrationRejected: [],
       };
 
       for (const field of ENRICHABLE_TEAM_FIELDS) {
@@ -1068,7 +1069,16 @@ export class TeamEnrichmentService {
           continue;
         }
 
-        const newValue = aiResponse[field];
+        let newValue = aiResponse[field];
+        // Reject search-failure narration the model sometimes emits for free-text
+        // fields instead of returning null (e.g. `No specific fund named "X" was
+        // found …`). Treat it as "AI returned nothing" so the field falls through
+        // to CannotEnrich / stays empty rather than storing the meta-text as a
+        // description. Same gate the judge/review path uses via isLikelyValueForField.
+        if (typeof newValue === 'string' && looksLikeAiNonAnswer(newValue)) {
+          skipReasons.aiNarrationRejected.push(field);
+          newValue = null;
+        }
         if (newValue) {
           (enrichmentUpdate as any)[field] = newValue;
           newFieldsMeta[field] = {

--- a/docs/TEAM_ENRICHMENT.md
+++ b/docs/TEAM_ENRICHMENT.md
@@ -296,6 +296,8 @@ Anything less than `agrees + high` stays on `TeamEnrichment` only — the user-f
 
    Same doctrine extends to the descriptions / industries / details rows: when the website corroborates, `agrees + medium` text-overlap verdicts (tagline overlap, about overlap, details match, tags overlap) are upshifted to `agrees + high`. This is the bench fix that recovered the `moreDetails` auto-promote rate after ScrapingDog Stage 1 came online (Stage 1 was previously capping these at Medium and overwriting Stage 1.5's high-confidence source-trust verdicts).
 
+   **Description comparators are positive-only.** For `shortDescription` / `longDescription` / `moreDetails`, Stage 1 emits a verdict **only on a positive overlap** (`tagline overlap` / `about overlap` / `details match`). A *failed* fuzzy overlap no longer emits a negative `uncertain` verdict (`tagline differs` / `about low overlap` / `details no match`) — a single weak text-overlap miss is too thin to judge on (doctrine: skip rather than guess a negative from one anchor), and the AI's description usually comes from the team's website rather than the LinkedIn tagline/about, so a non-overlap is expected, not a defect. Returning no verdict lets the AI judge (Stage 2) be the arbiter instead of this comparator silently overriding the AI at merge time. See also the [identity-corroborated description upshift](#identity-corroborated-description-upshift).
+
    **`website` (and other URL fields) — not judged by Stage 1.** Earlier revisions emitted a `host-match` / `host-mismatch` verdict by comparing the team's stored URL to the URL listed on the LinkedIn profile. This produced too many false negatives — companies routinely use alias domains, product subdomains, or rebrand without updating LinkedIn (e.g. team `Mercle` with website `mercle.ai` whose LinkedIn profile lists a different host) — so the comparator was condemning correct websites. The deterministic comparator is therefore intentionally silent on URL fields; the AI judge (Stage 2) verifies them via web search instead, and is explicitly instructed not to disagree on a URL solely because it differs from another URL we already have on file. Same reasoning as the `linkedinHandler` slug-equality removal.
 
    **Website reachability probe.** The judge runs a lightweight reachability probe on the website value being judged (single GET, follows redirects, 8s timeout, **uses the same `BROWSER_REQUEST_HEADERS` bouquet as `fetchWebsiteHtml`** so it doesn't get Cloudflare-blocked on real-but-bot-protected sites). The probe runs **unconditionally** when the team has a judgable website — it was previously nested inside the ScrapingDog success branch, which meant that any team without a `linkedinHandler` (or any ScrapingDog 403) silently skipped the probe and left the AI judge to guess at reachability.
@@ -336,6 +338,18 @@ A pure-function pass inserted between Stage 1 (ScrapingDog) and Stage 2 (AI judg
 `agrees + high` verdicts from Stage 1.5 are merged into the Stage-1 verdict map BEFORE the `stage1Resolved` set is computed — so any corroborated field skips the AI judge entirely and is promoted to `Team.<field>` on the same promotion gate as before. This is the primary mechanism by which the admin review queue shrinks.
 
 **Merge is confidence-aware, not positional.** When both Stage 1 (the ScrapingDog `compareProfileToTeam` comparator) AND Stage 1.5 produce a verdict for the same field, the `agrees + high` verdict is preserved — Stage 1 only overwrites Stage 1.5 when both are at the same tier (or when Stage 1 is `agrees + high`). This guards against Stage 1's fuzzy text-overlap heuristics silently demoting fields that Stage 1.5's source-trust rule already accepted. Bench evidence: an earlier version of this merge let Stage 1 unconditionally overwrite Stage 1.5, which dropped the `moreDetails` auto-promote rate from 47% → 16% and `linkedinHandler` from 97% → 73% once ScrapingDog Stage 1 came online (because `compareProfileToTeam` re-derives the same verdict at a weaker tier — `agrees+medium` from tagline / partial-name overlap — and was overwriting the high-confidence source-trust verdicts).
+
+#### Identity-corroborated description upshift
+
+After all verdicts are merged (Stage 1 + 1.5 + 2), a final pass lifts description verdicts that are `agrees` but only `medium` → `agrees + high` **when the team's identity is independently corroborated**. The rationale: `shortDescription` / `longDescription` / `moreDetails` paraphrase the team's own LinkedIn / website copy, so both the fuzzy text-overlap comparator and the AI judge deliberately start them at `medium` over *phrasing* variance — not a factual disagreement. Once we know **which** real-world entity the team is (any of `website` / `linkedinHandler` / `twitterHandler` verified at `agrees + high`, this run or persisted), that `medium` is the only thing keeping a correct description in the review queue — `listEnrichmentsForReview` flags anything below `agrees + high`. Lifting it auto-promotes the description.
+
+Scope is deliberately narrow:
+
+- Only `agrees` verdicts are lifted. Genuine `uncertain` / `disagrees` content doubt still surfaces for review.
+- Only the three description fields. Per trust-transfer doctrine, `Enriched` identity / social candidates still require their **own** independent verification — confirming one anchor never promotes a *different* identity field.
+- The original judge `note` is preserved with an `+ identity corroborated` marker (truncated to the 60-char note limit) so the upgrade is auditable.
+
+This is why a description blocked only on a `medium` confidence no longer pins its team in the admin queue when that team already has a verified website / LinkedIn / Twitter — which is the common case.
 
 #### Rule index
 
@@ -588,7 +602,10 @@ The validator rejects values **by structure**, not by enumerating placeholder st
 | `twitterHandler` | 1-15 alphanumeric / underscore (with optional `@` prefix or full `twitter.com` / `x.com` URL) | `acme team` (space), `acme-team` (hyphen), `n/a`, anything >15 chars |
 | `linkedinHandler` | `company/<slug>`, `school/<slug>`, `in/<slug>`, bare slug (2-100 alphanumeric / `_` / `-` / `.`), or full `linkedin.com/...` URL | `Coming soon!`, `n/a` |
 | `telegramHandler` | 3-32 alphanumeric / underscore (with optional `@` prefix or full `t.me` / `telegram.me` URL) | `@ab` (too short), `n/a`, `Coming soon!` |
-| descriptions, `moreDetails`, array fields (`industryTags` / `investmentFocus`) | any non-empty value | empty / whitespace-only / empty array |
+| `shortDescription` / `longDescription` / `moreDetails` | any non-empty prose that is NOT AI search-failure narration | empty / whitespace-only; AI "non-answer" text (see below) |
+| array fields (`industryTags` / `investmentFocus`) | any non-empty value | empty / whitespace-only / empty array |
+
+**AI non-answer rejection (description fields).** The enrichment AI sometimes narrates a failed search into a description instead of returning `null` — e.g. `No specific investment fund named "Angel Fund" was found that exactly matches the provided name. The term "angel fund" is widely used generically…`. `looksLikeAiNonAnswer` (in `team-enrichment-field-shape.util.ts`) flags that text by structure — search-meta phrasing like "no X was found", "could not find/locate", "unfortunately", "the name is generic" — and `isLikelyValueForField` rejects it for the three description fields. Two layers enforce this: (1) the enrichment AI prompt instructs the model to return `null` and never narrate; (2) the enrichment write path drops a narration value before it is persisted (logged under `aiNarrationRejected=[...]`), so the field is recorded as `CannotEnrich` / left empty rather than storing the meta-text. The patterns are anchored on search-meta phrasing so they don't trip on legitimate prose ("Acme **was founded** in 2019", "widely **used across** consumer apps").
 
 Two design choices worth noting:
 
@@ -664,10 +681,13 @@ Both the judge (Stage 1) and the enrichment pipeline (ScrapingDog branch) distin
 ```
 POST /v1/admin/teams/:uid/trigger-judgment           # Run judge for a team (skips if already judged)
 POST /v1/admin/teams/trigger-judgment                # Run judge for all pending teams
-POST /v1/admin/teams/:uid/trigger-force-judgment     # Re-run judge even if already judged
+POST /v1/admin/teams/:uid/trigger-force-judgment     # Re-run judge for one team even if already judged
+POST /v1/admin/teams/trigger-force-judgment          # Re-run judge for ALL eligible Enriched teams (incl. already-judged)
 ```
 
 All require `AdminAuthGuard`. They do NOT require `IS_TEAM_ENRICHMENT_ENABLED` — manual overrides.
+
+`trigger-force-judgment` (all) is the force analog of `trigger-force-enrichment` (all): it selects every eligibility-filtered team whose enrichment status is `Enriched` and that has ≥1 judgable field — **including** teams already `Judged` (that is the difference from the pending `trigger-judgment`, which skips them). Each team is re-judged fire-and-forget in the background; the response returns `{ total, started, skipped }` immediately. `InProgress` teams are skipped (per-team guard), and admin-finalized states (`Reviewed`/`Approved`) are left out of the bulk path — re-judge those one-off via the single-team `:uid/trigger-force-judgment`.
 
 ## Logo Verification (Vision-Model Pass)
 


### PR DESCRIPTION
## Summary

Three related improvements to Team Enrichment: stop storing AI "I couldn't find anything" text as a description, stop sending correct descriptions to admin review when the team's identity is already verified, and add an admin endpoint to re-run the AI judge across all teams.

## Changes

### 1. Reject AI non-answer text in descriptions

The enrichment AI occasionally wrote a narration of its failed search into a description field instead of leaving it empty — e.g. *"No specific investment fund named 'Angel Fund' was found that exactly matches the provided name. The term 'angel fund' is widely used generically…"*. That is not a description.

The AI is now instructed to return nothing when it can't find real information, and a safety check rejects this kind of "couldn't find / not found / generic term / unfortunately…" text before it is ever saved, so it no longer appears on team profiles or in the review queue. Legitimate descriptions are unaffected.

### 2. Fewer descriptions stuck in admin review

Descriptions are paraphrases of a team's own LinkedIn / website copy, so the judge often rated them "correct, but medium confidence" purely because the wording differed — and a medium-confidence field still showed up for an admin to review. Notes like *"about low overlap"* or *"tagline differs"* were appearing on descriptions that were actually fine, and almost always on teams that already had a verified website and/or social links.

Now:

- When a team's identity is independently confirmed (a verified website, LinkedIn, or Twitter), a description the judge already agreed with is treated as high-confidence and auto-approved instead of being queued for review.
- The deterministic LinkedIn check no longer flags a description as doubtful just because it doesn't textually overlap the LinkedIn tagline/about — it defers to the AI judge, which weighs the team's other verified signals.

**Impact (measured on the 104-team production sample):** teams in the review queue dropped from **68 → 45 (−34%)** from the confidence change alone, with further reductions once teams are re-judged. Genuinely doubtful descriptions still surface for review.

### 3. New admin endpoint: force re-judge all teams

`POST /v1/admin/teams/trigger-force-judgment`

We already had a per-team force re-judge and an "all pending" trigger, but no way to re-run the judge across **every** eligible team — including ones already judged. This adds that, mirroring the existing all-teams force-enrichment endpoint: it re-judges all eligible enriched teams in the background and returns how many were started vs skipped. Useful after a judge/rule change to refresh the whole review queue without touching teams one by one.

