### PR TITLE
LAB-2006 [Team News] Add a subscribe > emails when the news is updated

### DIFF
--- a/apps/web-api/src/team-news/team-news-query.service.ts
+++ b/apps/web-api/src/team-news/team-news-query.service.ts
@@ -8,6 +8,7 @@ import type {
   TeamNewsItemDto,
   TeamNewsListQuery,
   TeamNewsListResponse,
+  TeamNewsRecentResponse,
 } from 'libs/contracts/src/schema/team-news';
 import { buildTeamNewsEventDateWhere } from './team-news-event-date.where';
 import { TEAM_NEWS_EXCLUDED_TEAM_NAMES } from './team-news-public-list.config';
@@ -169,6 +170,65 @@ export class TeamNewsQueryService {
           items,
         };
       }),
+    };
+  }
+
+  /**
+   * Recent network news across all teams for the combined daily digest email's
+   * "Latest Network News" section. Consumed by the notification service.
+   *
+   * Selection is by ingestion time (`createdAt`) over the half-open watermark
+   * window `(sinceCreatedAt, untilCreatedAt]`. The notification service passes
+   * sinceCreatedAt = the start of the previous successful digest run and
+   * untilCreatedAt = the start of the current run, so each item is delivered in
+   * exactly one digest — no gaps, no duplicates — even though `eventDate` can
+   * trail ingestion by days. Items are still ordered/displayed by `eventDate`,
+   * matching the public feed. Applies the same excluded-team filter as the feed.
+   *
+   * Defaults (used only if the caller omits a bound, e.g. the very first run):
+   * untilCreatedAt = now, sinceCreatedAt = until − 1 day.
+   */
+  async getRecentNews(opts: {
+    sinceCreatedAt?: Date;
+    untilCreatedAt?: Date;
+    limit?: number;
+  }): Promise<TeamNewsRecentResponse> {
+    const until = opts.untilCreatedAt ?? new Date();
+    const since = opts.sinceCreatedAt ?? new Date(until.getTime() - 24 * 60 * 60 * 1000);
+    const limit = opts.limit ?? 50;
+
+    const where: Prisma.TeamNewsItemWhereInput = { createdAt: { gt: since, lte: until } };
+    if (TEAM_NEWS_EXCLUDED_TEAM_NAMES.length > 0) {
+      where.NOT = {
+        OR: TEAM_NEWS_EXCLUDED_TEAM_NAMES.map((name) => ({
+          team: { name: { equals: name, mode: 'insensitive' } },
+        })),
+      };
+    }
+
+    const rows = await this.prisma.teamNewsItem.findMany({
+      where,
+      orderBy: [{ eventDate: 'desc' }, { createdAt: 'desc' }],
+      take: limit,
+      include: {
+        team: {
+          select: {
+            uid: true,
+            name: true,
+            logo: { select: { url: true } },
+            teamFocusAreas: { include: { focusArea: true, ancestorArea: true } },
+          },
+        },
+      },
+    });
+
+    const discussions = await this.loadDiscussions(rows.map((r) => r.uid));
+
+    return {
+      generatedAt: new Date().toISOString(),
+      since: since.toISOString(),
+      until: until.toISOString(),
+      items: rows.map((row) => this.toDto(row, discussions.get(row.uid))),
     };
   }
 

--- a/apps/web-api/src/team-news/team-news.controller.ts
+++ b/apps/web-api/src/team-news/team-news.controller.ts
@@ -5,6 +5,7 @@ import { apiTeamNews } from 'libs/contracts/src/lib/contract-team-news';
 import {
   CreateTeamNewsDiscussionRequestSchema,
   TeamNewsListQueryParams,
+  TeamNewsRecentQueryParams,
 } from 'libs/contracts/src/schema/team-news';
 import { NoCache } from '../decorators/no-cache.decorator';
 import { UserTokenValidation } from '../guards/user-token-validation.guard';
@@ -24,7 +25,7 @@ export class TeamNewsController {
     private readonly teamNewsQueryService: TeamNewsQueryService,
     private readonly teamNewsService: TeamNewsService,
     private readonly membersService: MembersService,
-    private readonly accessControl: AccessControlV2Service,
+    private readonly accessControl: AccessControlV2Service
   ) {}
 
   @Api(server.route.getTeamNews)
@@ -48,12 +49,31 @@ export class TeamNewsController {
     return this.teamNewsQueryService.getFilters(params);
   }
 
