### PR TITLE
LAB-2039 [AI Apps] v0 / POC / fix gateway timeouts

### DIFF
--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -30,6 +30,14 @@ export const AI_APPS_S3_BUCKET = process.env.AI_APPS_S3_BUCKET || '';
 export const buildAppS3Key = (appId: string, deploymentId: string): string => `apps/${appId}/${deploymentId}/app.zip`;
 
 /**
+ * The sandbox host/URL for an app is deterministic from its appId, so we can
+ * compute it up front (before the runner responds): sandbox-<appId>.plnetwork.io
+ */
+export const buildAppHost = (appId: string): string => `sandbox-${appId}.plnetwork.io`;
+export const buildAppUrl = (appId: string): string => `https://${buildAppHost(appId)}`;
+export const buildAppHttpUrl = (appId: string): string => `http://${buildAppHost(appId)}`;
+
+/**
  * Public URL of THIS API's deploy endpoint, written into the starter kit so the
  * agent knows where to POST. Defaults to the conventional prod path.
  */

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -16,8 +16,17 @@ import {
   AI_APPS_RUNNER_TOKEN,
   AI_APPS_RUNNER_URL,
   AI_APPS_S3_BUCKET,
+  buildAppHost,
+  buildAppHttpUrl,
   buildAppS3Key,
+  buildAppUrl,
 } from './ai-apps.constants';
