### PR TITLE
LAB-2022 [Gantry] Save draft API

### DIFF
--- a/apps/web-api/prisma/migrations/20260617130000_add_roadmap_submission_draft/migration.sql
+++ b/apps/web-api/prisma/migrations/20260617130000_add_roadmap_submission_draft/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "RoadmapSubmissionDraft" (
+    "id" SERIAL NOT NULL,
+    "uid" TEXT NOT NULL,
+    "memberUid" TEXT NOT NULL,
+    "variant" TEXT NOT NULL DEFAULT 'idea',
+    "title" TEXT,
+    "description" TEXT,
+    "tags" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "type" TEXT,
+    "stage" TEXT,
+    "objectiveUid" TEXT,
+    "newObjectiveTitle" TEXT,
+    "showCreateObjective" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RoadmapSubmissionDraft_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoadmapSubmissionDraft_uid_key" ON "RoadmapSubmissionDraft"("uid");
+
+-- CreateIndex (one active draft per member)
+CREATE UNIQUE INDEX "RoadmapSubmissionDraft_memberUid_key" ON "RoadmapSubmissionDraft"("memberUid");
+
+-- AddForeignKey
+ALTER TABLE "RoadmapSubmissionDraft" ADD CONSTRAINT "RoadmapSubmissionDraft_memberUid_fkey" FOREIGN KEY ("memberUid") REFERENCES "Member"("uid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -241,6 +241,7 @@ model Member {
   roadmapItemUpvotes        RoadmapItemUpvote[]   @relation("roadmapItemUpvoter")
   roadmapItemPins           RoadmapItemPin[]      @relation("roadmapItemPinner")
   roadmapObjectivesCreated  RoadmapObjective[]    @relation("roadmapObjectiveCreatedBy")
+  roadmapSubmissionDraft    RoadmapSubmissionDraft? @relation("roadmapSubmissionDraftOwner")
 }
 
 model MemberApproval {
@@ -2886,6 +2887,31 @@ model RoadmapObjective {
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   items        RoadmapItem[]
+}
+
+/// Server-persisted snapshot of a member's in-progress Gantry create/submit form, so
+/// the draft follows them across devices and browsers. At most one active draft per
+/// member (unique memberUid). Payload fields are nullable — this is partial, unsaved
+/// form state, not a validated item. `variant` is "idea" | "roadmap"; `stage` mirrors
+/// RoadmapStage but is stored loosely as a string since it is unsubmitted form input.
+model RoadmapSubmissionDraft {
+  id        Int    @id @default(autoincrement())
+  uid       String @unique @default(cuid())
+  memberUid String @unique
+  member    Member @relation("roadmapSubmissionDraftOwner", fields: [memberUid], references: [uid], onDelete: Cascade)
+
+  variant             String   @default("idea")
+  title               String?
+  description         String?
+  tags                String[] @default([])
+  type                String?
+  stage               String?
+  objectiveUid        String?
+  newObjectiveTitle   String?
+  showCreateObjective Boolean  @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 /// Single-row table (id = 1) holding roadmap-wide configuration.

--- a/apps/web-api/src/roadmap/roadmap-drafts.service.spec.ts
+++ b/apps/web-api/src/roadmap/roadmap-drafts.service.spec.ts
@@ -1,0 +1,118 @@
+jest.mock('../analytics/service/analytics.service', () => ({
+  AnalyticsService: jest.fn().mockImplementation(() => ({ trackEvent: jest.fn() })),
+}));
+
+import type { AnalyticsService } from '../analytics/service/analytics.service';
+import type { PrismaService } from '../shared/prisma.service';
+import { ROADMAP_ANALYTICS_EVENTS } from './roadmap.constants';
+import { RoadmapDraftsService } from './roadmap-drafts.service';
+
+const buildPrismaMock = () => ({
+  roadmapSubmissionDraft: {
+    findUnique: jest.fn().mockResolvedValue(null),
+    upsert: jest.fn(),
+    deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+  },
+});
+
+const draftRow = {
+  uid: 'draft-1',
+  memberUid: 'member-1',
+  variant: 'idea',
+  title: 'My idea',
+  description: 'details',
+  tags: ['infra'],
+  type: 'Feature Request',
+  stage: 'IDEA',
+  objectiveUid: null,
+  newObjectiveTitle: null,
+  showCreateObjective: false,
+  updatedAt: new Date('2026-06-17T00:00:00.000Z'),
+};
+
+describe('RoadmapDraftsService', () => {
+  let service: RoadmapDraftsService;
+  let prisma: ReturnType<typeof buildPrismaMock>;
+  let analytics: { trackEvent: jest.Mock };
+
+  beforeEach(() => {
+    prisma = buildPrismaMock();
+    analytics = { trackEvent: jest.fn().mockResolvedValue(undefined) };
+    service = new RoadmapDraftsService(
+      prisma as unknown as PrismaService,
+      analytics as unknown as AnalyticsService
+    );
+  });
+
+  describe('getMyDraft', () => {
+    it('returns null when the member has no draft', async () => {
+      const result = await service.getMyDraft('member-1');
+      expect(result).toEqual({ draft: null });
+      expect(prisma.roadmapSubmissionDraft.findUnique).toHaveBeenCalledWith({ where: { memberUid: 'member-1' } });
+    });
+
+    it('serializes an existing draft', async () => {
+      prisma.roadmapSubmissionDraft.findUnique.mockResolvedValue(draftRow);
+      const result = await service.getMyDraft('member-1');
+      expect(result.draft).toMatchObject({
+        uid: 'draft-1',
+        variant: 'idea',
+        title: 'My idea',
+        tags: ['infra'],
+        stage: 'IDEA',
+        updatedAt: '2026-06-17T00:00:00.000Z',
+      });
+    });
+  });
+
+  describe('upsertMyDraft', () => {
+    it('full-replaces, defaulting omitted fields to empty', async () => {
+      prisma.roadmapSubmissionDraft.upsert.mockResolvedValue({ ...draftRow, variant: 'idea' });
+      await service.upsertMyDraft({ title: 'Only a title' }, 'member-1');
+
+      const args = prisma.roadmapSubmissionDraft.upsert.mock.calls[0][0];
+      expect(args.where).toEqual({ memberUid: 'member-1' });
+      expect(args.update).toEqual({
+        variant: 'idea',
+        title: 'Only a title',
+        description: null,
+        tags: [],
+        type: null,
+        stage: null,
+        objectiveUid: null,
+        newObjectiveTitle: null,
+        showCreateObjective: false,
+      });
+      expect(args.create).toEqual({ memberUid: 'member-1', ...args.update });
+    });
+
+    it('tracks a draft-saved analytics event', async () => {
+      prisma.roadmapSubmissionDraft.upsert.mockResolvedValue({ ...draftRow, variant: 'roadmap' });
+      await service.upsertMyDraft({ variant: 'roadmap' }, 'member-1');
+      expect(analytics.trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: ROADMAP_ANALYTICS_EVENTS.DRAFT_SAVED,
+          distinctId: 'member-1',
+          properties: { variant: 'roadmap' },
+        })
+      );
+    });
+  });
+
+  describe('discardMyDraft', () => {
+    it('reports deleted: false and skips analytics when no draft exists', async () => {
+      const result = await service.discardMyDraft('member-1');
+      expect(result).toEqual({ deleted: false });
+      expect(analytics.trackEvent).not.toHaveBeenCalled();
+    });
+
+    it('reports deleted: true and tracks when a draft is removed', async () => {
+      prisma.roadmapSubmissionDraft.deleteMany.mockResolvedValue({ count: 1 });
+      const result = await service.discardMyDraft('member-1');
+      expect(result).toEqual({ deleted: true });
+      expect(analytics.trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ name: ROADMAP_ANALYTICS_EVENTS.DRAFT_DISCARDED, distinctId: 'member-1' })
+      );
+    });
+  });
+});

