### PR TITLE
LAB-1987 [Gantry] Update in-app notifications

### DIFF
--- a/apps/web-api/src/roadmap/roadmap.constants.ts
+++ b/apps/web-api/src/roadmap/roadmap.constants.ts
@@ -54,25 +54,27 @@ export function itemDetailPath(itemUid: string): string {
  * All user-facing roadmap notification copy lives here so a wording change is a
  * one-file swap. Each entry maps to the bell's title + description fields.
  */
+// Titles lead with the status — item titles can be long or weird, so the status
+// prefix keeps the bell scannable.
 export const ROADMAP_NOTIFICATION_COPY = {
   newSubmission: (title: string) => ({
-    title: `New need: "${title}"`,
+    title: `New need: ${title}`,
     description: 'Take a look — boost it if it matters to you.',
   }),
   boostReturned: (title: string) => ({
-    title: `"${title}" is now in progress`,
+    title: `In Progress: ${title}`,
     description: 'Your boost budget is back — spend it on what matters next.',
   }),
   backedItemShipped: (title: string) => ({
-    title: `"${title}" just shipped 🎉`,
+    title: `Just Shipped: ${title} 🎉`,
     description: 'Something you boosted is now live.',
   }),
   needShipped: (title: string) => ({
-    title: `Your need "${title}" just shipped 🎉`,
+    title: `Just Shipped: ${title} 🎉`,
     description: "It's live now — go try it out.",
   }),
   needDeclined: (title: string, reason: string) => ({
-    title: `Your need "${title}" was not taken forward`,
+    title: `Declined: ${title}`,
     description: `Reason: ${reason}`,
   }),
 } as const;

--- a/apps/web-api/src/roadmap/roadmap.service.spec.ts
+++ b/apps/web-api/src/roadmap/roadmap.service.spec.ts
@@ -320,7 +320,7 @@ describe('RoadmapService', () => {
         expect(pushNotifications.create).toHaveBeenCalledTimes(1);
         expect(pushNotifications.create).toHaveBeenCalledWith(
           expect.objectContaining({
-            title: 'New need: "Test"',
+            title: 'New need: Test',
             description: 'Take a look — boost it if it matters to you.',
             link: expect.stringContaining('/gantry/item-1'),
             requiredPermissions: ['roadmap.view', 'roadmap.admin'],
@@ -365,7 +365,7 @@ describe('RoadmapService', () => {
         );
         expect(boostReturnedCalls.map(([dto]: [any]) => dto.recipientUid)).toEqual(['pinner-1', 'pinner-2']);
         expect(boostReturnedCalls[0][0]).toMatchObject({
-          title: '"Test" is now in progress',
+          title: 'In Progress: Test',
           description: 'Your boost budget is back — spend it on what matters next.',
           link: expect.stringContaining('/gantry/item-1'),
         });
@@ -413,7 +413,7 @@ describe('RoadmapService', () => {
         );
         expect(shippedBackerCalls.map(([dto]: [any]) => dto.recipientUid)).toEqual(['pinner-1', 'pinner-2']);
         expect(shippedBackerCalls[0][0]).toMatchObject({
-          title: '"Test" just shipped 🎉',
+          title: 'Just Shipped: Test 🎉',
           description: 'Something you boosted is now live.',
         });
 
@@ -423,7 +423,7 @@ describe('RoadmapService', () => {
         );
         expect(creatorCalls).toHaveLength(1);
         expect(creatorCalls[0][0]).toMatchObject({
-          title: 'Your need "Test" just shipped 🎉',
+          title: 'Just Shipped: Test 🎉',
           description: "It's live now — go try it out.",
           metadata: expect.objectContaining({ trigger: 'need_shipped' }),
         });

--- a/docs/GANTRY.md
+++ b/docs/GANTRY.md
@@ -157,11 +157,11 @@ the planned "pin"→"boost" wording swap is a one-file change. Links point at
 
 | Trigger | Recipients | Title — Description |
 | --- | --- | --- |
-| New need submitted (IDEA only — curator direct-creates don't broadcast) | everyone holding `roadmap.view` or `roadmap.admin` (one permission-gated notification, not per-member fan-out; the submitter is excluded — `PushNotificationsService` hides GANTRY broadcasts from their `metadata.authorUid`) | New need: "{title}" — Take a look — boost it if it matters to you. |
-| Item enters In Progress | each member whose pin was just auto-released | "{title}" is now in progress — Your boost budget is back — spend it on what matters next. |
-| Item ships | every member who ever pinned it (released pins included, deduped; creator excluded — they get the dedicated line below) | "{title}" just shipped 🎉 — Something you boosted is now live. |
-| Item ships | original submitter | Your need "{title}" just shipped 🎉 — It's live now — go try it out. |
-| Need declined | original submitter | Your need "{title}" was not taken forward — Reason: {reason} |
+| New need submitted (IDEA only — curator direct-creates don't broadcast) | everyone holding `roadmap.view` or `roadmap.admin` (one permission-gated notification, not per-member fan-out; the submitter is excluded — `PushNotificationsService` hides GANTRY broadcasts from their `metadata.authorUid`) | New need: {title} — Take a look — boost it if it matters to you. |
+| Item enters In Progress | each member whose pin was just auto-released | In Progress: {title} — Your boost budget is back — spend it on what matters next. |
+| Item ships | every member who ever pinned it (released pins included, deduped; creator excluded — they get the dedicated line below) | Just Shipped: {title} 🎉 — Something you boosted is now live. |
+| Item ships | original submitter | Just Shipped: {title} 🎉 — It's live now — go try it out. |
+| Need declined | original submitter | Declined: {title} — Reason: {reason} |
 
 No double-fire on IN_PROGRESS → SHIPPED: pins are released exactly once (at
 IN_PROGRESS), so the boost-returned notification cannot repeat at SHIPPED. Moves to


### PR DESCRIPTION
## Description

Update Gantry notifications:
<img width="910" height="252" alt="Screenshot 2026-06-11 at 9 19 49 AM" src="https://github.com/user-attachments/assets/53f709ad-ec3e-4573-869c-2e3035de1ed1" />


## Screenshots:
### Gantry
<img width="443" height="499" alt="Screenshot 2026-06-11 at 9 19 10 AM" src="https://github.com/user-attachments/assets/a5ebdbe8-18ea-434b-b08e-a38d1732b952" />



### In-app notifications:
<img width="1219" height="822" alt="Screenshot 2026-06-11 at 9 17 30 AM" src="https://github.com/user-attachments/assets/241e9898-cd87-404f-808f-209729de35b3" />



## Ticket

[LAB-1987](https://linear.app/plrs-labos/issue/LAB-1987/gantry-implement-3-in-app-notifications-for-the-gantryroadmap-module)