+  // The notification service pulls this at digest-cron time
+  // to build the "Latest Network News" email section. Selection is by the
+  // ingestion-time watermark window (sinceCreatedAt, untilCreatedAt].
+  @Api(server.route.getTeamNewsRecent)
+  @NoCache()
+  async getTeamNewsRecent(@Req() request: Request) {
+    const { sinceCreatedAt, untilCreatedAt, limit } = TeamNewsRecentQueryParams.parse(request.query);
+    const toDate = (value?: string): Date | undefined => {
+      if (!value) return undefined;
+      const d = new Date(value);
+      return Number.isNaN(d.getTime()) ? undefined : d;
+    };
+    return this.teamNewsQueryService.getRecentNews({
+      sinceCreatedAt: toDate(sinceCreatedAt),
+      untilCreatedAt: toDate(untilCreatedAt),
+      limit,
+    });
+  }
+
   @Api(server.route.createTeamNewsDiscussion)
   @UseGuards(UserTokenValidation)
   async createTeamNewsDiscussion(
     @Param('newsItemUid') newsItemUid: string,
     @Body() body: unknown,
-    @Req() req: Request & { userEmail?: string },
+    @Req() req: Request & { userEmail?: string }
   ) {
     const validated = CreateTeamNewsDiscussionRequestSchema.parse(body);
 

--- a/libs/contracts/src/lib/contract-team-news.ts
+++ b/libs/contracts/src/lib/contract-team-news.ts
@@ -7,6 +7,8 @@ import {
   TeamNewsGroupedResponseSchema,
   TeamNewsListQueryParams,
   TeamNewsListResponseSchema,
+  TeamNewsRecentQueryParams,
+  TeamNewsRecentResponseSchema,
 } from '../schema/team-news';
 import { getAPIVersionAsPath } from '../utils/versioned-path';
 
@@ -39,6 +41,15 @@ export const apiTeamNews = contract.router({
       200: TeamNewsFiltersResponseSchema,
     },
     summary: 'Facet counts for the Team News list',
+  },
+  getTeamNewsRecent: {
+    method: 'GET',
+    path: `${getAPIVersionAsPath('1')}/team-news/recent`,
+    query: TeamNewsRecentQueryParams,
+    responses: {
+      200: TeamNewsRecentResponseSchema,
+    },
+    summary: 'Recent network news across all teams (for the digest email)',
   },
   createTeamNewsDiscussion: {
     method: 'POST',

--- a/libs/contracts/src/schema/team-news.ts
+++ b/libs/contracts/src/schema/team-news.ts
@@ -221,6 +221,33 @@ export const TeamNewsPerTeamResponseSchema = z.object({
   items: z.array(TeamNewsItemSchema),
 });
 
+// Recent network news across all teams, ordered newest-first. Consumed by the
+// notification service (pl-notification-service) when it builds the combined
+// "Daily Forum Digest + Latest Network News" email. Public (no service auth).
+//
+// Selection is by ingestion time (`createdAt`), NOT `eventDate`: the digest is a
+// "what was ingested since the last digest" feed, so the notification service
+// passes a watermark window `(sinceCreatedAt, untilCreatedAt]` = (last
+// successful digest run, this run). createdAt is monotonic and never backdated,
+// which guarantees no gaps and no duplicates across daily runs even though
+// `eventDate` can trail ingestion by days. `eventDate` is still used for display
+// ("19d ago") and ordering, matching the public News feed.
+export const TeamNewsRecentQueryParams = z.object({
+  sinceCreatedAt: z.string().optional(),
+  untilCreatedAt: z.string().optional(),
+  limit: z
+    .preprocess((v) => (v === undefined || v === '' ? undefined : Number(v)), z.number().int().min(1).max(100).optional())
+    .default(50),
+});
+
+export const TeamNewsRecentResponseSchema = z.object({
+  generatedAt: z.string(),
+  // Echo of the resolved watermark window actually applied (after defaults).
+  since: z.string().nullable(),
+  until: z.string(),
+  items: z.array(TeamNewsItemSchema),
+});
+
 export type NewsEventType = z.infer<typeof NewsEventTypeSchema>;
 export type NewsDiscoveryOutcome = z.infer<typeof NewsDiscoveryOutcomeSchema>;
 export type TeamNewsItemDto = z.infer<typeof TeamNewsItemSchema>;
@@ -237,6 +264,8 @@ export type TeamNewsEnrichmentResponseItem = z.infer<typeof TeamNewsEnrichmentSc
 export type TeamWithNewsEnrichment = z.infer<typeof TeamWithNewsEnrichmentSchema>;
 export type TeamsWithNewsEnrichmentResponse = z.infer<typeof TeamsWithNewsEnrichmentResponseSchema>;
 export type TeamNewsPerTeamResponse = z.infer<typeof TeamNewsPerTeamResponseSchema>;
+export type TeamNewsRecentQuery = z.infer<typeof TeamNewsRecentQueryParams>;
+export type TeamNewsRecentResponse = z.infer<typeof TeamNewsRecentResponseSchema>;
 export type TeamNewsDiscussion = z.infer<typeof TeamNewsDiscussionSchema>;
 export type CreateTeamNewsDiscussionRequest = z.infer<typeof CreateTeamNewsDiscussionRequestSchema>;
 export type CreateTeamNewsDiscussionResponse = z.infer<typeof CreateTeamNewsDiscussionResponseSchema>;


### PR DESCRIPTION
# Latest Network News in the Forum Digest emails

## Summary

The **Daily** and **Weekly Forum Digest** emails now include a **Latest Network News** section alongside the existing forum posts. News is pulled from the directory at the moment each digest is sent, so subscribers get the network's recent shipping, raises, partnerships, and milestones in the same email they already receive.

The email is a single combined template per cadence:

- **Daily:** *Daily Forum Digest* + *Latest Network News*
- **Weekly:** *Weekly Forum Digest* + *Latest Network News*

Each section is independent — if there are no forum posts, only the news shows; if there's no new news, only the forum digest shows.

## Who receives what

A member subscribes to the digest at **one** frequency — **daily or weekly, not both**. The news section is included for both groups; each member only ever gets their chosen cadence.

## How it works (high level)

1. The digest runs on its existing schedule (daily, and weekly).
2. When it runs, it gathers the recent forum posts (as before) **and** the network news that has been added since the last successful digest of that same cadence.
3. It renders the combined email and sends it to that cadence's subscribers.

News is selected by **when it was added** (ingestion time), not by the date of the event itself. This matters because an item's event date can be days older than when it actually lands in the system, so "added since the last digest" is the only reliable way to decide what's genuinely new. The relative time shown in the email (e.g. "19d ago") still reflects the **event date**, matching what users see in the on-site "News from the network" feed.

The news section is **best-effort**: if news can't be loaded for any reason, the email still goes out with the forum digest — news never blocks the email.

### Delivered exactly once — no gaps, no duplicates

Each digest covers the window *(last successful send → this send]*. Because that window advances only when a send succeeds, every news item appears in **exactly one** email, and a failed or early run **self-heals** — anything missed is simply included in the next successful send.

## Day-by-day behavior

News is currently added **twice a week** (e.g. Mon & Thu). With **daily** emails, the news section appears only on the days news was added; other days carry just the forum digest.

### Daily — news added Mon & Thu (before that day's send)

| Day | News added | Email contents |
|-----|------------|----------------|
| Sun | — | Daily Forum Digest |
| **Mon** | ✅ | Daily Forum Digest **+ Latest Network News** (Monday's batch) |
| Tue | — | Daily Forum Digest |
| Wed | — | Daily Forum Digest |
| **Thu** | ✅ | Daily Forum Digest **+ Latest Network News** (Thursday's batch) |
| Fri | — | Daily Forum Digest |
| Sat | — | Daily Forum Digest |

So a member sees Latest Network News on **Mon and Thu**; other days it's the forum digest only. Monday's news is **not** repeated on Tue/Wed.

### Daily — news added after that day's send

If news is added *after* a day's email already went out, it's simply included in the **next day's** email instead. Nothing is lost or duplicated.

| Day | News added | Email contents |
|-----|------------|----------------|
| Mon | ✅ (after the send) | Daily Forum Digest (news not in yet) |
| **Tue** | — | Daily Forum Digest **+ Latest Network News** (Monday's batch) |
| Wed | — | Daily Forum Digest |

### Weekly

The weekly email's **Latest Network News** covers the **whole week** — all news added since the previous weekly send (both twice-weekly batches), next to the Weekly Forum Digest.

## Notes & edge cases

- **Self-healing:** if a send fails on a day news was added, that news is included in the next successful send — never dropped.
- **First run / fallback:** on the very first send (no prior history), the news section falls back to "added in the last day," so enabling this does not blast the entire news backlog.
- **Volume cap:** a single send shows up to a sane maximum of news items. Ongoing batches are small, so this only matters for a one-time historical backlog.
- **Display vs. selection:** items are *selected* by when they were added, but *shown* with their event-date relative time — consistent with the on-site news feed.


## Ticket

[LAB-2006](https://linear.app/plrs-labos/issue/LAB-2006/team-news-add-a-subscribe-emails-when-the-news-is-updated)