--- a/apps/web-api/src/roadmap/roadmap-drafts.service.ts
+++ b/apps/web-api/src/roadmap/roadmap-drafts.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+import { RoadmapSubmissionDraft } from '@prisma/client';
+import { RoadmapSubmissionDraftSchema, UpsertRoadmapDraftSchema } from 'libs/contracts/src/schema/roadmap';
+import { z } from 'zod';
+import { AnalyticsService } from '../analytics/service/analytics.service';
+import { PrismaService } from '../shared/prisma.service';
+import { ROADMAP_ANALYTICS_EVENTS } from './roadmap.constants';
+
+type UpsertDraftBody = z.infer<typeof UpsertRoadmapDraftSchema>;
+type DraftDto = z.infer<typeof RoadmapSubmissionDraftSchema>;
+
+@Injectable()
+export class RoadmapDraftsService {
+  constructor(private readonly prisma: PrismaService, private readonly analytics: AnalyticsService) {}
+
+  async getMyDraft(memberUid: string) {
+    const draft = await this.prisma.roadmapSubmissionDraft.findUnique({ where: { memberUid } });
+    return { draft: draft ? this.toDto(draft) : null };
+  }
+
+  async upsertMyDraft(body: UpsertDraftBody, memberUid: string) {
+    // PUT semantics: the autosave sends the whole form, so omitted fields reset to
+    // their empty defaults rather than being preserved from a previous save.
+    const data = {
+      variant: body.variant ?? 'idea',
+      title: body.title ?? null,
+      description: body.description ?? null,
+      tags: body.tags ?? [],
+      type: body.type ?? null,
+      stage: body.stage ?? null,
+      objectiveUid: body.objectiveUid ?? null,
+      newObjectiveTitle: body.newObjectiveTitle ?? null,
+      showCreateObjective: body.showCreateObjective ?? false,
+    };
+    const draft = await this.prisma.roadmapSubmissionDraft.upsert({
+      where: { memberUid },
+      create: { memberUid, ...data },
+      update: data,
+    });
+    await this.track(ROADMAP_ANALYTICS_EVENTS.DRAFT_SAVED, memberUid, { variant: draft.variant });
+    return { draft: this.toDto(draft) };
+  }
+
+  async discardMyDraft(memberUid: string) {
+    // Idempotent: discarding a non-existent draft is a success, not a 404.
+    const result = await this.prisma.roadmapSubmissionDraft.deleteMany({ where: { memberUid } });
+    const deleted = result.count > 0;
+    if (deleted) {
+      await this.track(ROADMAP_ANALYTICS_EVENTS.DRAFT_DISCARDED, memberUid, {});
+    }
+    return { deleted };
+  }
+
+  private toDto(draft: RoadmapSubmissionDraft): DraftDto {
+    return {
+      uid: draft.uid,
+      variant: draft.variant === 'roadmap' ? 'roadmap' : 'idea',
+      title: draft.title,
+      description: draft.description,
+      tags: draft.tags,
+      type: draft.type,
+      stage: (draft.stage as DraftDto['stage']) ?? null,
+      objectiveUid: draft.objectiveUid,
+      newObjectiveTitle: draft.newObjectiveTitle,
+      showCreateObjective: draft.showCreateObjective,
+      updatedAt: draft.updatedAt.toISOString(),
+    };
+  }
+
+  private async track(name: string, distinctId: string, properties: Record<string, unknown>) {
+    await this.analytics.trackEvent({ name, distinctId, properties });
+  }
+}

