### PR TITLE
LAB-2074 [Follow] Implement Follow Team API

### DIFF
--- a/apps/web-api/prisma/migrations/20260629120000_add_follow/migration.sql
+++ b/apps/web-api/prisma/migrations/20260629120000_add_follow/migration.sql
@@ -1,0 +1,30 @@
+-- CreateEnum
+CREATE TYPE "FollowEntityType" AS ENUM ('TEAM', 'MEMBER');
+
+-- CreateTable
+CREATE TABLE "Follow" (
+    "id" SERIAL NOT NULL,
+    "uid" TEXT NOT NULL,
+    "memberUid" TEXT NOT NULL,
+    "entityType" "FollowEntityType" NOT NULL DEFAULT 'TEAM',
+    "entityUid" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Follow_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Follow_uid_key" ON "Follow"("uid");
+
+-- CreateIndex
+CREATE INDEX "Follow_entityType_entityUid_idx" ON "Follow"("entityType", "entityUid");
+
+-- CreateIndex
+CREATE INDEX "Follow_memberUid_entityType_idx" ON "Follow"("memberUid", "entityType");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Follow_memberUid_entityType_entityUid_key" ON "Follow"("memberUid", "entityType", "entityUid");
+
+-- AddForeignKey
+ALTER TABLE "Follow" ADD CONSTRAINT "Follow_memberUid_fkey" FOREIGN KEY ("memberUid") REFERENCES "Member"("uid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -164,6 +164,7 @@ model Member {
   locationUid                        String?
   teamMemberRoles                    TeamMemberRole[]
   memberRoles                        MemberRole[]
+  following                          Follow[]                          @relation("MemberFollowing")
   preferences                        Json?
   projectContributions               ProjectContribution[]
   createdProjects                    Project[]
@@ -3311,4 +3312,33 @@ model AffinityListMembership {
   @@index([affinityListId])
   @@index([companyUid])
   @@index([personUid])
+}
+
+/// Polymorphic "follow" edge: a Member follows some entity. Today only Teams
+/// are followable (entityType = TEAM, entityUid = Team.uid), but the shape is
+/// intentionally generic — adding member-follows-member later means inserting
+/// rows with entityType = MEMBER and entityUid = Member.uid, no schema change.
+///
+/// `entityUid` is deliberately NOT a hard FK (it points at different tables per
+/// entityType), so cleanup of a followed entity is handled in the service layer
+/// / by the followed entity's own cascade where one exists. The follower side
+/// (`memberUid`) IS a real FK so a deleted member drops all their follows.
+enum FollowEntityType {
+  TEAM
+  MEMBER
+}
+
+model Follow {
+  id         Int              @id @default(autoincrement())
+  uid        String           @unique @default(cuid())
+  member     Member           @relation("MemberFollowing", fields: [memberUid], references: [uid], onDelete: Cascade)
+  memberUid  String
+  entityType FollowEntityType @default(TEAM)
+  entityUid  String
+  createdAt  DateTime         @default(now())
+  updatedAt  DateTime         @updatedAt
+
+  @@unique([memberUid, entityType, entityUid])
+  @@index([entityType, entityUid])
+  @@index([memberUid, entityType])
 }

--- a/apps/web-api/src/app.module.ts
+++ b/apps/web-api/src/app.module.ts
@@ -71,6 +71,7 @@ import { ArticleRequestsModule } from './article-requests/article-requests.modul
 import { JobOpeningsModule } from './job-openings/job-openings.module';
 import { JobAlertsModule } from './job-alerts/job-alerts.module';
 import { TeamNewsModule } from './team-news/team-news.module';
+import { FollowsModule } from './follows/follows.module';
 import { InvestorOutreachModule } from './investor-outreach/investor-outreach.module';
 import { PathfinderModule } from './pathfinder/pathfinder.module';
 import { InvestorListsModule } from './investor-lists/investor-lists.module';
@@ -169,6 +170,7 @@ import { AiAppsModule } from './ai-apps/ai-apps.module';
     JobOpeningsModule,
     JobAlertsModule,
     TeamNewsModule,
+    FollowsModule,
     InvestorOutreachModule,
     PathfinderModule,
     InvestorListsModule,

--- a/apps/web-api/src/follows/follows.controller.ts
+++ b/apps/web-api/src/follows/follows.controller.ts
@@ -1,0 +1,65 @@
+import { Controller, ForbiddenException, Logger, Param, Req, UseGuards } from '@nestjs/common';
+import { Api, initNestServer } from '@ts-rest/nest';
+import { Request } from 'express';
+import { apiFollow } from 'libs/contracts/src/lib/contract-follow';
+import { FollowedTeamsQueryParams, TeamFollowersQueryParams } from 'libs/contracts/src/schema/follow';
+import { UserTokenValidation } from '../guards/user-token-validation.guard';
+import { MembersService } from '../members/members.service';
+import { FollowsService } from './follows.service';
+
+const server = initNestServer(apiFollow);
+
+@Controller()
+export class FollowsController {
+  private readonly logger = new Logger(FollowsController.name);
+
+  constructor(private readonly followsService: FollowsService, private readonly membersService: MembersService) {}
+
+  @Api(server.route.followTeam)
+  @UseGuards(UserTokenValidation)
+  async followTeam(@Param('teamUid') teamUid: string, @Req() req: Request & { userEmail?: string }) {
+    const member = await this.resolveMember(req);
+    return this.followsService.followTeam(member.uid, teamUid);
+  }
+
+  @Api(server.route.unfollowTeam)
+  @UseGuards(UserTokenValidation)
+  async unfollowTeam(@Param('teamUid') teamUid: string, @Req() req: Request & { userEmail?: string }) {
+    const member = await this.resolveMember(req);
+    return this.followsService.unfollowTeam(member.uid, teamUid);
+  }
+
+  @Api(server.route.getFollowedTeams)
+  @UseGuards(UserTokenValidation)
+  async getFollowedTeams(@Req() req: Request & { userEmail?: string }) {
+    const member = await this.resolveMember(req);
+    const query = FollowedTeamsQueryParams.parse(req.query);
+    return this.followsService.getFollowedTeams(member.uid, query);
+  }
+
+  @Api(server.route.getTeamFollowers)
+  @UseGuards(UserTokenValidation)
+  async getTeamFollowers(@Param('teamUid') teamUid: string, @Req() req: Request & { userEmail?: string }) {
+    const member = await this.resolveMember(req);
+    const query = TeamFollowersQueryParams.parse(req.query);
+
+    // Followers of a team are visible only to that team's members and to
+    // directory admins.
+    const authorized =
+      this.membersService.checkIfAdminUser(member) || (await this.followsService.isTeamMember(member.uid, teamUid));
+
+    return this.followsService.getTeamFollowers(teamUid, query, authorized);
+  }
+
+  private async resolveMember(req: Request & { userEmail?: string }) {
+    if (!req.userEmail) {
+      throw new ForbiddenException('Authenticated member required');
+    }
+    const member = await this.membersService.findMemberByEmail(req.userEmail);
+    if (!member) {
+      this.logger.warn(`Follow request from authenticated email ${req.userEmail} that is not a member`);
+      throw new ForbiddenException('Member not found');
+    }
+    return member;
+  }
+}

--- a/apps/web-api/src/follows/follows.module.ts
+++ b/apps/web-api/src/follows/follows.module.ts
@@ -1,0 +1,13 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { SharedModule } from '../shared/shared.module';
+import { MembersModule } from '../members/members.module';
+import { FollowsController } from './follows.controller';
+import { FollowsService } from './follows.service';
+
+@Module({
+  imports: [SharedModule, forwardRef(() => MembersModule)],
+  controllers: [FollowsController],
+  providers: [FollowsService],
+  exports: [FollowsService],
+})
+export class FollowsModule {}

--- a/apps/web-api/src/follows/follows.service.ts
+++ b/apps/web-api/src/follows/follows.service.ts
@@ -1,0 +1,190 @@
+import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { FollowEntityType, Prisma } from '@prisma/client';
+import { PrismaService } from '../shared/prisma.service';
+import type {
+  FollowStatusResponse,
+  FollowedTeamsQuery,
+  FollowedTeamsResponse,
+  TeamFollowersQuery,
+  TeamFollowersResponse,
+} from 'libs/contracts/src/schema/follow';
+
+/**
+ * Follow feature data access. The persisted `Follow` edge is polymorphic
+ * (`entityType` + `entityUid`); this service currently exposes only the
+ * team-following surface. Member-following can be added by mirroring these
+ * methods with `FollowEntityType.MEMBER` — no schema or query reshaping needed.
+ */
+@Injectable()
+export class FollowsService {
+  private readonly logger = new Logger(FollowsService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Follow a team. Idempotent: re-following an already-followed team succeeds. */
+  async followTeam(memberUid: string, teamUid: string): Promise<FollowStatusResponse> {
+    await this.assertTeamExists(teamUid);
+
+    await this.prisma.follow.upsert({
+      where: {
+        memberUid_entityType_entityUid: {
+          memberUid,
+          entityType: FollowEntityType.TEAM,
+          entityUid: teamUid,
+        },
+      },
+      create: { memberUid, entityType: FollowEntityType.TEAM, entityUid: teamUid },
+      update: {},
+    });
+
+    return this.buildStatus(teamUid, true);
+  }
+
+  /** Unfollow a team. Idempotent: unfollowing a team not followed succeeds. */
+  async unfollowTeam(memberUid: string, teamUid: string): Promise<FollowStatusResponse> {
+    await this.assertTeamExists(teamUid);
+
+    await this.prisma.follow.deleteMany({
+      where: { memberUid, entityType: FollowEntityType.TEAM, entityUid: teamUid },
+    });
+
+    return this.buildStatus(teamUid, false);
+  }
+
+  /** Teams the member follows, newest-follow first. */
+  async getFollowedTeams(memberUid: string, query: FollowedTeamsQuery): Promise<FollowedTeamsResponse> {
+    const where: Prisma.FollowWhereInput = { memberUid, entityType: FollowEntityType.TEAM };
+    const skip = (query.page - 1) * query.limit;
+
+    const [follows, total] = await Promise.all([
+      this.prisma.follow.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: query.limit,
+      }),
+      this.prisma.follow.count({ where }),
+    ]);
+
+    const teamUids = follows.map((f) => f.entityUid);
+    const [teams, counts] = await Promise.all([
+      this.prisma.team.findMany({
+        where: { uid: { in: teamUids } },
+        select: { uid: true, name: true, shortDescription: true, logo: { select: { url: true } } },
+      }),
+      this.countFollowersByTeam(teamUids),
+    ]);
+    const teamByUid = new Map(teams.map((t) => [t.uid, t]));
+
+    // Preserve the follow-order (most recently followed first); drop any follow
+    // whose team no longer exists (entityUid is not a hard FK — see schema).
+    const items = follows
+      .map((f) => {
+        const team = teamByUid.get(f.entityUid);
+        if (!team) return null;
+        return {
+          uid: team.uid,
+          name: team.name,
+          logoUrl: team.logo?.url ?? null,
+          shortDescription: team.shortDescription ?? null,
+          followedAt: f.createdAt.toISOString(),
+          followerCount: counts.get(team.uid) ?? 0,
+        };
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null);
+
+    return { page: query.page, limit: query.limit, total, items };
+  }
+
+  /**
+   * Followers of a team. Restricted to members of that team and directory
+   * admins (caller is resolved/authorized in the controller, which passes
+   * `authorized`). Followers are returned newest-follow first.
+   */
+  async getTeamFollowers(
+    teamUid: string,
+    query: TeamFollowersQuery,
+    authorized: boolean
+  ): Promise<TeamFollowersResponse> {
+    const team = await this.prisma.team.findUnique({ where: { uid: teamUid }, select: { uid: true, name: true } });
+    if (!team) {
+      throw new NotFoundException(`Team with uid ${teamUid} not found`);
+    }
+    if (!authorized) {
+      throw new ForbiddenException('Only members of this team can view its followers');
+    }
+
+    const where: Prisma.FollowWhereInput = { entityType: FollowEntityType.TEAM, entityUid: teamUid };
+    const skip = (query.page - 1) * query.limit;
+
+    const [follows, total] = await Promise.all([
+      this.prisma.follow.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: query.limit,
+        include: { member: { select: { uid: true, name: true, image: { select: { url: true } } } } },
+      }),
+      this.prisma.follow.count({ where }),
+    ]);
+
+    return {
+      teamUid: team.uid,
+      teamName: team.name,
+      page: query.page,
+      limit: query.limit,
+      total,
+      items: follows.map((f) => ({
+        uid: f.member.uid,
+        name: f.member.name,
+        imageUrl: f.member.image?.url ?? null,
+        followedAt: f.createdAt.toISOString(),
+      })),
+    };
+  }
+
+  /**
+   * UIDs of teams a member follows, as a Set — used to stamp an `isFollowed`
+   * flag onto team / news listings without an N+1 per row.
+   */
+  async getFollowedTeamUids(memberUid: string): Promise<Set<string>> {
+    const follows = await this.prisma.follow.findMany({
+      where: { memberUid, entityType: FollowEntityType.TEAM },
+      select: { entityUid: true },
+    });
+    return new Set(follows.map((f) => f.entityUid));
+  }
+
+  /** True when the member is part of the team (any active or historical role). */
+  async isTeamMember(memberUid: string, teamUid: string): Promise<boolean> {
+    const role = await this.prisma.teamMemberRole.findFirst({
+      where: { memberUid, teamUid },
+      select: { id: true },
+    });
+    return !!role;
+  }
+
+  private async assertTeamExists(teamUid: string): Promise<void> {
+    const team = await this.prisma.team.findUnique({ where: { uid: teamUid }, select: { uid: true } });
+    if (!team) {
+      throw new NotFoundException(`Team with uid ${teamUid} not found`);
+    }
+  }
+
+  private async buildStatus(teamUid: string, following: boolean): Promise<FollowStatusResponse> {
+    const followerCount = await this.prisma.follow.count({
+      where: { entityType: FollowEntityType.TEAM, entityUid: teamUid },
+    });
+    return { following, entityType: 'TEAM', entityUid: teamUid, followerCount };
+  }
+
+  private async countFollowersByTeam(teamUids: string[]): Promise<Map<string, number>> {
+    if (teamUids.length === 0) return new Map();
+    const grouped = await this.prisma.follow.groupBy({
+      by: ['entityUid'],
+      where: { entityType: FollowEntityType.TEAM, entityUid: { in: teamUids } },
+      _count: { _all: true },
+    });
+    return new Map(grouped.map((g) => [g.entityUid, g._count._all]));
+  }
+}