+
+/** Edge/gateway statuses that mean "the runner may still have finished" — verify, don't fail. */
+const GATEWAY_TIMEOUT_STATUSES = [408, 502, 503, 504, 521, 522, 523, 524];
+/** How long to wait for the app to come up after a runner timeout. */
+const VERIFY_ATTEMPTS = 8;
+const VERIFY_INTERVAL_MS = 8000;
 
 interface RunnerDeployResponse {
   status?: string;
@@ -131,6 +140,10 @@ export class AiAppsService {
     }
 
     const s3Key = buildAppS3Key(dto.appId, dto.deploymentId);
+    // The sandbox host is deterministic from appId, so set the link up front.
+    const host = buildAppHost(dto.appId);
+    const url = buildAppUrl(dto.appId);
+    const httpUrl = buildAppHttpUrl(dto.appId);
 
     const app = await this.prisma.aiApp.upsert({
       where: { memberUid_appId: { memberUid, appId: dto.appId } },
@@ -141,18 +154,33 @@ export class AiAppsService {
         description: dto.description,
         status: 'DEPLOYING',
         deploymentId: dto.deploymentId,
+        url,
+        httpUrl,
+        host,
       },
       update: {
         name: dto.name,
         description: dto.description,
         status: 'DEPLOYING',
         deploymentId: dto.deploymentId,
+        url,
+        httpUrl,
+        host,
         notes: null,
       },
     });
 
     const eventContext = { appUid: app.uid, appId: dto.appId, deploymentId: dto.deploymentId };
     await this.recordEvent('DEPLOY_STARTED', memberUid, eventContext);
+
+    const markReady = async (port: number | null) => {
+      const updated = await this.prisma.aiApp.update({
+        where: { uid: app.uid },
+        data: { status: 'READY', url, httpUrl, host, port, notes: null },
+      });
+      await this.recordEvent('DEPLOY_SUCCEEDED', memberUid, { ...eventContext, message: url });
+      return (await this.withMember([updated]))[0];
+    };
 
     try {
       await this.awsService.uploadFileToS3(
@@ -166,24 +194,23 @@ export class AiAppsService {
         { appId: dto.appId, deploymentId: dto.deploymentId, s3Key },
         { headers: { 'Content-Type': 'application/json', 'x-runner-token': AI_APPS_RUNNER_TOKEN } }
       );
-
-      const updated = await this.prisma.aiApp.update({
-        where: { uid: app.uid },
-        data: {
-          status: 'READY',
-          url: data.url ?? null,
-          httpUrl: data.httpUrl ?? null,
-          host: data.host ?? null,
-          port: data.port ?? null,
-          notes: null,
-        },
-      });
-      await this.recordEvent('DEPLOY_SUCCEEDED', memberUid, { ...eventContext, message: updated.url ?? undefined });
-      return (await this.withMember([updated]))[0];
+      return markReady(data.port ?? null);
     } catch (error) {
       const message = axios.isAxiosError(error)
         ? `Runner error: ${error.response?.status ?? ''} ${JSON.stringify(error.response?.data ?? error.message)}`
         : `Deploy failed: ${(error as Error).message}`;
+
+      // A gateway timeout (Cloudflare 504/524, etc.) or no response doesn't mean the
+      // deploy failed — the long-running build often completes on the origin. Verify
+      // by checking whether the app is actually reachable before declaring failure.
+      if (this.isUncertainRunnerError(error)) {
+        this.logger.warn(`Runner timed out for ${dto.appId}; verifying app at ${url}. (${message})`);
+        if (await this.verifyAppLive(url)) {
+          this.logger.log(`AI App ${dto.appId} is live despite runner timeout — marking READY`);
+          return markReady(null);
+        }
+      }
+
       this.logger.error(`AI App deploy failed for ${dto.appId}: ${message}`);
       await this.prisma.aiApp.update({
         where: { uid: app.uid },
@@ -192,6 +219,40 @@ export class AiAppsService {
       await this.recordEvent('DEPLOY_FAILED', memberUid, { ...eventContext, message: message.slice(0, 2000) });
       throw new BadGatewayException('Failed to deploy app to the sandbox runner');
     }
+  }
+
+  /** True when the runner call timed out / hit a gateway error and the outcome is unknown. */
+  private isUncertainRunnerError(error: unknown): boolean {
+    if (!axios.isAxiosError(error)) {
+      return false;
+    }
+    // No response at all (connection reset / our own timeout) → unknown.
+    if (!error.response) {
+      return true;
+    }
+    return GATEWAY_TIMEOUT_STATUSES.includes(error.response.status);
+  }
+
+  /**
+   * Polls the app URL until it responds (any non-gateway HTTP status means the
+   * server is up — even a 404 from the app counts). Returns false if it never
+   * becomes reachable within the verification window.
+   */
+  private async verifyAppLive(url: string): Promise<boolean> {
+    for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt++) {
+      try {
+        const res = await axios.get(url, { timeout: 10000, validateStatus: () => true, maxRedirects: 0 });
+        if (res.status && !GATEWAY_TIMEOUT_STATUSES.includes(res.status)) {
+          return true;
+        }
+      } catch {
+        // Not reachable yet — keep polling.
+      }
+      if (attempt < VERIFY_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, VERIFY_INTERVAL_MS));
+      }
+    }
+    return false;
   }
 
   /**

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -21,11 +21,12 @@ GET  /starter-kit/download  ──►  RBAC ai_apps.write
                             ◄──  ZIP (instructions, token, styles, app/)
 
 POST /deploy (multipart)    ──►  AiAppTokenGuard (x-app-token)
-  x-app-token: <token>           upsert AiApp (status=DEPLOYING)
+  x-app-token: <token>           upsert AiApp (status=DEPLOYING, url=sandbox-<appId>.plnetwork.io set up front)
   file=app.zip + metadata        upload app.zip ──────────────────►  s3://<bucket>/apps/<appId>/<deploymentId>/app.zip
                                  POST /deploy ────────────────────►  pull from S3, build + run
                                    x-runner-token: <server secret>
-                                 store url/host/port (status=READY) ◄── { url, host, port }
+                                 200 → status=READY                ◄── { port } (or 504 timeout)
+                                 504/timeout → poll app URL, READY if reachable
                             ◄──  AiApp record
 
 GET  /            ──► RBAC ai_apps.read ── list all apps (dashboard)
@@ -61,6 +62,10 @@ curl -X POST "$AI_APPS_DEPLOY_ENDPOINT" \
 ```
 
 The backend uploads the ZIP to `s3://<AI_APPS_S3_BUCKET>/apps/<appId>/<deploymentId>/app.zip`, then calls the runner with that `s3Key`. Response is the stored `AiApp` record (status `READY` with `url`/`host`/`port`, or `ERROR` with `notes`).
+
+**Deterministic URL:** the sandbox host is always `sandbox-<appId>.plnetwork.io`, so `url`/`httpUrl`/`host` are computed from `appId` and stored on the record **at deploy start** (status `DEPLOYING`) — the link exists before the runner finishes. For `appId` `test-hello-01` the URL is `https://sandbox-test-hello-01.plnetwork.io`.
+
+**Timeout handling:** the runner build can exceed the edge (Cloudflare) timeout and return `504`/`524` even though the deploy actually completes. On a gateway timeout (or no response), the backend does **not** fail blindly — it polls the app URL (`buildAppUrl(appId)`) for ~1 min and marks the app `READY` if it becomes reachable (any non-gateway HTTP status counts, including `404` from the app). Only if it stays unreachable — or the runner returns a non-timeout error (e.g. `400`/auth) — is it marked `ERROR` / `DEPLOY_FAILED`. This prevents false failures for slow-but-successful deploys.
 
 ### Delete request
 


### PR DESCRIPTION
## Description

 1. Deterministic URL, set up front — the host is always `sandbox-<appId>.plnetwork.io`, so url/httpUrl/host are now computed from appId and written at deploy start (status: DEPLOYING). The link exists immediately, before the runner responds.                                                                                                                                    
                                                                                                                                                                                                                                                                       
2. Verify-before-fail on gateway timeouts — on a 504/524/502/503/408 or no-response error (GATEWAY_TIMEOUT_STATUSES), deploy() no longer fails blindly. It polls the app URL (verifyAppLive, ~1 min: 8 × 8s) and:                                                    
  - reachable (any non-gateway status, even a 404 from the app) → READY + DEPLOY_SUCCEEDED                                                                                                                                                                             
  - still unreachable → ERROR + DEPLOY_FAILED 