--- a/apps/web-api/src/roadmap/roadmap.constants.ts
+++ b/apps/web-api/src/roadmap/roadmap.constants.ts
@@ -16,6 +16,8 @@ export const ROADMAP_ANALYTICS_EVENTS = {
   OBJECTIVE_CREATED: 'gantry_objective_created',
   OBJECTIVE_SET: 'gantry_objective_set',
   PIN_LIMIT_CHANGED: 'gantry_pin_limit_changed',
+  DRAFT_SAVED: 'gantry_draft_saved',
+  DRAFT_DISCARDED: 'gantry_draft_discarded',
 } as const;
 
 /**

--- a/apps/web-api/src/roadmap/roadmap.controller.ts
+++ b/apps/web-api/src/roadmap/roadmap.controller.ts
@@ -15,6 +15,7 @@ import {
   UpdatePinNoteSchema,
   UpdateRoadmapItemSchema,
   UpdateRoadmapSettingsSchema,
+  UpsertRoadmapDraftSchema,
 } from 'libs/contracts/src/schema/roadmap';
 import { NoCache } from '../decorators/no-cache.decorator';
 import { UserTokenCheckGuard } from '../guards/user-token-check.guard';
@@ -22,6 +23,7 @@ import { MembersService } from '../members/members.service';
 import { RbacGuard } from '../rbac/rbac.guard';
 import { RequirePermissions } from '../rbac/rbac.decorator';
 import { ADMIN_PERMISSIONS, ROADMAP_PERMISSIONS } from '../access-control-v2/access-control-v2.constants';
+import { RoadmapDraftsService } from './roadmap-drafts.service';
 import { RoadmapObjectivesService } from './roadmap-objectives.service';
 import { RoadmapPinsService } from './roadmap-pins.service';
 import { RoadmapService } from './roadmap.service';
@@ -41,6 +43,7 @@ export class RoadmapController {
     private readonly roadmapService: RoadmapService,
     private readonly roadmapPinsService: RoadmapPinsService,
     private readonly roadmapObjectivesService: RoadmapObjectivesService,
+    private readonly roadmapDraftsService: RoadmapDraftsService,
     private readonly membersService: MembersService
   ) {}
 
@@ -202,6 +205,29 @@ export class RoadmapController {
     const member = await this.resolveMember(req);
     const parsed = UpdateRoadmapSettingsSchema.parse(body);
     return this.roadmapPinsService.updateSettings(parsed, member.uid);
+  }
+
+  @Api(server.route.getMyRoadmapDraft)
+  @RequirePermissions(VIEW)
+  @NoCache()
+  async getMyRoadmapDraft(@Req() req: Request) {
+    const member = await this.resolveMember(req);
+    return this.roadmapDraftsService.getMyDraft(member.uid);
+  }
+
+  @Api(server.route.upsertMyRoadmapDraft)
+  @RequirePermissions(VIEW)
+  async upsertMyRoadmapDraft(@Body() body: unknown, @Req() req: Request) {
+    const member = await this.resolveMember(req);
+    const parsed = UpsertRoadmapDraftSchema.parse(body ?? {});
+    return this.roadmapDraftsService.upsertMyDraft(parsed, member.uid);
+  }
+
+  @Api(server.route.deleteMyRoadmapDraft)
+  @RequirePermissions(VIEW)
+  async deleteMyRoadmapDraft(@Req() req: Request) {
+    const member = await this.resolveMember(req);
+    return this.roadmapDraftsService.discardMyDraft(member.uid);
   }
 
   private async resolveMember(req: Request & { userEmail?: string }) {

--- a/apps/web-api/src/roadmap/roadmap.module.ts
+++ b/apps/web-api/src/roadmap/roadmap.module.ts
@@ -6,6 +6,7 @@ import { PushNotificationsModule } from '../push-notifications/push-notification
 import { RbacModule } from '../rbac/rbac.module';
 import { SharedModule } from '../shared/shared.module';
 import { RoadmapController } from './roadmap.controller';
+import { RoadmapDraftsService } from './roadmap-drafts.service';
 import { RoadmapObjectivesService } from './roadmap-objectives.service';
 import { RoadmapPinsService } from './roadmap-pins.service';
 import { RoadmapService } from './roadmap.service';
@@ -13,7 +14,7 @@ import { RoadmapService } from './roadmap.service';
 @Module({
   imports: [SharedModule, MembersModule, RbacModule, AccessControlV2Module, PushNotificationsModule, AnalyticsModule],
   controllers: [RoadmapController],
-  providers: [RoadmapService, RoadmapPinsService, RoadmapObjectivesService],
-  exports: [RoadmapService, RoadmapPinsService, RoadmapObjectivesService],
+  providers: [RoadmapService, RoadmapPinsService, RoadmapObjectivesService, RoadmapDraftsService],
+  exports: [RoadmapService, RoadmapPinsService, RoadmapObjectivesService, RoadmapDraftsService],
 })
 export class RoadmapModule {}

--- a/docs/GANTRY.md
+++ b/docs/GANTRY.md
@@ -210,6 +210,11 @@ All models in `apps/web-api/prisma/schema.prisma`:
   item leaves a pinnable stage — released rows are the frozen history.
 - **`RoadmapObjective`** — OKR chip: unique title, display order, assigned items.
 - **`RoadmapSettings`** — single row; `pinLimit` (default 3).
+- **`RoadmapSubmissionDraft`** — server-side snapshot of a member's in-progress
+  create/submit form, so a draft follows them across devices. One row per member
+  (unique `memberUid`); all payload fields (`variant`, `title`, `description`, `tags`,
+  `type`, `stage`, `objectiveUid`, `newObjectiveTitle`, `showCreateObjective`) are
+  nullable partial form state, plus `updatedAt` for the "last edited" UI.
 
 ## API quick reference
 
@@ -230,6 +235,7 @@ Base: `/v1/roadmap` (guards: `UserTokenCheckGuard` + `RbacGuard`). Contracts in
 | `/objectives` | GET / POST | view / item.curate | List / create-or-find objective |
 | `/items/:uid/objective` | PATCH | item.curate | Set/clear an item's objective |
 | `/settings` | GET / PATCH | view / item.curate | Read / tune the pin budget |
+| `/drafts/me` | GET / PUT / DELETE | view | Read (or null) / autosave-upsert / discard the member's own in-progress submission draft |
 
 ## Reference files
 

--- a/libs/contracts/src/lib/contract-roadmap.ts
+++ b/libs/contracts/src/lib/contract-roadmap.ts
@@ -5,7 +5,9 @@ import {
   CreateRoadmapItemSchema,
   CreateRoadmapObjectiveSchema,
   DeclineRoadmapItemSchema,
+  DeleteRoadmapDraftResponseSchema,
   PinRoadmapItemSchema,
+  RoadmapDraftResponseSchema,
   ReorderRoadmapItemsResponseSchema,
   ReorderRoadmapItemsSchema,
   RoadmapBuildButtonClickSchema,
@@ -23,6 +25,7 @@ import {
   UpdatePinNoteSchema,
   UpdateRoadmapItemSchema,
   UpdateRoadmapSettingsSchema,
+  UpsertRoadmapDraftSchema,
 } from '../schema/roadmap';
 import { getAPIVersionAsPath } from '../utils/versioned-path';
 
@@ -217,5 +220,31 @@ export const apiRoadmap = contract.router({
       200: RoadmapSettingsSchema,
     },
     summary: 'Update roadmap settings (curators only)',
+  },
+  getMyRoadmapDraft: {
+    method: 'GET',
+    path: `${getAPIVersionAsPath('1')}/roadmap/drafts/me`,
+    responses: {
+      200: RoadmapDraftResponseSchema,
+    },
+    summary: "Get the current member's in-progress submission draft (or null)",
+  },
+  upsertMyRoadmapDraft: {
+    method: 'PUT',
+    path: `${getAPIVersionAsPath('1')}/roadmap/drafts/me`,
+    body: UpsertRoadmapDraftSchema,
+    responses: {
+      200: RoadmapDraftResponseSchema,
+    },
+    summary: "Create or replace the current member's submission draft (autosave)",
+  },
+  deleteMyRoadmapDraft: {
+    method: 'DELETE',
+    path: `${getAPIVersionAsPath('1')}/roadmap/drafts/me`,
+    body: z.object({}),
+    responses: {
+      200: DeleteRoadmapDraftResponseSchema,
+    },
+    summary: "Discard the current member's submission draft",
   },
 });

--- a/libs/contracts/src/schema/roadmap.ts
+++ b/libs/contracts/src/schema/roadmap.ts
@@ -240,3 +240,51 @@ export const RoadmapSettingsSchema = z.object({
 export const UpdateRoadmapSettingsSchema = z.object({
   pinLimit: z.number().int().min(0).max(100),
 });
+
+// --- Submission drafts ---
+
+/** Which form the member was filling in: a member idea or a curator roadmap card. */
+export const RoadmapDraftVariantSchema = z.enum(['idea', 'roadmap']);
+
+/**
+ * Server-persisted snapshot of an in-progress create/submit form. Every payload field
+ * is nullable — this is partial, unsaved form state, not a validated item.
+ */
+export const RoadmapSubmissionDraftSchema = z.object({
+  uid: z.string(),
+  variant: RoadmapDraftVariantSchema,
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  tags: z.array(z.string()),
+  type: z.string().nullable(),
+  stage: RoadmapStageSchema.nullable(),
+  objectiveUid: z.string().nullable(),
+  newObjectiveTitle: z.string().nullable(),
+  showCreateObjective: z.boolean(),
+  updatedAt: z.string(),
+});
+
+/** GET response: the member's single draft, or null when none has been saved. */
+export const RoadmapDraftResponseSchema = z.object({
+  draft: RoadmapSubmissionDraftSchema.nullable(),
+});
+
+/**
+ * Full-replace upsert body for the debounced autosave. Omitted fields fall back to
+ * their empty defaults (PUT semantics — the UI sends the whole form each save).
+ */
+export const UpsertRoadmapDraftSchema = z.object({
+  variant: RoadmapDraftVariantSchema.optional(),
+  title: z.string().max(500).optional().nullable(),
+  description: z.string().optional().nullable(),
+  tags: z.array(z.string()).optional(),
+  type: z.string().max(500).optional().nullable(),
+  stage: RoadmapStageSchema.optional().nullable(),
+  objectiveUid: z.string().optional().nullable(),
+  newObjectiveTitle: z.string().max(150).optional().nullable(),
+  showCreateObjective: z.boolean().optional(),
+});
+
+export const DeleteRoadmapDraftResponseSchema = z.object({
+  deleted: z.boolean(),
+});