--- a/apps/web-api/src/follows/follows.service.ts
+++ b/apps/web-api/src/follows/follows.service.ts
@@ -70,7 +70,7 @@ export class FollowsService {
     const [teams, counts] = await Promise.all([
       this.prisma.team.findMany({
         where: { uid: { in: teamUids } },
-        select: { uid: true, name: true, shortDescription: true, logo: { select: { url: true } } },
+        select: { uid: true, name: true, logo: { select: { url: true } } },
       }),
       this.countFollowersByTeam(teamUids),
     ]);
@@ -86,7 +86,6 @@ export class FollowsService {
           uid: team.uid,
           name: team.name,
           logoUrl: team.logo?.url ?? null,
-          shortDescription: team.shortDescription ?? null,
           followedAt: f.createdAt.toISOString(),
           followerCount: counts.get(team.uid) ?? 0,
         };

--- a/apps/web-api/src/push-notifications/push-notifications.service.ts
+++ b/apps/web-api/src/push-notifications/push-notifications.service.ts
@@ -577,11 +577,78 @@ export class PushNotificationsService {
       );
     }
 
+    // ---- TEAM_NEWS: personalize the copy to name the teams THIS member follows ----
+    await this.personalizeTeamNewsCopy(memberUid, paginatedNotifications);
+
     return {
       notifications: paginatedNotifications,
       total: notifications.length,
       unreadCount: await this.getUnreadCount(memberUid),
     };
