### PR TITLE
LAB-2090 [AI Apps] Feedback form on app detail page

### DIFF
--- a/apps/web-api/prisma/migrations/20260706130000_ai_apps_feedback/migration.sql
+++ b/apps/web-api/prisma/migrations/20260706130000_ai_apps_feedback/migration.sql
@@ -1,0 +1,17 @@
+-- AI Apps: free-text feedback left by PL Infra members on an app's detail page.
+-- A member may submit multiple entries per app; the list is readable only by
+-- the app's creator and directory admins (enforced in the service).
+
+CREATE TABLE IF NOT EXISTS "AiAppFeedback" (
+  "id" SERIAL NOT NULL,
+  "uid" TEXT NOT NULL,
+  "appUid" TEXT NOT NULL,
+  "memberUid" TEXT NOT NULL,
+  "text" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "AiAppFeedback_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "AiAppFeedback_uid_key" ON "AiAppFeedback"("uid");
+CREATE INDEX IF NOT EXISTS "AiAppFeedback_appUid_idx" ON "AiAppFeedback"("appUid");
+CREATE INDEX IF NOT EXISTS "AiAppFeedback_memberUid_idx" ON "AiAppFeedback"("memberUid");

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -2976,6 +2976,23 @@ model AiApp {
   @@index([status])
 }
 
+/// Free-text feedback left by a PL Infra member on an app's detail page. A
+/// member may submit multiple entries per app. Readable only by the app's
+/// creator and directory admins (enforced in the service).
+model AiAppFeedback {
+  id        Int      @id @default(autoincrement())
+  uid       String   @unique @default(cuid())
+  /// The app the feedback is about (AiApp.uid; no FK relation, matching the other POC tables).
+  appUid    String
+  /// The member who submitted the feedback.
+  memberUid String
+  text      String
+  createdAt DateTime @default(now())
+
+  @@index([appUid])
+  @@index([memberUid])
+}
+
 enum AiAppConnectStatus {
   PENDING // session started by the agent, awaiting member login + approval
   APPROVED // member logged in with ai_apps.write; a short-lived deploy token was issued

--- a/apps/web-api/src/ai-apps/ai-apps-feedback.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-feedback.spec.ts
@@ -1,0 +1,102 @@
+/// <reference types="multer" />
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+
+// axios ships ESM (not in the jest transform allowlist) and the feedback paths
+// under test never call it.
+jest.mock('axios', () => ({ isAxiosError: jest.fn(() => false) }));
+
+import { AiAppsService } from './ai-apps.service';
+
+const APP = { uid: 'app-1', memberUid: 'creator-1', appId: 'demo' };
+
+function buildService(overrides: Record<string, any> = {}) {
+  const prisma = {
+    aiApp: { findUnique: jest.fn().mockResolvedValue(APP) },
+    aiAppFeedback: {
+      create: jest
+        .fn()
+        .mockImplementation(({ data }) => Promise.resolve({ uid: 'fb-1', createdAt: new Date(0), ...data })),
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    member: {
+      findMany: jest.fn().mockResolvedValue([]),
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
+    ...overrides,
+  };
+  return { service: new AiAppsService(prisma as any, {} as any), prisma };
+}
+
+describe('AiAppsService feedback', () => {
+  describe('submitFeedback', () => {
+    it('throws 404 when the app does not exist', async () => {
+      const { service, prisma } = buildService();
+      prisma.aiApp.findUnique.mockResolvedValue(null);
+      await expect(service.submitFeedback('member-1', 'missing', 'hi')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('stores feedback for any member and allows repeat submissions', async () => {
+      const { service, prisma } = buildService();
+      await service.submitFeedback('member-1', 'app-1', 'first');
+      await service.submitFeedback('member-1', 'app-1', 'second');
+      expect(prisma.aiAppFeedback.create).toHaveBeenCalledTimes(2);
+      expect(prisma.aiAppFeedback.create).toHaveBeenLastCalledWith({
+        data: { appUid: 'app-1', memberUid: 'member-1', text: 'second' },
+      });
+    });
+
+    it('returns the submitter as `member` instead of raw memberUid', async () => {
+      const { service, prisma } = buildService();
+      prisma.member.findMany.mockResolvedValue([{ uid: 'member-1', name: 'Ada' }]);
+      const result = await service.submitFeedback('member-1', 'app-1', 'hi');
+      expect(result.member).toEqual({ uid: 'member-1', name: 'Ada' });
+      expect(result).not.toHaveProperty('memberUid');
+    });
+  });
+
+  describe('listFeedback', () => {
+    it('throws 404 when the app does not exist', async () => {
+      const { service, prisma } = buildService();
+      prisma.aiApp.findUnique.mockResolvedValue(null);
+      await expect(service.listFeedback('creator-1', 'missing')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('allows the app creator', async () => {
+      const { service, prisma } = buildService();
+      await expect(service.listFeedback('creator-1', 'app-1')).resolves.toEqual([]);
+      // No admin lookup needed for the creator.
+      expect(prisma.member.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('allows a directory admin who is not the creator', async () => {
+      const { service, prisma } = buildService();
+      prisma.member.findUnique.mockResolvedValue({ memberRoles: [{ name: 'DIRECTORYADMIN' }] });
+      await expect(service.listFeedback('admin-1', 'app-1')).resolves.toEqual([]);
+    });
+
+    it('rejects a regular viewer who is neither creator nor admin', async () => {
+      const { service, prisma } = buildService();
+      prisma.member.findUnique.mockResolvedValue({ memberRoles: [] });
+      await expect(service.listFeedback('viewer-1', 'app-1')).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('returns feedback newest first with submitter info', async () => {
+      const { service, prisma } = buildService();
+      prisma.aiAppFeedback.findMany.mockResolvedValue([
+        { uid: 'fb-2', appUid: 'app-1', memberUid: 'member-2', text: 'later', createdAt: new Date(2) },
+        { uid: 'fb-1', appUid: 'app-1', memberUid: 'member-1', text: 'earlier', createdAt: new Date(1) },
+      ]);
+      prisma.member.findMany.mockResolvedValue([{ uid: 'member-2', name: 'Bea' }]);
+
+      const result = await service.listFeedback('creator-1', 'app-1');
+      expect(prisma.aiAppFeedback.findMany).toHaveBeenCalledWith({
+        where: { appUid: 'app-1' },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(result.map((f) => f.text)).toEqual(['later', 'earlier']);
+      expect(result[0].member).toEqual({ uid: 'member-2', name: 'Bea' });
+      // Unknown submitter resolves to null rather than leaking the uid.
+      expect(result[1].member).toBeNull();
+    });
+  });
+});

--- a/apps/web-api/src/ai-apps/ai-apps.controller.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.controller.ts
@@ -31,6 +31,7 @@ import { AiAppTokenGuard } from './guards/ai-app-token.guard';
 import { DeployAppDto } from './dto/deploy-app.dto';
 import { StartConnectDto } from './dto/start-connect.dto';
 import { PollConnectDto } from './dto/poll-connect.dto';
+import { SubmitFeedbackDto } from './dto/submit-feedback.dto';
 import { AI_APPS_MAX_ZIP_BYTES } from './ai-apps.constants';
 
 const READ = { anyOf: [AI_APPS_PERMISSIONS.READ, AI_APPS_PERMISSIONS.WRITE] };
@@ -130,6 +131,33 @@ export class AiAppsController {
   async getAppEvents(@Param('uid') uid: string, @Query('limit') limit?: string) {
     await this.aiAppsService.getApp(uid); // 404 if the app doesn't exist
     return this.aiAppsService.listEvents(uid, limit ? Number(limit) : undefined);
+  }
+
+  /**
+   * Submit free-text feedback on an app from its detail page. Any member with
+   * AI Apps access may submit, more than once per app.
+   */
+  @NoCache()
+  @Post(':uid/feedback')
+  @UseGuards(UserTokenCheckGuard, RbacGuard)
+  @RequirePermissions(READ)
+  @UsePipes(ZodValidationPipe)
+  async submitFeedback(@Param('uid') uid: string, @Body() body: SubmitFeedbackDto, @Req() req: any) {
+    const memberUid = await this.resolveMemberUid(req);
+    return this.aiAppsService.submitFeedback(memberUid, uid, body.text);
+  }
+
+  /**
+   * All feedback for one app, newest first. Restricted to the app's creator and
+   * directory admins (checked in the service).
+   */
+  @NoCache()
+  @Get(':uid/feedback')
+  @UseGuards(UserTokenCheckGuard, RbacGuard)
+  @RequirePermissions(READ)
+  async listFeedback(@Param('uid') uid: string, @Req() req: any) {
+    const memberUid = await this.resolveMemberUid(req);
+    return this.aiAppsService.listFeedback(memberUid, uid);
   }
 
   /**

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -1,13 +1,15 @@
 import {
   BadGatewayException,
+  ForbiddenException,
   Injectable,
   InternalServerErrorException,
   Logger,
   NotFoundException,
 } from '@nestjs/common';
 import axios from 'axios';
-import { AiApp, AiAppEvent, AiAppEventType } from '@prisma/client';
+import { AiApp, AiAppEvent, AiAppEventType, AiAppFeedback } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
+import { isDirectoryAdmin } from '../utils/constants';
 import { AwsService } from '../utils/aws/aws.service';
 import { DeployAppDto } from './dto/deploy-app.dto';
 import {
@@ -106,6 +108,46 @@ export class AiAppsService {
       take: Math.min(Math.max(limit, 1), 500),
     });
     return this.withMember(events);
+  }
+
+  /**
+   * Stores free-text feedback from a member viewing the app's detail page. Any
+   * member with AI Apps access may submit, and may do so more than once per app.
+   */
+  async submitFeedback(memberUid: string, appUid: string, text: string): Promise<WithMember<AiAppFeedback>> {
+    const app = await this.prisma.aiApp.findUnique({ where: { uid: appUid } });
+    if (!app) {
+      throw new NotFoundException(`AI App not found: ${appUid}`);
+    }
+    const feedback = await this.prisma.aiAppFeedback.create({
+      data: { appUid: app.uid, memberUid, text },
+    });
+    return (await this.withMember([feedback]))[0];
+  }
+
+  /**
+   * All feedback for one app, newest first, with submitter info. Visible only
+   * to the app's creator and directory admins.
+   */
+  async listFeedback(requesterUid: string, appUid: string): Promise<Array<WithMember<AiAppFeedback>>> {
+    const app = await this.prisma.aiApp.findUnique({ where: { uid: appUid } });
+    if (!app) {
+      throw new NotFoundException(`AI App not found: ${appUid}`);
+    }
+    if (app.memberUid !== requesterUid) {
+      const requester = await this.prisma.member.findUnique({
+        where: { uid: requesterUid },
+        select: { memberRoles: { select: { name: true } } },
+      });
+      if (!requester || !isDirectoryAdmin(requester)) {
+        throw new ForbiddenException('Only the app creator or a directory admin can view feedback');
+      }
+    }
+    const feedback = await this.prisma.aiAppFeedback.findMany({
+      where: { appUid: app.uid },
+      orderBy: { createdAt: 'desc' },
+    });
+    return this.withMember(feedback);
   }
 
   /**

--- a/apps/web-api/src/ai-apps/dto/submit-feedback.dto.ts
+++ b/apps/web-api/src/ai-apps/dto/submit-feedback.dto.ts
@@ -1,0 +1,12 @@
+import { createZodDto } from '@abitia/zod-dto';
+import { z } from 'zod';
+
+/**
+ * Body posted from the app detail page to `POST /v1/ai-apps/:uid/feedback`.
+ * Free-text only; a member may submit multiple entries per app.
+ */
+export const SubmitFeedbackSchema = z.object({
+  text: z.string().trim().min(1).max(4000),
+});
+
+export class SubmitFeedbackDto extends createZodDto(SubmitFeedbackSchema) {}

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -90,6 +90,8 @@ The `deployToken` is held in agent memory only and never written into the kit, s
 | GET    | `/v1/ai-apps/events`             | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Event log (audit feed); `?appUid=` to scope, `?limit=` (default 100, max 500) |
 | GET    | `/v1/ai-apps/:uid`               | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Single app detail |
 | GET    | `/v1/ai-apps/:uid/events`        | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Full event/status history for one app (404 if app missing) |
+| POST   | `/v1/ai-apps/:uid/feedback`      | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Submit free-text feedback on an app (multiple entries per member allowed) |
+| GET    | `/v1/ai-apps/:uid/feedback`      | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` + creator/directory-admin (checked in service) | All feedback for one app, newest first, with submitter info |
 | GET    | `/v1/ai-apps/starter-kit/download` | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.write`   | Stream the starter-kit ZIP (no token inside) |
 | POST   | `/v1/ai-apps/connect`            | none (agent)                  | —                 | Start a connect session; returns `connectUrl`/`userCode`/`pollToken` |
 | POST   | `/v1/ai-apps/connect/poll`       | none (agent, `pollToken` in body) | —             | Poll a session; returns the `deployToken` once `APPROVED` |
@@ -169,6 +171,14 @@ enum AiAppEventType {
   DELETE_STARTED  DELETE_SUCCEEDED  DELETE_FAILED
 }
 
+model AiAppFeedback {         // free-text feedback from the app detail page
+  uid       String @unique
+  appUid    String             // AiApp.uid (no FK relation, matching the other POC tables)
+  memberUid String             // submitter; may submit multiple entries per app
+  text      String
+  createdAt DateTime @default(now())
+}
+
 model AiAppEvent {            // append-only audit log — one row per event, never updated
   uid          String @unique
   memberUid    String         // who triggered it
@@ -189,8 +199,12 @@ Apps are **lazy-created on first deploy** — there is no registration form.
 
 ## RBAC
 
-- `ai_apps.read` — view the dashboard (list/detail).
+- `ai_apps.read` — view the dashboard (list/detail) and submit feedback on an app.
 - `ai_apps.write` — download the starter kit and deploy.
+
+Reading an app's feedback list additionally requires being the app's creator or a
+directory admin (`isDirectoryAdmin`) — enforced in `AiAppsService.listFeedback`,
+not by a separate permission.
 
 Both are seeded in migration `20260623120000_ai_apps` and attached to the **PL Infra Team** policy (`pl_infra_team_pl_internal`), and registered in `access-control-v2.constants.ts` + `access-control-v2.seed.ts`.
 


### PR DESCRIPTION
## Summary

Members with AI Apps access can now submit free-text feedback on an AI app from its detail page, and may do so more than once per app.
The feedback list for an app is visible only to the app's creator and Directory admins; regular viewers are rejected, and members without AI Apps access cannot use the endpoints at all.
Successful submissions return the stored feedback entry; invalid or unauthorized requests return standard error responses (400/403/404) the frontend can surface.
Added a database migration for the new feedback storage, unit tests covering all ticket scenarios, and updated `docs/AI_APPS.md`

## New endpoints

Submit feedback (any member with AI Apps access, repeatable):

```bash
curl -X POST "https://<api-host>/v1/ai-apps/<appUid>/feedback" \
  -H "Authorization: Bearer <member-jwt>" \
  -H "Content-Type: application/json" \
  -d '{"text": "Love the app, but the search is slow."}'
```

List feedback for an app (app creator or Directory admin only, newest first):

```bash
curl "https://<api-host>/v1/ai-apps/<appUid>/feedback" \
  -H "Authorization: Bearer <member-jwt>"
```


## Ticket

[LAB-2090](https://linear.app/plrs-labos/issue/LAB-2090/ai-apps-feedback-form-on-app-detail-page)