### PR DESCRIPTION
## Summary

Added server-side persistence for in-progress Gantry create/submit forms so a member's draft follows them across devices and browsers. Each member has at most one active draft, which mirrors the create form (variant, title, description, tags, type, stage, objective fields) and tracks when it was last edited.

Three new authenticated, member-scoped endpoints:

| Method | Endpoint | Purpose |
| --- | --- | --- |
| `GET` | `/v1/roadmap/drafts/me` | Fetch the member's draft (or `null` if none) |
| `PUT` | `/v1/roadmap/drafts/me` | Create or replace the draft (debounced autosave) |
| `DELETE` | `/v1/roadmap/drafts/me` | Discard the draft (idempotent) |

Notes:
- Auth required — pass a member Bearer token; the draft is scoped to that member.
- `PUT` is a full replace: the UI sends the whole form on each autosave, and omitted
  fields reset to their empty defaults.
- `DELETE` is idempotent: discarding when no draft exists returns `200` with
  `deleted: false` (not a 404).

## Test with curl

### Get my draft (or null)

```bash
curl -s -X GET "$BASE_URL/v1/roadmap/drafts/me" \
  -H "Authorization: Bearer $TOKEN"
```

### Upsert (autosave) — idea, full payload

```bash
curl -s -X PUT "$BASE_URL/v1/roadmap/drafts/me" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "variant": "idea",
    "title": "Faster cold-start for the build agents",
    "description": "Caching the base image would cut the ~40s agent spin-up time.",
    "tags": ["infra", "performance", "build-agents"],
    "type": "Improvement",
    "stage": "IDEA",
    "objectiveUid": null,
    "newObjectiveTitle": null,
    "showCreateObjective": false
  }'
```