+  }
+
+  /**
+   * Rewrite TEAM_NEWS notification copy per-recipient so it names the teams the
+   * member actually follows, rather than the run's most-recent teams.
+   *
+   * TEAM_NEWS is a single public broadcast row (one copy stored at ingest time
+   * naming the most-recent teams). Here, at read time, we know who is asking:
+   * for any team the member follows that is part of the run (metadata.teamUids),
+   * we float those teams to the front and rebuild the description so the named
+   * teams are the followed ones — e.g. "New updates from Lido Finance, Lava
+   * Network + 40 more". When the member follows none of the run's teams the
+   * stored (most-recent) copy is left untouched. The mutation is in-memory only
+   * (the response objects), never persisted.
+   */
+  private async personalizeTeamNewsCopy(memberUid: string, notifications: NotificationWithReadStatus[]): Promise<void> {
+    const teamNewsNotifs = notifications.filter(
+      (n) =>
+        n.category === PushNotificationCategory.TEAM_NEWS &&
+        Array.isArray((n.metadata as any)?.teamUids) &&
+        (n.metadata as any).teamUids.length > 0
+    );
+    if (teamNewsNotifs.length === 0) return;
+
+    const allTeamUids = [...new Set(teamNewsNotifs.flatMap((n) => (n.metadata as any).teamUids as string[]))];
+
+    const follows = await this.prisma.follow.findMany({
+      where: { memberUid, entityType: 'TEAM', entityUid: { in: allTeamUids } },
+      select: { entityUid: true },
+    });
+    const followedSet = new Set(follows.map((f) => f.entityUid));
+    if (followedSet.size === 0) return;
+
+    const NAMED = 2;
+    // Pre-fetch names for every team that could be named (the followed-first
+    // top-N of each notification) in one query.
+    const candidateUids = new Set<string>();
+    for (const n of teamNewsNotifs) {
+      const uids = (n.metadata as any).teamUids as string[];
+      const reordered = [...uids].sort((a, b) => Number(followedSet.has(b)) - Number(followedSet.has(a)));
+      reordered.slice(0, NAMED).forEach((uid) => candidateUids.add(uid));
+    }
+    const teams = await this.prisma.team.findMany({
+      where: { uid: { in: [...candidateUids] } },
+      select: { uid: true, name: true },
+    });
+    const nameByUid = new Map(teams.map((t) => [t.uid, t.name]));
+
+    for (const n of teamNewsNotifs) {
+      const uids = (n.metadata as any).teamUids as string[];
+      // Stable sort: followed teams first, original (most-recent) order within.
+      const reordered = [...uids].sort((a, b) => Number(followedSet.has(b)) - Number(followedSet.has(a)));
+      const names = reordered.slice(0, NAMED).map((uid) => nameByUid.get(uid) ?? 'a team');
+      const remaining = reordered.length - names.length;
+      n.description =
+        remaining > 0
+          ? `New updates from companies like ${names.join(', ')} + ${remaining} more`
+          : `New updates from ${names.join(', ')}`;
+      n.metadata = {
+        ...(n.metadata as Record<string, any>),
+        teamUids: reordered,
+        followedTeamUids: reordered.filter((uid) => followedSet.has(uid)),
+      } as Prisma.JsonValue;
+    }
   }
 
   /**

--- a/apps/web-api/src/team-news/team-news-enrichment.service.ts
+++ b/apps/web-api/src/team-news/team-news-enrichment.service.ts
@@ -140,6 +140,8 @@ export class TeamNewsEnrichmentService {
           // The service-side per-team endpoint does not surface forum-link
           // counts; consumers that need them should use the public list APIs.
           discussion: { count: 0, latestTopicUrl: null },
+          // Service-to-service endpoint: no member context, so never "followed".
+          isFollowed: false,
         };
       }),
     };

--- a/apps/web-api/src/team-news/team-news-query.service.ts
+++ b/apps/web-api/src/team-news/team-news-query.service.ts
@@ -84,41 +84,91 @@ export class TeamNewsQueryService {
     return and.length > 0 ? { AND: and } : {};
   }
 
-  async listTeamNews(query: TeamNewsListQuery): Promise<TeamNewsListResponse> {
+  async listTeamNews(
+    query: TeamNewsListQuery,
+    followedTeamUids: Set<string> = new Set()
+  ): Promise<TeamNewsListResponse> {
     const where = this.buildWhere(query);
     const skip = (query.page - 1) * query.limit;
-
-    const [rows, total] = await Promise.all([
-      this.prisma.teamNewsItem.findMany({
-        where,
-        orderBy: [{ eventDate: 'desc' }, { createdAt: 'desc' }],
-        skip,
-        take: query.limit,
-        include: {
-          team: {
-            select: {
-              uid: true,
-              name: true,
-              logo: { select: { url: true } },
-              teamFocusAreas: { include: { focusArea: true, ancestorArea: true } },
-            },
-          },
+    const orderBy: Prisma.TeamNewsItemOrderByWithRelationInput[] = [{ eventDate: 'desc' }, { createdAt: 'desc' }];
+    const include = {
+      team: {
+        select: {
+          uid: true,
+          name: true,
+          logo: { select: { url: true } },
+          teamFocusAreas: { include: { focusArea: true, ancestorArea: true } },
         },
-      }),
+      },
+    } as const;
+
+    const followed = [...followedTeamUids];
+
+    // Anonymous caller (or follows nothing): single ordered+paginated query.
+    if (followed.length === 0) {
+      const [rows, total] = await Promise.all([
+        this.prisma.teamNewsItem.findMany({ where, orderBy, skip, take: query.limit, include }),
+        this.prisma.teamNewsItem.count({ where }),
+      ]);
+      const discussions = await this.loadDiscussions(rows.map((r) => r.uid));
+      return {
+        page: query.page,
+        limit: query.limit,
+        total,
+        items: rows.map((row) => this.toDto(row, discussions.get(row.uid), followedTeamUids)),
+      };
+    }
+
+    // Followed-first: paginate across two ordered segments (followed teams,
+    // then everyone else) so the global ordering stays stable across pages.
+    const followedWhere: Prisma.TeamNewsItemWhereInput = { AND: [where, { teamUid: { in: followed } }] };
+    const unfollowedWhere: Prisma.TeamNewsItemWhereInput = { AND: [where, { teamUid: { notIn: followed } }] };
+
+    const [followedTotal, total] = await Promise.all([
+      this.prisma.teamNewsItem.count({ where: followedWhere }),
       this.prisma.teamNewsItem.count({ where }),
     ]);
 
-    const discussions = await this.loadDiscussions(rows.map((r) => r.uid));
+    const rows: Prisma.TeamNewsItemGetPayload<{ include: typeof include }>[] = [];
+    const followedTake = Math.min(query.limit, Math.max(0, followedTotal - skip));
+    if (followedTake > 0) {
+      rows.push(
+        ...(await this.prisma.teamNewsItem.findMany({
+          where: followedWhere,
+          orderBy,
+          skip: Math.min(skip, followedTotal),
+          take: followedTake,
+          include,
+        }))
+      );
+    }
+    const remaining = query.limit - followedTake;
+    if (remaining > 0) {
+      rows.push(
+        ...(await this.prisma.teamNewsItem.findMany({
+          where: unfollowedWhere,
+          orderBy,
+          skip: Math.max(0, skip - followedTotal),
+          take: remaining,
+          include,
+        }))
+      );
+    }
 
+    const discussions = await this.loadDiscussions(rows.map((r) => r.uid));
     return {
       page: query.page,
       limit: query.limit,
       total,
-      items: rows.map((row) => this.toDto(row, discussions.get(row.uid))),
+      items: rows.map((row) => this.toDto(row, discussions.get(row.uid), followedTeamUids)),
     };
   }
 
-  async listTeamNewsByTeam(teamUid: string, query: TeamNewsByTeamQuery): Promise<TeamNewsByTeamResponse> {
+  async listTeamNewsByTeam(
+    teamUid: string,
+    query: TeamNewsByTeamQuery,
+    followedTeamUids: Set<string> = new Set()
+  ): Promise<TeamNewsByTeamResponse> {
     const team = await this.prisma.team.findUnique({
       where: { uid: teamUid },
       select: { uid: true, name: true },
@@ -171,11 +221,14 @@ export class TeamNewsQueryService {
       page: query.page,
       limit: query.limit,
       total,
-      items: rows.map((row) => this.toDto(row, discussions.get(row.uid))),
+      items: rows.map((row) => this.toDto(row, discussions.get(row.uid), followedTeamUids)),
     };
   }
 
-  async listGroupedByFocusArea(query: TeamNewsListQuery): Promise<TeamNewsGroupedResponse> {
+  async listGroupedByFocusArea(
+    query: TeamNewsListQuery,
+    followedTeamUids: Set<string> = new Set()
+  ): Promise<TeamNewsGroupedResponse> {
     const where = this.buildWhere(query);
     const rows = await this.prisma.teamNewsItem.findMany({
       where,
@@ -203,12 +256,20 @@ export class TeamNewsQueryService {
 
     const groups = new Map<string, TeamNewsItemDto[]>();
     for (const row of rows) {
-      const dto = this.toDto(row, discussions.get(row.uid));
+      const dto = this.toDto(row, discussions.get(row.uid), followedTeamUids);
       if (dto.focusAreas.length === 0) continue;
       for (const title of dto.focusAreas) {
         if (!focusByTitle.has(title)) continue;
         if (!groups.has(title)) groups.set(title, []);
         groups.get(title)!.push(dto);
+      }
+    }
+
+    // Within each focus-area group, surface followed-team news first while
+    // preserving the eventDate-desc order the rows arrived in (stable sort).
+    if (followedTeamUids.size > 0) {
+      for (const items of groups.values()) {
+        items.sort((a, b) => Number(b.isFollowed) - Number(a.isFollowed));
       }
     }
 
@@ -394,7 +455,8 @@ export class TeamNewsQueryService {
         }>;
       };
     },
-    discussion: TeamNewsDiscussion | undefined
+    discussion: TeamNewsDiscussion | undefined,
+    followedTeamUids: Set<string> = new Set()
   ): TeamNewsItemDto {
     const focusAreas: string[] = [];
     const subFocusAreas: string[] = [];
@@ -421,6 +483,7 @@ export class TeamNewsQueryService {
       subFocusAreas: [...new Set(subFocusAreas)],
       createdAt: row.createdAt.toISOString(),
       discussion: discussion ?? EMPTY_DISCUSSION,
+      isFollowed: followedTeamUids.has(row.teamUid),
     };
   }
 }

--- a/apps/web-api/src/team-news/team-news.controller.ts
+++ b/apps/web-api/src/team-news/team-news.controller.ts
@@ -10,9 +10,11 @@ import {
 } from 'libs/contracts/src/schema/team-news';
 import { NoCache } from '../decorators/no-cache.decorator';
 import { UserTokenValidation } from '../guards/user-token-validation.guard';
+import { UserTokenCheckGuard } from '../guards/user-token-check.guard';
 import { MembersService } from '../members/members.service';
 import { AccessControlV2Service } from '../access-control-v2/services/access-control-v2.service';
 import { FORUM_PERMISSIONS } from '../access-control-v2/access-control-v2.constants';
+import { FollowsService } from '../follows/follows.service';
 import { TeamNewsQueryService } from './team-news-query.service';
 import { TeamNewsService } from './team-news.service';
 
@@ -26,21 +28,26 @@ export class TeamNewsController {
     private readonly teamNewsQueryService: TeamNewsQueryService,
     private readonly teamNewsService: TeamNewsService,
     private readonly membersService: MembersService,
-    private readonly accessControl: AccessControlV2Service
+    private readonly accessControl: AccessControlV2Service,
+    private readonly followsService: FollowsService
   ) {}
 
   @Api(server.route.getTeamNews)
   @NoCache()
-  async getTeamNews(@Req() request: Request) {
+  @UseGuards(UserTokenCheckGuard)
+  async getTeamNews(@Req() request: Request & { userEmail?: string }) {
     const params = TeamNewsListQueryParams.parse(request.query);
-    return this.teamNewsQueryService.listTeamNews(params);
+    const followed = await this.resolveFollowedTeamUids(request.userEmail);
+    return this.teamNewsQueryService.listTeamNews(params, followed);
   }
 
   @Api(server.route.getTeamNewsGrouped)
   @NoCache()
-  async getTeamNewsGrouped(@Req() request: Request) {
+  @UseGuards(UserTokenCheckGuard)
+  async getTeamNewsGrouped(@Req() request: Request & { userEmail?: string }) {
     const params = TeamNewsListQueryParams.parse(request.query);
-    return this.teamNewsQueryService.listGroupedByFocusArea(params);
+    const followed = await this.resolveFollowedTeamUids(request.userEmail);
+    return this.teamNewsQueryService.listGroupedByFocusArea(params, followed);
   }
 
   @Api(server.route.getTeamNewsFilters)
@@ -71,9 +78,11 @@ export class TeamNewsController {
 
   @Api(server.route.getTeamNewsByTeam)
   @NoCache()
-  async getTeamNewsByTeam(@Param('teamUid') teamUid: string, @Req() request: Request) {
+  @UseGuards(UserTokenCheckGuard)
+  async getTeamNewsByTeam(@Param('teamUid') teamUid: string, @Req() request: Request & { userEmail?: string }) {
     const params = TeamNewsByTeamQueryParams.parse(request.query);
-    return this.teamNewsQueryService.listTeamNewsByTeam(teamUid, params);
+    const followed = await this.resolveFollowedTeamUids(request.userEmail);
+    return this.teamNewsQueryService.listTeamNewsByTeam(teamUid, params, followed);
   }
 
   @Api(server.route.createTeamNewsDiscussion)
@@ -104,5 +113,21 @@ export class TeamNewsController {
     }
 
     return this.teamNewsService.createForumLink(newsItemUid, validated, member.uid);
+  }
+
+  /**
+   * Resolve the authenticated caller's followed-team UIDs (empty set when
+   * anonymous or not a member). Used to stamp `isFollowed` and order
+   * followed-team news first on the public news endpoints.
+   */
+  private async resolveFollowedTeamUids(userEmail?: string): Promise<Set<string>> {
+    if (!userEmail) {
+      return new Set();
+    }
+    const member = await this.membersService.findMemberByEmail(userEmail);
+    if (!member) {
+      return new Set();
+    }
+    return this.followsService.getFollowedTeamUids(member.uid);
   }
 }

