### PR TITLE
LAB-2031 [Automation] Improve Swagger docs for Web API

### DIFF
--- a/apps/web-api/src/main.ts
+++ b/apps/web-api/src/main.ts
@@ -3,13 +3,13 @@
 // Do NOT move this import below others — doing so may break logging, metrics, or tracing!
 import './instrumentation';
 import { NestFactory } from '@nestjs/core';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as Sentry from '@sentry/node';
 import { AppModule } from './app.module';
 import { mainConfig } from './main.config';
 import { APP_ENV } from './utils/constants';
 import { createForestAdminAgent } from './utils/forest-admin/agent';
 import { SetupService } from './setup.service';
+import { setupSwagger } from './swagger/swagger.setup';
 
 export async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -20,15 +20,9 @@ export async function bootstrap() {
   // Responsible for loading every major app configuration:
   mainConfig(app);
 
-  // Swagger Documentation
-  const config = new DocumentBuilder()
-    .setTitle('Protocol Labs Directory API')
-    .setDescription('The Protocol Labs Directory API documentation')
-    .setVersion('1.0')
-    .addTag('PL')
-    .build();
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document);
+  // Swagger Documentation — three audience-scoped docs:
+  //   /api/docs (user) · /api/admin/docs (back-office) · /api/internal/docs (service)
+  setupSwagger(app);
 
   // Sentry - Error Reporting
   Sentry.init({

--- a/apps/web-api/src/swagger/route-audience.util.ts
+++ b/apps/web-api/src/swagger/route-audience.util.ts
@@ -1,0 +1,89 @@
+import { INestApplication } from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { MetadataScanner, ModulesContainer } from '@nestjs/core';
+import { TsRestAppRouteMetadataKey } from '@ts-rest/nest';
+import type { AppRoute } from '@ts-rest/core';
+import { AUDIENCE_PRIORITY, DEFAULT_AUDIENCE, DocAudience, GUARD_AUDIENCE } from './swagger.constants';
+
+export interface RouteMeta {
+  /** Which document the operation belongs to. */
+  audience: DocAudience;
+  /** True when the route is protected by an audience-determining guard. */
+  requiresAuth: boolean;
+  /** The ts-rest contract for the route, when defined via `@Api()/@TsRest()`. */
+  appRoute?: AppRoute;
+}
+
+/** Resolve a guard entry (class or instance) to its class name. */
+function guardName(guard: unknown): string | undefined {
+  if (typeof guard === 'function') return guard.name;
+  if (guard && typeof guard === 'object') return guard.constructor?.name;
+  return undefined;
+}
+
+/**
+ * Collect the audience-determining guards applied at the class and method level.
+ * Returns the matching audiences (may be empty for unguarded / neutral routes).
+ */
+function collectAudiences(controllerClass: any, handler: any): DocAudience[] {
+  const classGuards: unknown[] = Reflect.getMetadata(GUARDS_METADATA, controllerClass) ?? [];
+  const methodGuards: unknown[] = Reflect.getMetadata(GUARDS_METADATA, handler) ?? [];
+  const audiences: DocAudience[] = [];
+
+  for (const guard of [...classGuards, ...methodGuards]) {
+    const name = guardName(guard);
+    const audience = name ? GUARD_AUDIENCE[name] : undefined;
+    if (audience) audiences.push(audience);
+  }
+  return audiences;
+}
+
+/** Pick the most restrictive audience from a list (INTERNAL > ADMIN > USER). */
+function mostRestrictive(audiences: DocAudience[]): DocAudience | undefined {
+  if (!audiences.length) return undefined;
+  return audiences.reduce((winner, current) =>
+    AUDIENCE_PRIORITY[current] > AUDIENCE_PRIORITY[winner] ? current : winner
+  );
+}
+
+/**
+ * Walks every controller registered in the application and builds a map keyed by
+ * `operationId` (`${ControllerName}_${methodName}`) describing the audience, auth
+ * requirement, and ts-rest contract for each route handler.
+ *
+ * The `operationId` key matches the `operationIdFactory` configured in
+ * `swagger.setup.ts`, so the generated OpenAPI document can be post-processed by
+ * looking up `operation.operationId` here.
+ */
+export function buildRouteMetaMap(app: INestApplication): Map<string, RouteMeta> {
+  const modulesContainer = app.get(ModulesContainer);
+  const metadataScanner = new MetadataScanner();
+  const map = new Map<string, RouteMeta>();
+
+  for (const moduleRef of modulesContainer.values()) {
+    for (const wrapper of moduleRef.controllers.values()) {
+      const { metatype, instance } = wrapper;
+      if (!metatype || !instance) continue;
+
+      const prototype = Object.getPrototypeOf(instance);
+      const methodNames = metadataScanner.getAllMethodNames(prototype);
+
+      for (const methodName of methodNames) {
+        const handler = prototype[methodName];
+        if (typeof handler !== 'function') continue;
+
+        const audiences = collectAudiences(metatype, handler);
+        const resolved = mostRestrictive(audiences);
+        const appRoute: AppRoute | undefined = Reflect.getMetadata(TsRestAppRouteMetadataKey, handler);
+
+        map.set(`${metatype.name}_${methodName}`, {
+          audience: resolved ?? DEFAULT_AUDIENCE,
+          requiresAuth: resolved !== undefined,
+          appRoute,
+        });
+      }
+    }
+  }
+
+  return map;
+}

--- a/apps/web-api/src/swagger/swagger.constants.ts
+++ b/apps/web-api/src/swagger/swagger.constants.ts
@@ -1,0 +1,101 @@
+/**
+ * Configuration for the audience-scoped Swagger documents.
+ *
+ * The web-api serves three OpenAPI documents instead of one flat list:
+ *  - USER     → public / member-facing endpoints              (/api/docs)
+ *  - ADMIN    → back-office / directory-admin endpoints        (/api/admin/docs)
+ *  - INTERNAL → service-to-service / internal endpoints        (/api/internal/docs)
+ *
+ * Every endpoint is classified into exactly one audience based on the guards it
+ * is protected by (see `route-audience.util.ts`). This avoids hand-annotating
+ * each of the ~90 controllers.
+ */
+
+export enum DocAudience {
+  USER = 'user',
+  ADMIN = 'admin',
+  INTERNAL = 'internal',
+}
+
+/** Security scheme identifiers registered on each document. */
+export const SECURITY_SCHEMES = {
+  [DocAudience.USER]: 'user-token',
+  [DocAudience.ADMIN]: 'admin-token',
+  [DocAudience.INTERNAL]: 'service-token',
+} as const;
+
+export interface SwaggerDocConfig {
+  audience: DocAudience;
+  path: string;
+  title: string;
+  description: string;
+}
+
+export const SWAGGER_DOCS: SwaggerDocConfig[] = [
+  {
+    audience: DocAudience.USER,
+    path: 'api/docs',
+    title: 'Protocol Labs Directory API — User',
+    description:
+      'Public and member-facing endpoints of the Protocol Labs Directory API. ' +
+      'Authenticate with a member access token (Bearer JWT).',
+  },
+  {
+    audience: DocAudience.ADMIN,
+    path: 'api/admin/docs',
+    title: 'Protocol Labs Directory API — Admin (Back Office)',
+    description:
+      'Back-office / directory-admin endpoints. Requires a directory admin access token (Bearer JWT) ' +
+      'with the appropriate admin permissions.',
+  },
+  {
+    audience: DocAudience.INTERNAL,
+    path: 'api/internal/docs',
+    title: 'Protocol Labs Directory API — Internal (Service)',
+    description:
+      'Service-to-service and internal endpoints. Requires a shared service secret in the ' +
+      '`Authorization` header (e.g. `Basic <INTERNAL_SERVICE_SECRET>`).',
+  },
+];
+
+/**
+ * Maps a guard class name to the audience it implies.
+ *
+ * When a route is protected by guards from more than one audience, the most
+ * restrictive audience wins (INTERNAL > ADMIN > USER) — see AUDIENCE_PRIORITY.
+ *
+ * Guards not listed here (e.g. RbacGuard, GoogleRecaptchaGuard, CSRFGuard) are
+ * "neutral": they do not, on their own, place an endpoint into an audience.
+ */
+export const GUARD_AUDIENCE: Record<string, DocAudience> = {
+  // Admin / back-office
+  AdminAuthGuard: DocAudience.ADMIN,
+  DemoDayAdminAuthGuard: DocAudience.ADMIN,
+  DemoDayReadAuthGuard: DocAudience.ADMIN,
+  TeamPitchAdminAuthGuard: DocAudience.ADMIN,
+  TeamMembershipSourceReadAuthGuard: DocAudience.ADMIN,
+
+  // Internal / service-to-service
+  ServiceAuthGuard: DocAudience.INTERNAL,
+  InternalAuthGuard: DocAudience.INTERNAL,
+  InternalServiceThrottlerGuard: DocAudience.INTERNAL,
+
+  // User / member-facing
+  UserTokenValidation: DocAudience.USER,
+  UserTokenCheckGuard: DocAudience.USER,
+  OptionalUserTokenCheckGuard: DocAudience.USER,
+  UserAccessTokenValidateGuard: DocAudience.USER,
+  UserAuthValidateGuard: DocAudience.USER,
+  UserAuthTokenValidation: DocAudience.USER,
+  AuthGuard: DocAudience.USER,
+};
+
+/** Higher number = more restrictive. Used to pick the audience when guards mix. */
+export const AUDIENCE_PRIORITY: Record<DocAudience, number> = {
+  [DocAudience.USER]: 0,
+  [DocAudience.ADMIN]: 1,
+  [DocAudience.INTERNAL]: 2,
+};
+
+/** Endpoints with no audience-determining guard fall back to the USER document. */
+export const DEFAULT_AUDIENCE = DocAudience.USER;

--- a/apps/web-api/src/swagger/swagger.setup.ts
+++ b/apps/web-api/src/swagger/swagger.setup.ts
@@ -1,0 +1,192 @@
+import { INestApplication, Logger } from '@nestjs/common';
+import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
+import { patchNestjsSwagger } from '@abitia/zod-dto';
+import { patchNestJsSwagger } from 'nestjs-zod';
+import { DocAudience, SECURITY_SCHEMES, SWAGGER_DOCS, DEFAULT_AUDIENCE } from './swagger.constants';
+import { buildRouteMetaMap, RouteMeta } from './route-audience.util';
+import { buildOperationFromAppRoute } from './tsrest-schema.util';
+
+const logger = new Logger('Swagger');
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head'] as const;
+
+/** Derive a human tag from a controller class name, e.g. `MemberController` → `Member`. */
+function deriveTag(operationId: string): string {
+  const controllerName = operationId.split('_')[0] ?? operationId;
+  return controllerName
+    .replace(/Controller$/, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .trim();
+}
+
+/**
+ * Merge ts-rest-derived parameters into an operation without clobbering parameters
+ * Nest already produced (it auto-adds bare path params). Existing entries win, except
+ * a path param that has no schema is upgraded with the contract's schema.
+ */
+function mergeParameters(existing: any[], derived: any[]): any[] {
+  const byKey = new Map<string, any>();
+  for (const p of existing) byKey.set(`${p.in}:${p.name}`, p);
+  for (const p of derived) {
+    const key = `${p.in}:${p.name}`;
+    const current = byKey.get(key);
+    if (!current) {
+      byKey.set(key, p);
+    } else if (!current.schema && p.schema) {
+      current.schema = p.schema;
+    }
+  }
+  return [...byKey.values()];
+}
+
+/** Fill request/response schemas, security and tags onto a single operation in place. */
+function enrichOperation(operation: any, meta: RouteMeta | undefined): void {
+  const audience = meta?.audience ?? DEFAULT_AUDIENCE;
+
+  // 1. Schemas from the ts-rest contract — only fill what's missing so manual
+  //    @ApiOkResponseFromZod / @ApiBodyFromZod / @ApiQueryFromZod decorators win.
+  if (meta?.appRoute) {
+    const fragments = buildOperationFromAppRoute(meta.appRoute);
+
+    if (fragments.parameters.length) {
+      operation.parameters = mergeParameters(operation.parameters ?? [], fragments.parameters);
+    }
+    if (!operation.requestBody && fragments.requestBody) {
+      operation.requestBody = fragments.requestBody;
+    }
+    if (fragments.responses && Object.keys(fragments.responses).length) {
+      operation.responses = operation.responses ?? {};
+      for (const [status, response] of Object.entries(fragments.responses)) {
+        const current = operation.responses[status];
+        if (!current || !current.content) {
+          // keep any description Nest already set; add the contract's content/schema
+          operation.responses[status] = { ...response, ...(current ?? {}), content: response.content };
+        }
+      }
+    }
+    if (!operation.summary && fragments.summary) operation.summary = fragments.summary;
+    if (!operation.description && fragments.description) operation.description = fragments.description;
+  }
+
+  // 2. Security: attach the audience's scheme when the route is guarded.
+  if (meta?.requiresAuth && (!operation.security || !operation.security.length)) {
+    operation.security = [{ [SECURITY_SCHEMES[audience]]: [] }];
+  }
+
+  // 3. Tags: keep existing @ApiTags; otherwise fall back to the controller name.
+  if (!operation.tags || !operation.tags.length) {
+    operation.tags = [deriveTag(operation.operationId ?? '')];
+  }
+}
+
+/**
+ * Splits the full OpenAPI document into one document per audience, enriching each
+ * operation with contract schemas, security requirements and tags along the way.
+ */
+function splitByAudience(
+  document: OpenAPIObject,
+  routeMeta: Map<string, RouteMeta>
+): Record<DocAudience, OpenAPIObject> {
+  const buckets: Record<DocAudience, Record<string, any>> = {
+    [DocAudience.USER]: {},
+    [DocAudience.ADMIN]: {},
+    [DocAudience.INTERNAL]: {},
+  };
+  const usedTags: Record<DocAudience, Set<string>> = {
+    [DocAudience.USER]: new Set(),
+    [DocAudience.ADMIN]: new Set(),
+    [DocAudience.INTERNAL]: new Set(),
+  };
+  const unclassified: string[] = [];
+
+  for (const [path, pathItem] of Object.entries(document.paths)) {
+    for (const [key, value] of Object.entries(pathItem as Record<string, any>)) {
+      if (!HTTP_METHODS.includes(key as any)) continue;
+
+      const operation = value;
+      const meta = routeMeta.get(operation.operationId);
+      const audience = meta?.audience ?? DEFAULT_AUDIENCE;
+      if (!meta) unclassified.push(`${key.toUpperCase()} ${path} (${operation.operationId})`);
+
+      enrichOperation(operation, meta);
+      for (const tag of operation.tags ?? []) usedTags[audience].add(tag);
+
+      const bucket = buckets[audience];
+      if (!bucket[path]) {
+        bucket[path] = {};
+        // preserve any path-level (non-method) keys such as shared `parameters`
+        for (const [k, v] of Object.entries(pathItem as Record<string, any>)) {
+          if (!HTTP_METHODS.includes(k as any)) bucket[path][k] = v;
+        }
+      }
+      bucket[path][key] = operation;
+    }
+  }
+
+  if (unclassified.length) {
+    logger.warn(
+      `${unclassified.length} operation(s) had no guard classification and defaulted to the ${DEFAULT_AUDIENCE} doc:\n  ` +
+        unclassified.join('\n  ')
+    );
+  }
+
+  const result = {} as Record<DocAudience, OpenAPIObject>;
+  for (const cfg of SWAGGER_DOCS) {
+    result[cfg.audience] = {
+      ...document,
+      info: { ...document.info, title: cfg.title, description: cfg.description },
+      paths: buckets[cfg.audience],
+      tags: [...usedTags[cfg.audience]].sort().map((name) => ({ name })),
+    };
+  }
+  return result;
+}
+
+/**
+ * Builds and serves three audience-scoped Swagger documents (User / Admin / Internal).
+ * Endpoints are classified automatically from their guards and enriched with schemas
+ * from the ts-rest contracts — no per-controller annotation required.
+ */
+export function setupSwagger(app: INestApplication): void {
+  // Render zod DTO classes (admin/back-office controllers) — the two patches compose,
+  // each falling through to the other for unrecognised types.
+  patchNestjsSwagger();
+  patchNestJsSwagger();
+
+  const config = new DocumentBuilder()
+    .setTitle('Protocol Labs Directory API')
+    .setDescription('The Protocol Labs Directory API documentation')
+    .setVersion('1.0')
+    .addBearerAuth(
+      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT', description: 'Member access token' },
+      SECURITY_SCHEMES[DocAudience.USER]
+    )
+    .addBearerAuth(
+      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT', description: 'Directory admin access token' },
+      SECURITY_SCHEMES[DocAudience.ADMIN]
+    )
+    .addApiKey(
+      {
+        type: 'apiKey',
+        name: 'Authorization',
+        in: 'header',
+        description: 'Service secret, e.g. "Basic <INTERNAL_SERVICE_SECRET>"',
+      },
+      SECURITY_SCHEMES[DocAudience.INTERNAL]
+    )
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config, {
+    operationIdFactory: (controllerKey, methodKey) => `${controllerKey}_${methodKey}`,
+    deepScanRoutes: true,
+  });
+
+  const routeMeta = buildRouteMetaMap(app);
+  const documents = splitByAudience(document, routeMeta);
+
+  for (const cfg of SWAGGER_DOCS) {
+    const doc = documents[cfg.audience];
+    SwaggerModule.setup(cfg.path, app, doc);
+    logger.log(`Serving "${cfg.title}" at /${cfg.path} (${Object.keys(doc.paths).length} paths)`);
+  }
+}

--- a/apps/web-api/src/swagger/swagger.setup.ts
+++ b/apps/web-api/src/swagger/swagger.setup.ts
@@ -1,12 +1,50 @@
 import { INestApplication, Logger } from '@nestjs/common';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
-import { patchNestjsSwagger } from '@abitia/zod-dto';
-import { patchNestJsSwagger } from 'nestjs-zod';
+import { SchemaObjectFactory } from '@nestjs/swagger/dist/services/schema-object-factory';
+import { zodTypeToOpenApi } from '@abitia/zod-dto/dist/OpenApi/zodTypeToOpenApi';
+import { zodToOpenAPI } from 'nestjs-zod';
 import { DocAudience, SECURITY_SCHEMES, SWAGGER_DOCS, DEFAULT_AUDIENCE } from './swagger.constants';
 import { buildRouteMetaMap, RouteMeta } from './route-audience.util';
 import { buildOperationFromAppRoute } from './tsrest-schema.util';
 
 const logger = new Logger('Swagger');
+
+let zodDtoPatchApplied = false;
+
+/**
+ * Render both @abitia/zod-dto and nestjs-zod DTO classes in the OpenAPI schema.
+ *
+ * Both libraries ship a `patchNestjsSwagger()` helper that monkey-patches
+ * `SchemaObjectFactory.prototype.exploreModelSchema`, but neither preserves
+ * `this` when it falls through to the previously installed patch. Stacking them
+ * therefore throws `Cannot read properties of undefined (reading 'isLazyTypeFunc')`
+ * the moment the second patch delegates to the first. We install a single wrapper
+ * that recognises both DTO styles and calls the original with the correct `this`.
+ */
+function patchSwaggerForZodDtos(): void {
+  if (zodDtoPatchApplied) return;
+  zodDtoPatchApplied = true;
+
+  const proto = SchemaObjectFactory.prototype as any;
+  const original = proto.exploreModelSchema;
+
+  proto.exploreModelSchema = function (type: any, schemas: any, schemaRefsStack: any) {
+    if (this.isLazyTypeFunc(type)) {
+      type = type();
+    }
+    // @abitia/zod-dto DTOs expose `zodSchema`.
+    if (type?.zodSchema) {
+      schemas[type.name] = zodTypeToOpenApi(type.zodSchema);
+      return type.name;
+    }
+    // nestjs-zod DTOs expose `isZodDto` + `schema`.
+    if (type?.isZodDto && type?.schema) {
+      schemas[type.name] = zodToOpenAPI(type.schema);
+      return type.name;
+    }
+    return original.call(this, type, schemas, schemaRefsStack);
+  };
+}
 
 const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head'] as const;
 
@@ -148,10 +186,30 @@ function splitByAudience(
  * from the ts-rest contracts — no per-controller annotation required.
  */
 export function setupSwagger(app: INestApplication): void {
-  // Render zod DTO classes (admin/back-office controllers) — the two patches compose,
-  // each falling through to the other for unrecognised types.
-  patchNestjsSwagger();
-  patchNestJsSwagger();
+  // Render both @abitia/zod-dto and nestjs-zod DTO classes (one composed patch).
+  patchSwaggerForZodDtos();
+
+  // The global Helmet CSP sets `default-src 'none'` with no `connect-src`, which
+  // blocks Swagger UI's "Try it out" fetch (it falls back to default-src). curl
+  // works because it ignores CSP. Relax the CSP only on the doc routes so the UI
+  // can call the API on its own origin; the strict CSP still applies everywhere else.
+  const docPaths = SWAGGER_DOCS.map((cfg) => `/${cfg.path}`);
+  app.use((req: any, res: any, next: () => void) => {
+    if (docPaths.some((p) => req.path === p || req.path.startsWith(`${p}/`) || req.path.startsWith(`${p}-`))) {
+      res.setHeader(
+        'Content-Security-Policy',
+        [
+          "default-src 'self'",
+          "connect-src 'self'",
+          "img-src 'self' data: https:",
+          "script-src 'self' 'unsafe-inline'",
+          "style-src 'self' https: 'unsafe-inline'",
+          "font-src 'self' https: data:",
+        ].join('; ')
+      );
+    }
+    next();
+  });
 
   const config = new DocumentBuilder()
     .setTitle('Protocol Labs Directory API')

--- a/apps/web-api/src/swagger/tsrest-schema.util.ts
+++ b/apps/web-api/src/swagger/tsrest-schema.util.ts
@@ -1,0 +1,95 @@
+import zodToJsonSchema from 'zod-to-json-schema';
+import type { AppRoute } from '@ts-rest/core';
+
+/**
+ * Derives OpenAPI schema fragments (parameters / requestBody / responses) from a
+ * ts-rest `AppRoute` contract. The contracts in `libs/contracts` already carry the
+ * full Zod definitions, so this lets the Swagger document reflect real request and
+ * response shapes without per-endpoint decorators.
+ *
+ * Mirrors the conversion options used by `src/decorators/api-response-from-zod.ts`
+ * (`openApi3` target, inlined `$ref`s).
+ */
+
+const toJsonSchema = (zodSchema: any): any => zodToJsonSchema(zodSchema, { target: 'openApi3', $refStrategy: 'none' });
+
+const isZodSchema = (value: any): boolean => !!value && typeof value._def === 'object';
+
+export interface OperationSchemaFragments {
+  summary?: string;
+  description?: string;
+  parameters: any[];
+  requestBody?: any;
+  responses: Record<string, any>;
+}
+
+/** Extract `:param` placeholders from a ts-rest path. */
+function pathParamNames(path: string): string[] {
+  return (path.match(/:([A-Za-z0-9_]+)/g) ?? []).map((p) => p.slice(1));
+}
+
+function buildQueryParameters(appRoute: AppRoute): any[] {
+  const query = (appRoute as any).query;
+  if (!isZodSchema(query)) return [];
+
+  const json = toJsonSchema(query);
+  const properties: Record<string, any> = json?.properties ?? {};
+  const required: string[] = json?.required ?? [];
+
+  return Object.entries(properties).map(([name, schema]) => ({
+    name,
+    in: 'query',
+    required: required.includes(name),
+    schema,
+  }));
+}
+
+function buildPathParameters(appRoute: AppRoute): any[] {
+  const pathParams = (appRoute as any).pathParams;
+  const json = isZodSchema(pathParams) ? toJsonSchema(pathParams) : undefined;
+  const properties: Record<string, any> = json?.properties ?? {};
+
+  return pathParamNames(appRoute.path).map((name) => ({
+    name,
+    in: 'path',
+    required: true, // path params are always required
+    schema: properties[name] ?? { type: 'string' },
+  }));
+}
+
+function buildRequestBody(appRoute: AppRoute): any | undefined {
+  if (appRoute.method === 'GET') return undefined;
+  const body = (appRoute as any).body;
+  if (!isZodSchema(body)) return undefined;
+
+  return {
+    required: true,
+    content: {
+      'application/json': { schema: toJsonSchema(body) },
+    },
+  };
+}
+
+function buildResponses(appRoute: AppRoute): Record<string, any> {
+  const responses: Record<string, any> = {};
+  const contractResponses: Record<string, any> = (appRoute as any).responses ?? {};
+
+  for (const [status, schema] of Object.entries(contractResponses)) {
+    const response: any = { description: '' };
+    if (isZodSchema(schema)) {
+      response.content = { 'application/json': { schema: toJsonSchema(schema) } };
+    }
+    responses[status] = response;
+  }
+  return responses;
+}
+
+export function buildOperationFromAppRoute(appRoute: AppRoute): OperationSchemaFragments {
+  return {
+    summary: (appRoute as any).summary,
+    description: (appRoute as any).description,
+    parameters: [...buildPathParameters(appRoute), ...buildQueryParameters(appRoute)],
+    requestBody: buildRequestBody(appRoute),
+    responses: buildResponses(appRoute),
+  };
+}


### PR DESCRIPTION
## Summary

The Web API previously exposed a single flat Swagger UI with no auth, no request/response schemas, and inconsistent grouping. This change splits it into **three audience-scoped API docs**, each with correct schemas, authorization, and tags.

- **Split docs** — separate User, Admin (back-office), and Internal (service-to-service) documentation.
- **Correct schemas** — request/response bodies, query params, and path params now show real shapes.
- **All endpoints covered** — every registered endpoint appears in the appropriate doc.
- **Authorization** — each doc has an `Authorize` button and per-endpoint lock icons reflecting the
  required token (user / admin / service).
- **Tags & grouping** — endpoints are grouped consistently by domain.

Endpoints are sorted into the right doc automatically, so no per-controller annotation is needed.

## Where to find the docs

With the API running (`yarn nx serve web-api`, default port `3000`):

| Audience | URL |
|---|---|
| **User** (public / member-facing) | http://localhost:3000/api/docs |
| **Admin** (back-office) | http://localhost:3000/api/admin/docs |
| **Internal** (service-to-service) | http://localhost:3000/api/internal/docs |

Notes:
- Port comes from `PORT` (defaults to `3000`).
- On deployed environments, use the API host instead of `localhost:3000`
  (e.g. `https://<api-host>/api/docs`).
- Raw OpenAPI JSON is available at each path + `-json`
  (e.g. `http://localhost:3000/api/docs-json`) for importing into Postman/Insomnia.

## Screenshots
### User
<img width="1469" height="689" alt="Screenshot 2026-06-22 at 5 32 00 PM" src="https://github.com/user-attachments/assets/8b09d83d-18b7-4844-b032-cc1f7e016501" />

### Admin
<img width="1471" height="628" alt="Screenshot 2026-06-22 at 5 32 10 PM" src="https://github.com/user-attachments/assets/18a83e46-63da-4273-b805-c0a7cb6bca5e" />

### Internal
<img width="1489" height="583" alt="Screenshot 2026-06-22 at 5 31 42 PM" src="https://github.com/user-attachments/assets/80b63679-1d5c-463c-a348-ca450a99e836" />



## Ticket

[LAB-2031](https://linear.app/plrs-labos/issue/LAB-2031/automation-improve-swagger-docs-for-web-api)