### Upsert (autosave) — roadmap variant, with a new objective

```bash
curl -s -X PUT "$BASE_URL/v1/roadmap/drafts/me" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "variant": "roadmap",
    "title": "Self-serve roadmap permission requests",
    "description": "Let members request Gantry access from the directory.",
    "tags": ["rbac", "self-serve"],
    "type": "Feature Request",
    "stage": "PLANNED",
    "newObjectiveTitle": "Q3 Access & Onboarding",
    "showCreateObjective": true
  }'
```

### Upsert (autosave) — minimal, title only

Omitted fields fall back to empty defaults (`variant: "idea"`, empty tags, null
stage, `showCreateObjective: false`).

```bash
curl -s -X PUT "$BASE_URL/v1/roadmap/drafts/me" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{ "title": "Half-written idea" }'
```

### Discard my draft

```bash
curl -s -X DELETE "$BASE_URL/v1/roadmap/drafts/me" \
  -H "Authorization: Bearer $TOKEN"
```

## Expected responses

```jsonc
// GET when no draft exists
{ "draft": null }

// GET / PUT with a saved draft
{
  "draft": {
    "uid": "clxxxx...",
    "variant": "idea",
    "title": "Faster cold-start for the build agents",
    "description": "Caching the base image would cut the ~40s agent spin-up time.",
    "tags": ["infra", "performance", "build-agents"],
    "type": "Improvement",
    "stage": "IDEA",
    "objectiveUid": null,
    "newObjectiveTitle": null,
    "showCreateObjective": false,
    "updatedAt": "2026-06-17T00:00:00.000Z"
  }
}

// DELETE
{ "deleted": true }   // or false when there was nothing to discard
```

## Ticket

[LAB-2022](https://linear.app/plrs-labos/issue/LAB-2022/gantry-save-draft-api)

