### PR TITLE
LAB-2004 [Team News] In app notification when news is refreshe

### DIFF
--- a/apps/web-api/src/team-news/team-news.service.spec.ts
+++ b/apps/web-api/src/team-news/team-news.service.spec.ts
@@ -191,16 +191,17 @@ describe('TeamNewsService.ingestTeamNews notifications', () => {
     const dto = push.create.mock.calls[0][0];
     expect(dto).toMatchObject({
       category: 'TEAM_NEWS',
-      title: '3 news updates from ARIA, Bluesky', // small run -> count + team names
-      description: 'newest +2 more', // latest headline across the run + remaining count
+      title: 'Latest News from the network', // static title — teams live in the description
+      description: 'New updates from ARIA, Bluesky', // ≤2 teams, no "+N more"
       link: '/home',
       isPublic: true,
     });
     expect(dto.metadata).toMatchObject({ eventType: 'team_news', runId: 'run-1', teamCount: 2, updateCount: 3 });
+    // Ordered most-recent-first: t1's newest event (06-11) leads t2's (06-10).
     expect(dto.metadata.teamUids).toEqual(['t1', 't2']);
   });
 
-  it('uses single-team copy with the latest headline when only one team has news', async () => {
+  it('uses single-team copy when only one team has news', async () => {
     prisma.teamNewsItem.findUnique.mockResolvedValue(null);
 
     await service.ingestTeamNews({
@@ -213,17 +214,17 @@ describe('TeamNewsService.ingestTeamNews notifications', () => {
 
     expect(push.create).toHaveBeenCalledTimes(1);
     expect(push.create.mock.calls[0][0]).toMatchObject({
-      title: '2 news updates from ARIA',
-      description: 'newest +1 more', // latest headline + remaining count
+      title: 'Latest News from the network',
+      description: 'New updates from ARIA',
       image: 'https://cdn/aria.png',
       metadata: { teamCount: 1, updateCount: 2 },
     });
   });
 
-  it('drops the count from the title for a large run (> small-run threshold)', async () => {
+  it('keeps the static title regardless of run size', async () => {
     prisma.teamNewsItem.findUnique.mockResolvedValue(null);
 
-    // 6 items for one team — above TEAM_NEWS_SMALL_RUN_MAX (5).
+    // 6 items for one team — run size no longer affects the title.
     const items = Array.from({ length: 6 }, (_, i) =>
       ingestItem({ teamUid: 't1', title: `item ${i}`, sourceUrl: `https://x/${i}`, eventDate: `2026-06-${10 + i}T00:00:00.000Z` })
     );
@@ -232,8 +233,8 @@ describe('TeamNewsService.ingestTeamNews notifications', () => {
 
     expect(push.create).toHaveBeenCalledTimes(1);
     expect(push.create.mock.calls[0][0]).toMatchObject({
-      title: 'Latest news from ARIA', // no count for large runs
-      description: 'item 5 +5 more', // newest eventDate (10+5=15) + remaining
+      title: 'Latest News from the network',
+      description: 'New updates from ARIA',
       metadata: { teamCount: 1, updateCount: 6 },
     });
   });
@@ -253,6 +254,7 @@ describe('TeamNewsService.ingestTeamNews notifications', () => {
         teamUids: ['t1'],
         teamCount: 1,
         updateCount: 1,
+        teamLatest: { t1: '2026-06-10T00:00:00.000Z' },
         latestTitle: 'ARIA raised a seed round',
         latestEventDate: '2026-06-10T00:00:00.000Z',
       },
@@ -266,7 +268,8 @@ describe('TeamNewsService.ingestTeamNews notifications', () => {
     expect(updateArg.where).toEqual({ id: 99 });
     expect(updateArg.data.metadata).toMatchObject({ teamCount: 2, updateCount: 2 });
     expect(updateArg.data.metadata.teamUids).toEqual(['t1', 't2']);
-    expect(updateArg.data.title).toBe('2 news updates from ARIA, Bluesky');
+    expect(updateArg.data.title).toBe('Latest News from the network');
+    expect(updateArg.data.description).toBe('New updates from ARIA, Bluesky');
   });
 
   it('does not notify when items only update existing rows', async () => {

--- a/apps/web-api/src/team-news/team-news.service.ts
+++ b/apps/web-api/src/team-news/team-news.service.ts
@@ -20,10 +20,13 @@ const RECENT_WINDOW_DAYS = 14;
 // the home page; there is no per-item detail route.
 const TEAM_NEWS_NOTIFICATION_LINK = '/home';
 
-// At or below this many updates, the title includes the exact count
-// ("4 news updates from …"); above it, the count is dropped for a broader
-// headline ("Latest news from …") since a precise number reads as noise.
-const TEAM_NEWS_SMALL_RUN_MAX = 5;
+// Static title for every run notification — the team breakdown lives in the
+// description instead (see buildRunCopy).
+const TEAM_NEWS_NOTIFICATION_TITLE = 'Latest News from the network';
+
+// How many team names to spell out in the description before collapsing the
+// remainder into "+N more".
+const TEAM_NEWS_NAMED_TEAMS = 2;
 
 interface ParseOutcome {
   ok: boolean;
@@ -152,11 +155,13 @@ export class TeamNewsService {
     if (createdByTeam.size === 0) return;
     const runId = dto.runId ?? null;
 
-    // This batch's contribution.
-    const batchTeamUids = [...createdByTeam.keys()];
+    // This batch's contribution: total inserts + each team's most-recent
+    // event date (the basis for ordering teams in the copy).
     const batchUpdates = [...createdByTeam.values()].reduce((sum, agg) => sum + agg.count, 0);
+    const batchLatestByTeam = new Map<string, number>();
     let batchLatest = { title: '', date: new Date(0) };
-    for (const agg of createdByTeam.values()) {
+    for (const [uid, agg] of createdByTeam) {
+      batchLatestByTeam.set(uid, agg.latestEventDate.getTime());
       if (agg.latestEventDate.getTime() >= batchLatest.date.getTime()) {
         batchLatest = { title: agg.latestTitle, date: agg.latestEventDate };
       }
@@ -175,7 +180,24 @@ export class TeamNewsService {
 
       // Merge this batch into the run's running totals.
       const prevMeta = (existing?.metadata as Record<string, any>) ?? {};
-      const teamUids: string[] = [...new Set<string>([...(prevMeta.teamUids ?? []), ...batchTeamUids])];
+
+      // Track each team's latest event date across the whole run so the team
+      // list can be ordered most-recent-first — the same order the home feed's
+      // "All" tab uses (eventDate DESC). Seed from any teams already on the
+      // notification (legacy rows may lack `teamLatest`) so a mid-run deploy
+      // never drops earlier teams.
+      const teamLatest: Record<string, string> = {};
+      for (const uid of prevMeta.teamUids ?? []) {
+        teamLatest[uid] = prevMeta.teamLatest?.[uid] ?? new Date(0).toISOString();
+      }
+      for (const [uid, ms] of batchLatestByTeam) {
+        const prev = teamLatest[uid] ? new Date(teamLatest[uid]).getTime() : 0;
+        if (ms >= prev) teamLatest[uid] = new Date(ms).toISOString();
+      }
+      const teamUids = Object.keys(teamLatest).sort(
+        (a, b) => new Date(teamLatest[b]).getTime() - new Date(teamLatest[a]).getTime()
+      );
+
       const updateCount: number = (prevMeta.updateCount ?? 0) + batchUpdates;
       const prevLatestDate = prevMeta.latestEventDate ? new Date(prevMeta.latestEventDate) : new Date(0);
       const latest =
@@ -183,13 +205,14 @@ export class TeamNewsService {
           ? batchLatest
           : { title: prevMeta.latestTitle ?? '', date: prevLatestDate };
 
-      const copy = await this.buildRunCopy(teamUids, updateCount, latest.title);
+      const copy = await this.buildRunCopy(teamUids);
       const metadata = {
         eventType: 'team_news',
         runId,
         teamUids,
         teamCount: teamUids.length,
         updateCount,
+        teamLatest,
         latestTitle: latest.title,
         latestEventDate: latest.date.toISOString(),
       };
@@ -229,41 +252,39 @@ export class TeamNewsService {
   }
 
   /**
-   * Build the notification copy for a run from its merged totals. Title names a
-   * couple of teams; the count is included only for small runs, and the most
-   * recent headline is the preview — e.g.:
-   *   small:  "4 news updates from Bluesky, Coinbase, and more"
-   *           "Bluesky shipped v1.122… +3 more"
-   *   large:  "Latest news from Bluesky, Coinbase, and more"
-   *           "Bluesky shipped v1.122… +59 more"
+   * Build the notification copy for a run. The title is fixed; the description
+   * lists the teams with fresh news, ordered most-recent-first (same order as
+   * the home feed's "All" tab) so the first team named matches the first card
+   * on /home — e.g.:
+   *   many:   title "Latest News from the network"
+   *           desc  "New updates from companies like Lido Finance, Lava Network + 40 more"
+   *   one:    title "Latest News from the network"
+   *           desc  "New updates from Lido Finance"
+   * `teamUids` is expected pre-sorted by latest event date (see notifyRun).
    * A team logo is attached only when the whole run is about one team.
    */
   private async buildRunCopy(
-    teamUids: string[],
-    updateCount: number,
-    latestTitle: string
-  ): Promise<{ title: string; description?: string; image?: string }> {
-    // Only the first couple of names appear in the title; fetch just those.
-    const sampleUids = teamUids.slice(0, 2);
+    teamUids: string[]
+  ): Promise<{ title: string; description: string; image?: string }> {
+    // Only the spelled-out names need fetching; the rest collapse into "+N more".
+    const sampleUids = teamUids.slice(0, TEAM_NEWS_NAMED_TEAMS);
     const teams = await this.prisma.team.findMany({
       where: { uid: { in: sampleUids } },
       select: { uid: true, name: true, logo: { select: { url: true } } },
     });
     const teamByUid = new Map(teams.map((t) => [t.uid, t]));
     const names = sampleUids.map((uid) => teamByUid.get(uid)?.name ?? 'a team');
-    const teamList = teamUids.length > 2 ? `${names.join(', ')}, and more` : names.join(', ');
+    const nameList = names.join(', ');
 
-    const title =
-      updateCount <= TEAM_NEWS_SMALL_RUN_MAX
-        ? `${updateCount} news update${updateCount === 1 ? '' : 's'} from ${teamList}`
-        : `Latest news from ${teamList}`;
-
-    const headline = latestTitle || title;
-    const description = updateCount > 1 ? `${headline} +${updateCount - 1} more` : headline;
+    const remaining = teamUids.length - names.length;
+    const description =
+      remaining > 0
+        ? `New updates from companies like ${nameList} + ${remaining} more`
+        : `New updates from ${nameList}`;
 
     const image = teamUids.length === 1 ? teamByUid.get(teamUids[0])?.logo?.url ?? undefined : undefined;
 
-    return { title, description, image };
+    return { title: TEAM_NEWS_NOTIFICATION_TITLE, description, image };
   }
 
   private bumpRejectionCounter(result: IngestTeamNewsResponse, reason: ParseOutcome['reason']) {


### PR DESCRIPTION
## Description

Update for the https://github.com/memser-spaceport/pln-directory-portal/pull/3181

<img width="479" height="157" alt="Screenshot 2026-06-18 at 4 45 17 PM" src="https://github.com/user-attachments/assets/81762028-307a-41ca-a4e1-ed3f6081786b" />

## Ticket

[LAB-2004](https://linear.app/plrs-labos/issue/LAB-2004/team-news-in-app-notification-when-news-is-refreshed)