--- a/apps/web-api/src/team-news/team-news.module.ts
+++ b/apps/web-api/src/team-news/team-news.module.ts
@@ -3,6 +3,7 @@ import { SharedModule } from '../shared/shared.module';
 import { MembersModule } from '../members/members.module';
 import { AccessControlV2Module } from '../access-control-v2/access-control-v2.module';
 import { PushNotificationsModule } from '../push-notifications/push-notifications.module';
+import { FollowsModule } from '../follows/follows.module';
 import { TeamNewsController } from './team-news.controller';
 import { TeamNewsServiceController } from './team-news-service.controller';
 import { TeamNewsService } from './team-news.service';
@@ -10,7 +11,7 @@ import { TeamNewsQueryService } from './team-news-query.service';
 import { TeamNewsEnrichmentService } from './team-news-enrichment.service';
 
 @Module({
-  imports: [SharedModule, forwardRef(() => MembersModule), AccessControlV2Module, PushNotificationsModule],
+  imports: [SharedModule, forwardRef(() => MembersModule), AccessControlV2Module, PushNotificationsModule, FollowsModule],
   controllers: [TeamNewsController, TeamNewsServiceController],
   providers: [TeamNewsService, TeamNewsQueryService, TeamNewsEnrichmentService],
   exports: [TeamNewsService, TeamNewsQueryService, TeamNewsEnrichmentService],

--- a/apps/web-api/src/teams/teams.controller.ts
+++ b/apps/web-api/src/teams/teams.controller.ts
@@ -31,6 +31,7 @@ import { PrismaQueryBuilder } from '../utils/prisma-query-builder';
 import { ENABLED_RETRIEVAL_PROFILE } from '../utils/prisma-query-builder/profile/defaults';
 import { prismaQueryableFieldsFromZod } from '../utils/prisma-queryable-fields-from-zod';
 import { TeamsService } from './teams.service';
+import { FollowsService } from '../follows/follows.service';
 import { TeamEnrichmentService } from '../team-enrichment/team-enrichment.service';
 import { NoCache } from '../decorators/no-cache.decorator';
 import { UserTokenValidation } from '../guards/user-token-validation.guard';
@@ -50,7 +51,8 @@ export class TeamsController {
   constructor(
     private readonly teamsService: TeamsService,
     private readonly membersService: MembersService,
-    private readonly teamEnrichmentService: TeamEnrichmentService
+    private readonly teamEnrichmentService: TeamEnrichmentService,
+    private readonly followsService: FollowsService
   ) {}
 
   @Api(server.route.teamFilters)
@@ -84,7 +86,8 @@ export class TeamsController {
   @ApiQueryFromZod(TeamQueryParams)
   @ApiOkResponseFromZod(ResponseTeamWithRelationsSchema.array())
   @NoCache()
-  findAll(@Req() request: Request) {
+  @UseGuards(UserTokenCheckGuard)
+  async findAll(@Req() request: Request) {
     const queryableFields = prismaQueryableFieldsFromZod(ResponseTeamWithRelationsSchema);
     const builder = new PrismaQueryBuilder(queryableFields);
     const builtQuery = builder.build(request.query);
@@ -149,7 +152,32 @@ export class TeamsController {
       builtQuery.include = { investorProfile: true, logo: { select: { url: true } } };
     }
 
-    return this.teamsService.findAll(builtQuery);
+    const result = await this.teamsService.findAll(builtQuery);
+    // Stamp `isFollowed` per team for the authenticated caller (false for all
+    // when anonymous). Optional auth via UserTokenCheckGuard keeps this public.
+    await this.stampIsFollowed(result.teams, request['userEmail']);
+    return result;
+  }
+
+  /**
+   * Adds an `isFollowed` boolean to each team in a list for the current member.
+   * Resolves the member's followed-team set once (no per-row query) and defaults
+   * every team to `false` when the request is anonymous.
+   */
+  private async stampIsFollowed(teams: any[], userEmail?: string): Promise<void> {
+    if (!Array.isArray(teams) || teams.length === 0) {
+      return;
+    }
+    let followed = new Set<string>();
+    if (userEmail) {
+      const member = await this.membersService.findMemberByEmail(userEmail);
+      if (member) {
+        followed = await this.followsService.getFollowedTeamUids(member.uid);
+      }
+    }
+    for (const team of teams) {
+      team.isFollowed = team?.uid ? followed.has(team.uid) : false;
+    }
   }
 
   @Api(server.route.getTeam)

--- a/apps/web-api/src/teams/teams.module.ts
+++ b/apps/web-api/src/teams/teams.module.ts
@@ -10,6 +10,7 @@ import { AdminModule } from "../admin/admin.module";
 import { ParticipantsRequestModule } from "../participants-request/participants-request.module";
 import { OpenSearchModule } from '../opensearch/opensearch.module';
 import { TeamEnrichmentModule } from '../team-enrichment/team-enrichment.module';
+import { FollowsModule } from '../follows/follows.module';
 import { JwtService } from '../utils/jwt/jwt.service';
 
 @Module({
@@ -22,6 +23,7 @@ import { JwtService } from '../utils/jwt/jwt.service';
     HuskyModule,
     OpenSearchModule,
     forwardRef(() => TeamEnrichmentModule),
+    FollowsModule,
   ],
   controllers: [TeamsController],
   providers: [TeamsService, TeamsHooksService, JwtService],

--- a/docs/FOLLOW.md
+++ b/docs/FOLLOW.md
@@ -1,0 +1,237 @@
+# Follow (Teams)
+
+> Status: **Shipped — teams only.** The storage model and contracts are designed to extend to other followable entities (members) without a schema change.
+
+Lets a member **follow** and **unfollow** teams, see the **teams they follow**, and (for a team's own members and directory admins) see **who follows a team**. Following also personalizes the rest of the directory: the teams list and the team-news feed expose an `isFollowed` flag, followed-team news is surfaced first, and the `TEAM_NEWS` push notification names the teams a member actually follows.
+
+The follow relationship lives in a single **polymorphic `Follow` table** (`memberUid` → `entityType` + `entityUid`). Today only `entityType = TEAM` rows exist; member-follows-member is added later by writing `entityType = MEMBER` rows — no migration to the table shape required.
+
+## Data model
+
+```prisma
+enum FollowEntityType {
+  TEAM
+  MEMBER
+}
+
+model Follow {
+  id         Int              @id @default(autoincrement())
+  uid        String           @unique @default(cuid())
+  member     Member           @relation("MemberFollowing", fields: [memberUid], references: [uid], onDelete: Cascade)
+  memberUid  String
+  entityType FollowEntityType @default(TEAM)
+  entityUid  String
+  createdAt  DateTime         @default(now())
+  updatedAt  DateTime         @updatedAt
+
+  @@unique([memberUid, entityType, entityUid])
+  @@index([entityType, entityUid])
+  @@index([memberUid, entityType])
+}
+```
+
+- **`memberUid`** is the follower. It is a real FK to `Member.uid` with `onDelete: Cascade`, so deleting a member removes all of their follows.
+- **`entityType` + `entityUid`** is the followed thing. `entityUid` is **intentionally not a hard FK** — it references different tables per `entityType` (`Team.uid` for `TEAM`, `Member.uid` for `MEMBER` later). Cleanup of a deleted followed entity is handled in the service layer / by that entity's own cascades.
+- **`@@unique([memberUid, entityType, entityUid])`** makes follow/unfollow idempotent and prevents duplicate edges.
+- The two indexes serve the two read directions: `(entityType, entityUid)` for "who follows this entity" and `(memberUid, entityType)` for "what does this member follow".
+
+Migration: `apps/web-api/prisma/migrations/20260629120000_add_follow/`.
+
+## Endpoints
+
+| Method | Path | Auth | Notes |
+|--------|------|------|-------|
+| POST   | `/v1/teams/:teamUid/follow`            | `UserTokenValidation` (required) | Follow a team. Idempotent. |
+| DELETE | `/v1/teams/:teamUid/follow`            | `UserTokenValidation` (required) | Unfollow a team. Idempotent. |
+| GET    | `/v1/members/me/following/teams`       | `UserTokenValidation` (required) | Teams the caller follows, paginated, most-recent-follow first. |
+| GET    | `/v1/teams/:teamUid/followers`         | `UserTokenValidation` (required) | A team's followers. **403** unless caller is a member of the team or a directory admin. |
+| GET    | `/v1/teams`                            | `UserTokenCheckGuard` (optional) | Existing endpoint; each team now carries `isFollowed`. |
+| GET    | `/v1/team-news`                        | `UserTokenCheckGuard` (optional) | Existing endpoint; items carry `isFollowed`; followed-team news ordered first. |
+| GET    | `/v1/team-news/grouped-by-focus-area`  | `UserTokenCheckGuard` (optional) | Existing endpoint; `isFollowed` + followed-first within each group. |
+| GET    | `/v1/teams/:teamUid/team-news`         | `UserTokenCheckGuard` (optional) | Existing endpoint; items carry `isFollowed`. |
+
+Endpoints requiring auth use `UserTokenValidation` (rejects with **401** when no/invalid token). The four read endpoints use the **optional** `UserTokenCheckGuard` so they remain public: an anonymous caller gets `isFollowed: false` everywhere and the original ordering.
+
+Contracts: `libs/contracts/src/lib/contract-follow.ts` + `libs/contracts/src/schema/follow.ts`. Implementation: `apps/web-api/src/follows/`.
+
+Examples below use a member access token (`-H "Authorization: Bearer $TOKEN"`) and the seeded local data where the **Directory Admin** member follows _Murazik, Leannon and Cremin_, _Ernser, Borer and Zboncak_, and _Beer - Stamm_.
+
+### Follow a team
+
+`POST /v1/teams/:teamUid/follow`
+
+Idempotent — following an already-followed team returns `201` with the same state. The response reflects the resulting follow state and the team's current follower count, so a UI can toggle off a single field.
+
+```bash
+curl -X POST "http://localhost:3000/v1/teams/uid-murazik-leannon-and-cremin/follow" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{
+  "following": true,
+  "entityType": "TEAM",
+  "entityUid": "uid-murazik-leannon-and-cremin",
+  "followerCount": 1
+}
+```
+
+`404` if the team does not exist; `401` if unauthenticated.
+
+### Unfollow a team
+
+`DELETE /v1/teams/:teamUid/follow`
+
+Idempotent — unfollowing a team you don't follow returns `200` with `following: false`.
+
+```bash
+curl -X DELETE "http://localhost:3000/v1/teams/uid-murazik-leannon-and-cremin/follow" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{
+  "following": false,
+  "entityType": "TEAM",
+  "entityUid": "uid-murazik-leannon-and-cremin",
+  "followerCount": 0
+}
+```
+
+### List teams I follow
+
+`GET /v1/members/me/following/teams?page=1&limit=50`
+
+Paginated, most-recently-followed first. `page` defaults to `1`, `limit` defaults to `50` (max `200`). A followed team that no longer exists is dropped from the list.
+
+```bash
+curl "http://localhost:3000/v1/members/me/following/teams?page=1&limit=50" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{
+  "page": 1,
+  "limit": 50,
+  "total": 3,
+  "items": [
+    {
+      "uid": "uid-murazik-leannon-and-cremin",
+      "name": "Murazik, Leannon and Cremin",
+      "logoUrl": "https://loremflickr.com/640/480/animals",
+      "shortDescription": null,
+      "followedAt": "2026-06-28T17:32:42.747Z",
+      "followerCount": 1
+    },
+    {
+      "uid": "uid-ernser-borer-and-zboncak",
+      "name": "Ernser, Borer and Zboncak",
+      "logoUrl": "https://loremflickr.com/640/480/animals",
+      "shortDescription": null,
+      "followedAt": "2026-06-27T17:32:42.747Z",
+      "followerCount": 1
+    },
+    {
+      "uid": "uid-beer---stamm",
+      "name": "Beer - Stamm",
+      "logoUrl": "https://loremflickr.com/640/480/animals",
+      "shortDescription": null,
+      "followedAt": "2026-06-26T17:32:42.747Z",
+      "followerCount": 3
+    }
+  ]
+}
+```
+
+### List a team's followers
+
+`GET /v1/teams/:teamUid/followers?page=1&limit=50`
+
+Restricted: the caller must be a **member of the team** or a **directory admin**, otherwise the endpoint returns `403`. Followers are returned most-recent-follow first, paginated.
+
+```bash
+# Called by the Directory Admin (admins can view any team's followers;
+# team members can view their own team's)
+curl "http://localhost:3000/v1/teams/uid-beer---stamm/followers?page=1&limit=50" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{
+  "teamUid": "uid-beer---stamm",
+  "teamName": "Beer - Stamm",
+  "page": 1,
+  "limit": 50,
+  "total": 3,
+  "items": [
+    { "uid": "uid-bud",            "name": "Bud",             "imageUrl": null, "followedAt": "2026-06-29T12:51:35.053Z" },
+    { "uid": "uid-coby",           "name": "Coby",            "imageUrl": null, "followedAt": "2026-06-28T16:51:35.053Z" },
+    { "uid": "uid-directoryadmin", "name": "Directory Admin", "imageUrl": null, "followedAt": "2026-06-26T17:32:42.747Z" }
+  ]
+}
+```
+
+A caller who is neither a member of the team nor a directory admin:
+
+```json
+{ "statusCode": 403, "message": "Only members of this team can view its followers" }
+```
+
+`404` if the team does not exist.
+
+## Integrations with existing endpoints
+
+### `isFollowed` on the teams list
+
+`GET /v1/teams` resolves the caller's followed-team set once per request and stamps an `isFollowed` boolean onto every team in the response (no per-row query). Anonymous callers get `false` for all teams.
+
+```bash
+curl "http://localhost:3000/v1/teams?limit=3" -H "Authorization: Bearer $TOKEN"
+```
+
+```jsonc
+{
+  "count": 160,
+  "teams": [
+    { "uid": "uid-murazik-leannon-and-cremin", "name": "Murazik, Leannon and Cremin", "isFollowed": true,  "...": "..." },
+    { "uid": "uid-kuhn-group",                  "name": "Kuhn Group",                  "isFollowed": false, "...": "..." }
+  ]
+}
+```
+
+### `isFollowed` + followed-first ordering on team news
+
+`GET /v1/team-news`, `GET /v1/team-news/grouped-by-focus-area`, and `GET /v1/teams/:teamUid/team-news` each stamp `isFollowed` on every item. On the flat list and within each focus-area group, **news from followed teams is ordered ahead of the rest** (preserving `eventDate desc` within each segment). The flat list paginates across two ordered segments (followed teams, then everyone else) so the global ordering stays stable across pages.
+
+```bash
+curl "http://localhost:3000/v1/team-news?limit=5&windowDays=365" -H "Authorization: Bearer $TOKEN"
+```
+
+```jsonc
+{
+  "page": 1,
+  "limit": 5,
+  "total": 17,
+  "items": [
+    { "teamName": "Murazik, Leannon and Cremin", "isFollowed": true,  "...": "..." },
+    { "teamName": "Ernser, Borer and Zboncak",   "isFollowed": true,  "...": "..." },
+    { "teamName": "Kuhn Group",                  "isFollowed": false, "...": "..." }
+  ]
+}
+```
+
+### Personalized `TEAM_NEWS` notification copy
+
+`TEAM_NEWS` is a single **public broadcast** row — one copy is stored at ingest time naming the run's most-recent teams. When a member fetches their notifications (`getForUser`), the copy is **rewritten per-recipient**: teams the member follows are floated to the front and named, so the description reads e.g. _"New updates from companies like Lido Finance, Lava Network + 40 more"_ with the member's followed teams first. When the member follows none of the run's teams, the stored most-recent copy is shown unchanged. The rewrite is in-memory only (never persisted), and the reordered `teamUids` plus a `followedTeamUids` list are added to the returned notification's `metadata` for the client.
+
+See also [PUSH_NOTIFICATIONS.md](./PUSH_NOTIFICATIONS.md) and the team-news feature notes.
+
+## Extending to members (future)
+
+The model and surface were built so that "follow a member" is additive:
+
+1. Write `Follow` rows with `entityType = MEMBER` and `entityUid = <Member.uid>` — no migration to the `Follow` table.
+2. Add member-scoped routes mirroring the team ones, e.g. `POST /v1/members/:memberUid/follow` and `GET /v1/members/me/following/members`.
+3. Reuse the existing service methods by parameterizing them on `FollowEntityType` (the team methods are thin wrappers over the same queries).
+
+The `(entityType, entityUid)` and `(memberUid, entityType)` indexes already cover both read directions for any entity type.

--- a/docs/FOLLOW.md
+++ b/docs/FOLLOW.md
@@ -119,7 +119,6 @@ curl "http://localhost:3000/v1/members/me/following/teams?page=1&limit=50" \
       "uid": "uid-murazik-leannon-and-cremin",
       "name": "Murazik, Leannon and Cremin",
       "logoUrl": "https://loremflickr.com/640/480/animals",
-      "shortDescription": null,
       "followedAt": "2026-06-28T17:32:42.747Z",
       "followerCount": 1
     },
@@ -127,7 +126,6 @@ curl "http://localhost:3000/v1/members/me/following/teams?page=1&limit=50" \
       "uid": "uid-ernser-borer-and-zboncak",
       "name": "Ernser, Borer and Zboncak",
       "logoUrl": "https://loremflickr.com/640/480/animals",
-      "shortDescription": null,
       "followedAt": "2026-06-27T17:32:42.747Z",
       "followerCount": 1
     },
@@ -135,7 +133,6 @@ curl "http://localhost:3000/v1/members/me/following/teams?page=1&limit=50" \
       "uid": "uid-beer---stamm",
       "name": "Beer - Stamm",
       "logoUrl": "https://loremflickr.com/640/480/animals",
-      "shortDescription": null,
       "followedAt": "2026-06-26T17:32:42.747Z",
       "followerCount": 3
     }

--- a/libs/contracts/src/lib/contract-follow.ts
+++ b/libs/contracts/src/lib/contract-follow.ts
@@ -1,0 +1,58 @@
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+import {
+  FollowStatusResponseSchema,
+  FollowedTeamsQueryParams,
+  FollowedTeamsResponseSchema,
+  TeamFollowersQueryParams,
+  TeamFollowersResponseSchema,
+} from '../schema/follow';
+import { getAPIVersionAsPath } from '../utils/versioned-path';
+
+const contract = initContract();
+
+/**
+ * Follow feature endpoints. Paths are entity-scoped so the same shape extends
+ * to other followable entities later (e.g. `/members/:memberUid/follow`).
+ */
+export const apiFollow = contract.router({
+  followTeam: {
+    method: 'POST',
+    path: `${getAPIVersionAsPath('1')}/teams/:teamUid/follow`,
+    pathParams: z.object({ teamUid: z.string() }),
+    body: z.object({}).optional(),
+    responses: {
+      201: FollowStatusResponseSchema,
+    },
+    summary: 'Follow a team (authenticated member)',
+  },
+  unfollowTeam: {
+    method: 'DELETE',
+    path: `${getAPIVersionAsPath('1')}/teams/:teamUid/follow`,
+    pathParams: z.object({ teamUid: z.string() }),
+    body: z.object({}).optional(),
+    responses: {
+      200: FollowStatusResponseSchema,
+    },
+    summary: 'Unfollow a team (authenticated member)',
+  },
+  getFollowedTeams: {
+    method: 'GET',
+    path: `${getAPIVersionAsPath('1')}/members/me/following/teams`,
+    query: FollowedTeamsQueryParams,
+    responses: {
+      200: FollowedTeamsResponseSchema,
+    },
+    summary: 'List the teams the authenticated member follows',
+  },
+  getTeamFollowers: {
+    method: 'GET',
+    path: `${getAPIVersionAsPath('1')}/teams/:teamUid/followers`,
+    pathParams: z.object({ teamUid: z.string() }),
+    query: TeamFollowersQueryParams,
+    responses: {
+      200: TeamFollowersResponseSchema,
+    },
+    summary: 'List a team\'s followers (team members and admins only)',
+  },
+});

--- a/libs/contracts/src/schema/follow.ts
+++ b/libs/contracts/src/schema/follow.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+/**
+ * Follow feature shared schemas.
+ *
+ * The persisted edge is polymorphic (see the `Follow` Prisma model): a member
+ * follows an entity identified by `entityType` + `entityUid`. Today only teams
+ * are followable; member-follows-member can be added later without reshaping
+ * these contracts (add `MEMBER` handling alongside `TEAM`).
+ */
+export const FollowEntityTypeSchema = z.enum(['TEAM', 'MEMBER']);
+export type FollowEntityType = z.infer<typeof FollowEntityTypeSchema>;
+
+const PaginationQuery = {
+  page: z
+    .preprocess((v) => (v === undefined || v === '' ? undefined : Number(v)), z.number().int().min(1))
+    .optional()
+    .default(1),
+  limit: z
+    .preprocess((v) => (v === undefined || v === '' ? undefined : Number(v)), z.number().int().min(1).max(200))
+    .optional()
+    .default(50),
+};
+
+export const FollowedTeamsQueryParams = z.object({ ...PaginationQuery });
+export type FollowedTeamsQuery = z.infer<typeof FollowedTeamsQueryParams>;
+
+export const TeamFollowersQueryParams = z.object({ ...PaginationQuery });
+export type TeamFollowersQuery = z.infer<typeof TeamFollowersQueryParams>;
+
+// Response of follow / unfollow mutations. `following` reflects the resulting
+// state, so the client can toggle UI off a single field. Idempotent: following
+// an already-followed team (or unfollowing one not followed) is a success.
+export const FollowStatusResponseSchema = z.object({
+  following: z.boolean(),
+  entityType: FollowEntityTypeSchema,
+  entityUid: z.string(),
+  followerCount: z.number().int().min(0),
+});
+export type FollowStatusResponse = z.infer<typeof FollowStatusResponseSchema>;
+
+// One team in the "teams I follow" list.
+export const FollowedTeamSchema = z.object({
+  uid: z.string(),
+  name: z.string(),
+  logoUrl: z.string().nullable(),
+  shortDescription: z.string().nullable(),
+  followedAt: z.string(),
+  followerCount: z.number().int().min(0),
+});
+export type FollowedTeam = z.infer<typeof FollowedTeamSchema>;
+
+export const FollowedTeamsResponseSchema = z.object({
+  page: z.number().int(),
+  limit: z.number().int(),
+  total: z.number().int(),
+  items: z.array(FollowedTeamSchema),
+});
+export type FollowedTeamsResponse = z.infer<typeof FollowedTeamsResponseSchema>;
+
+// One follower in a team's followers list.
+export const TeamFollowerSchema = z.object({
+  uid: z.string(),
+  name: z.string(),
+  imageUrl: z.string().nullable(),
+  followedAt: z.string(),
+});
+export type TeamFollower = z.infer<typeof TeamFollowerSchema>;
+
+export const TeamFollowersResponseSchema = z.object({
+  teamUid: z.string(),
+  teamName: z.string(),
+  page: z.number().int(),
+  limit: z.number().int(),
+  total: z.number().int(),
+  items: z.array(TeamFollowerSchema),
+});
+export type TeamFollowersResponse = z.infer<typeof TeamFollowersResponseSchema>;

--- a/libs/contracts/src/schema/follow.ts
+++ b/libs/contracts/src/schema/follow.ts
@@ -44,7 +44,6 @@ export const FollowedTeamSchema = z.object({
   uid: z.string(),
   name: z.string(),
   logoUrl: z.string().nullable(),
-  shortDescription: z.string().nullable(),
   followedAt: z.string(),
   followerCount: z.number().int().min(0),
 });

--- a/libs/contracts/src/schema/index.ts
+++ b/libs/contracts/src/schema/index.ts
@@ -44,3 +44,4 @@ export * from './job-alert';
 export * from './team-job-enrichment';
 export * from './team-news';
 export * from './roadmap';
+export * from './follow';

--- a/libs/contracts/src/schema/team-news.ts
+++ b/libs/contracts/src/schema/team-news.ts
@@ -74,6 +74,10 @@ export const TeamNewsItemSchema = z.object({
   subFocusAreas: z.array(z.string()),
   createdAt: z.string(),
   discussion: TeamNewsDiscussionSchema,
+  // True when the authenticated caller follows this item's team. Always false
+  // for anonymous requests. Followed-team news is also surfaced first in the
+  // flat list (`GET /v1/team-news`) and within each focus-area group.
+  isFollowed: z.boolean(),
 });
 
 // POST /v1/team-news/{newsItemUid}/discussions — links a TeamNewsItem to a


### PR DESCRIPTION
## Summary

Adds the ability for a member to **follow / unfollow teams** and surfaces "follow" context across the directory. The follow edge is stored in a new, **polymorphic `Follow` table** (`memberUid` → `entityType` + `entityUid`). Today only teams are followable; the same table and contracts extend to member-follows-member later by adding `entityType = MEMBER` rows — **no schema reshaping required**.

See [FOLLOW.md](https://github.com/memser-spaceport/pln-directory-portal/blob/feat/LAB-2074-follow-implement-follow-team-api/docs/FOLLOW.md) for more details

### What's included

**New endpoints**
- `POST   /v1/teams/:teamUid/follow` — follow a team (auth required, idempotent)
- `DELETE /v1/teams/:teamUid/follow` — unfollow a team (auth required, idempotent)
- `GET    /v1/members/me/following/teams` — teams the caller follows (paginated)
- `GET    /v1/teams/:teamUid/followers` — a team's followers (team members + admins only)

**Updated endpoints**
- `GET /v1/teams` — each team now carries an `isFollowed` boolean for the caller.
- `GET /v1/team-news` and `GET /v1/team-news/grouped-by-focus-area` — news items now carry `isFollowed`, and **followed-team news is ordered first** (in the flat list and within each focus-area group). `GET /v1/teams/:teamUid/team-news` also stamps `isFollowed`.
- **TEAM_NEWS notification copy is personalized per recipient**: instead of naming the run's most-recent teams, it now names the teams **that member follows** (e.g. _"New updates from companies like Lido Finance, Lava Network + 40 more"_), floating followed teams to the front. When the member follows none of the run's teams, the stored most-recent copy is shown unchanged.

All three updated read endpoints use **optional auth** (`UserTokenCheckGuard`) so they stay public — anonymous callers get `isFollowed: false` everywhere and the original ordering.

### Design notes
- `Follow` is polymorphic and extensible: `@@unique([memberUid, entityType, entityUid])`, indexed on `(entityType, entityUid)` (followers-of-entity) and `(memberUid, entityType)` (entities-followed-by-member). The follower side (`memberUid`) is a real FK with cascade delete; `entityUid` is intentionally not a hard FK because it points at different tables per `entityType`.
- Follow/unfollow are **idempotent** (upsert / deleteMany), so retries and double-clicks are safe.
- `isFollowed` is resolved once per request as a `Set` of followed team UIDs (no N+1).
- Followed-first news ordering paginates across two ordered segments (followed teams, then the rest), so the global ordering is stable across pages.

### Migration
- `apps/web-api/prisma/migrations/20260629120000_add_follow/` — creates the `FollowEntityType` enum, the `Follow` table, its indexes, and the member FK.

---

## Endpoint reference & examples

Base URL in examples: `http://localhost:3000`. Authenticated calls send a member access token: `-H "Authorization: Bearer $TOKEN"`. Examples use seeded data (member **Marcia** follows _Murazik, Leannon and Cremin_, _Ernser, Borer and Zboncak_, and _Beer - Stamm_; member **Richmond** is a member of _Beer - Stamm_).

### 1. Follow a team

```bash
curl -X POST "http://localhost:3000/v1/teams/uid-murazik-leannon-and-cremin/follow" \
  -H "Authorization: Bearer $TOKEN"
```

```json
{
  "following": true,
  "entityType": "TEAM",
  "entityUid": "uid-murazik-leannon-and-cremin",
  "followerCount": 1
}
```

### 2. Unfollow a team

```bash
curl -X DELETE "http://localhost:3000/v1/teams/uid-murazik-leannon-and-cremin/follow" \
  -H "Authorization: Bearer $TOKEN"
```

```json
{
  "following": false,
  "entityType": "TEAM",
  "entityUid": "uid-murazik-leannon-and-cremin",
  "followerCount": 0
}
```

### 3. List teams I follow

```bash
curl "http://localhost:3000/v1/members/me/following/teams?page=1&limit=50" \
  -H "Authorization: Bearer $TOKEN"
```

```json
{
  "page": 1,
  "limit": 50,
  "total": 3,
  "items": [
    {
      "uid": "uid-murazik-leannon-and-cremin",
      "name": "Murazik, Leannon and Cremin",
      "logoUrl": "https://loremflickr.com/640/480/animals",
      "followedAt": "2026-06-28T16:51:35.053Z",
      "followerCount": 1
    },
    {
      "uid": "uid-ernser-borer-and-zboncak",
      "name": "Ernser, Borer and Zboncak",
      "logoUrl": "https://loremflickr.com/640/480/animals",
      "followedAt": "2026-06-27T16:51:35.053Z",
      "followerCount": 1
    },
    {
      "uid": "uid-beer---stamm",
      "name": "Beer - Stamm",
      "logoUrl": "https://loremflickr.com/640/480/animals",
      "followedAt": "2026-06-26T16:51:35.053Z",
      "followerCount": 3
    }
  ]
}
```

### 4. List a team's followers (team members + admins only)

```bash
# Called by Richmond, a member of "Beer - Stamm"
curl "http://localhost:3000/v1/teams/uid-beer---stamm/followers?page=1&limit=50" \
  -H "Authorization: Bearer $TOKEN"
```

```json
{
  "teamUid": "uid-beer---stamm",
  "teamName": "Beer - Stamm",
  "page": 1,
  "limit": 50,
  "total": 3,
  "items": [
    { "uid": "uid-bud",    "name": "Bud",    "imageUrl": null, "followedAt": "2026-06-29T12:51:35.053Z" },
    { "uid": "uid-coby",   "name": "Coby",   "imageUrl": null, "followedAt": "2026-06-28T16:51:35.053Z" },
    { "uid": "uid-marcia", "name": "Marcia", "imageUrl": null, "followedAt": "2026-06-26T16:51:35.053Z" }
  ]
}
```

A caller who is neither a member of the team nor a directory admin receives:

```json
{ "statusCode": 403, "message": "Only members of this team can view its followers" }
```

### 5. Get teams — `isFollowed` flag

```bash
# Anonymous (or any caller without a follow): isFollowed is false for all
curl "http://localhost:3000/v1/teams?limit=3"
```

```json
{
  "count": 160,
  "teams": [
    { "uid": "...", "name": "Kuhn Group",        "isFollowed": false, "...": "..." },
    { "uid": "uid-beer---stamm", "name": "Beer - Stamm", "isFollowed": false, "...": "..." }
  ]
}
```

Authenticated (as Marcia), followed teams come back with `"isFollowed": true`.

### 6. Get team news — `isFollowed` + followed-first ordering

```bash
# Anonymous: isFollowed false, default eventDate-desc ordering
curl "http://localhost:3000/v1/team-news?limit=5&windowDays=365"
```

```json
{
  "page": 1,
  "limit": 5,
  "total": 17,
  "items": [
    { "teamName": "Ernser, Borer and Zboncak",    "isFollowed": false, "...": "..." },
    { "teamName": "Murazik, Leannon and Cremin",  "isFollowed": false, "...": "..." }
  ]
}
```

Authenticated (as Marcia), news from _Murazik_ and _Ernser_ (teams she follows) is ordered ahead of the rest and each carries `"isFollowed": true`.

---

## Ticket

[LAB-2074](https://linear.app/plrs-labos/issue/LAB-2074/follow-implement-follow-team-api)
