### PR TITLE
LAB-2099 [AI Apps] Support draft apps with required secrets and deploy-with-secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,15 +137,12 @@ AI_APPS_S3_BUCKET=
 # AI_APPS_APP_DOMAIN: Base domain deployed apps are served under (app URL = https://<appId>.<domain>).
 # Use dev.plnetwork.io on Dev and prod.plnetwork.io on Prod.
 AI_APPS_APP_DOMAIN=dev.plnetwork.io
-# AI_APPS_DEPLOY_ENDPOINT: Public URL of this API's deploy endpoint, written into the starter kit.
-# Ex: https://api-directory.plnetwork.io/v1/ai-apps/deploy
-AI_APPS_DEPLOY_ENDPOINT=
-# AI_APPS_CONNECT_ENDPOINT: Public URL of this API's connect-session endpoint, written into the starter kit.
-# Ex: https://api-directory.plnetwork.io/v1/ai-apps/connect
-AI_APPS_CONNECT_ENDPOINT=
-# AI_APPS_DRAFT_ENDPOINT: Public URL of this API's draft-registration endpoint (apps needing runtime secrets), written into the starter kit.
-# Ex: https://api-directory.plnetwork.io/v1/ai-apps/draft
-AI_APPS_DRAFT_ENDPOINT=
+# AI_APPS_BASE_URL: Public base URL of this API. The agent-facing endpoint URLs written into the
+# starter kit (deploy, connect, draft) are derived from it as <base>/v1/ai-apps/<endpoint>.
+# Ex: https://api-directory.plnetwork.io (use http://localhost:3000 locally)
+AI_APPS_BASE_URL=
+# Optional per-endpoint overrides (rarely needed — derived from AI_APPS_BASE_URL when unset):
+# AI_APPS_DEPLOY_ENDPOINT= / AI_APPS_CONNECT_ENDPOINT= / AI_APPS_DRAFT_ENDPOINT=
 # AI_APPS_PORTAL_URL: Base URL of the LabOS portal that hosts the connect/approval page (used to build the connect link).
 # Ex: https://directory.plnetwork.io
 AI_APPS_PORTAL_URL=

--- a/.env.example
+++ b/.env.example
@@ -143,9 +143,16 @@ AI_APPS_DEPLOY_ENDPOINT=
 # AI_APPS_CONNECT_ENDPOINT: Public URL of this API's connect-session endpoint, written into the starter kit.
 # Ex: https://api-directory.plnetwork.io/v1/ai-apps/connect
 AI_APPS_CONNECT_ENDPOINT=
+# AI_APPS_DRAFT_ENDPOINT: Public URL of this API's draft-registration endpoint (apps needing runtime secrets), written into the starter kit.
+# Ex: https://api-directory.plnetwork.io/v1/ai-apps/draft
+AI_APPS_DRAFT_ENDPOINT=
 # AI_APPS_PORTAL_URL: Base URL of the LabOS portal that hosts the connect/approval page (used to build the connect link).
 # Ex: https://directory.plnetwork.io
 AI_APPS_PORTAL_URL=
+# AI_APPS_RUNNER_PROJECT: Project scope for the runner's secrets API (/v1/projects/<project>/secrets).
+AI_APPS_RUNNER_PROJECT=default
+# AI_APPS_RUNNER_ENVIRONMENT: Environment label the runner stores secrets under (dev on Dev, prod on Prod).
+AI_APPS_RUNNER_ENVIRONMENT=dev
 
 # Email Configuration
 # IS_EMAIL_ENABLED: Toggle for enabling or disabling email functionality.

--- a/apps/web-api/prisma/migrations/20260707120000_ai_apps_draft_secrets/migration.sql
+++ b/apps/web-api/prisma/migrations/20260707120000_ai_apps_draft_secrets/migration.sql
@@ -1,0 +1,13 @@
+-- AI Apps: draft apps with runtime secrets.
+-- An agent can now register a DRAFT app that declares which env var NAMES the
+-- app needs; the member provides the values in LabOS (values go straight to the
+-- sandbox runner's secret store — never stored here) and triggers the deploy.
+
+ALTER TYPE "AiAppStatus" ADD VALUE IF NOT EXISTS 'DRAFT';
+
+ALTER TYPE "AiAppEventType" ADD VALUE IF NOT EXISTS 'DRAFT_CREATED';
+ALTER TYPE "AiAppEventType" ADD VALUE IF NOT EXISTS 'SECRETS_UPDATED';
+
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "s3Key" TEXT;
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "requiredEnvVars" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "providedEnvVars" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -2943,6 +2943,7 @@ model RoadmapSettings {
 
 enum AiAppStatus {
   IN_DEVELOPMENT
+  DRAFT // registered by the agent with required env vars; awaiting member secrets + deploy
   DEPLOYING
   READY
   ERROR
@@ -2968,6 +2969,14 @@ model AiApp {
   host         String?
   port         Int?
   deploymentId String?
+  /// S3 key of the last uploaded app bundle, kept so a member-triggered deploy
+  /// (draft flow) can redeploy without the agent re-uploading.
+  s3Key        String?
+  /// Env var NAMES the agent declared the app needs at runtime (draft flow).
+  requiredEnvVars String[]  @default([])
+  /// Env var NAMES the member has provided values for. Values are never stored
+  /// here — they go straight to the sandbox runner's secret store.
+  providedEnvVars String[]  @default([])
   createdAt    DateTime    @default(now())
   updatedAt    DateTime    @updatedAt
 
@@ -3040,6 +3049,8 @@ enum AiAppEventType {
   KIT_DOWNLOADED
   CONNECT_APPROVED
   CONNECT_DENIED
+  DRAFT_CREATED
+  SECRETS_UPDATED
   DEPLOY_STARTED
   DEPLOY_SUCCEEDED
   DEPLOY_FAILED

--- a/apps/web-api/src/ai-apps/ai-apps-draft.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-draft.spec.ts
@@ -1,0 +1,221 @@
+/// <reference types="multer" />
+import { BadGatewayException, BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+
+// axios ships ESM (not in the jest transform allowlist); the draft/deploy paths
+// under test call it, so mock the calls themselves.
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  get: jest.fn(),
+  isAxiosError: jest.fn((error: any) => !!error?.isAxiosError),
+}));
+
+// The constants module reads env vars at import time; pin the bucket so the
+// upload paths are exercised regardless of the test environment.
+jest.mock('./ai-apps.constants', () => ({
+  ...jest.requireActual('./ai-apps.constants'),
+  AI_APPS_S3_BUCKET: 'test-bucket',
+}));
+
+import axios from 'axios';
+import { AiAppsService } from './ai-apps.service';
+import { RegisterDraftSchema } from './dto/register-draft.dto';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const APP = {
+  uid: 'app-1',
+  memberUid: 'creator-1',
+  appId: 'demo',
+  name: 'Demo',
+  status: 'DRAFT',
+  s3Key: 'apps/demo/d1/app.zip',
+  deploymentId: 'd1',
+  requiredEnvVars: ['OPENAI_API_KEY', 'SUPABASE_URL'],
+  providedEnvVars: [],
+};
+
+const FILE = { buffer: Buffer.from('zip'), mimetype: 'application/zip' } as Express.Multer.File;
+
+function buildService(app: Record<string, any> | null = APP) {
+  const prisma = {
+    aiApp: {
+      findUnique: jest.fn().mockResolvedValue(app),
+      upsert: jest.fn().mockImplementation(({ create }) => Promise.resolve({ ...APP, ...create, uid: 'app-1' })),
+      update: jest.fn().mockImplementation(({ data }) => Promise.resolve({ ...APP, ...data })),
+    },
+    aiAppEvent: { create: jest.fn().mockResolvedValue({}) },
+    member: {
+      findMany: jest.fn().mockResolvedValue([]),
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
+  };
+  const aws = { uploadFileToS3: jest.fn().mockResolvedValue(undefined) };
+  return { service: new AiAppsService(prisma as any, aws as any), prisma, aws };
+}
+
+/** Route runner calls by URL: secrets store + deploy both answer 200 by default. */
+function mockRunnerOk() {
+  mockedAxios.post.mockImplementation((url: string) =>
+    url.includes('/secrets')
+      ? Promise.resolve({ status: 200, data: { ok: true } })
+      : Promise.resolve({ status: 200, data: { port: 31001 } })
+  );
+}
+
+function eventTypes(prisma: any): string[] {
+  return prisma.aiAppEvent.create.mock.calls.map(([{ data }]) => data.type);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('RegisterDraftSchema.requiredEnvVars', () => {
+  const base = { appId: 'demo', name: 'Demo', deploymentId: 'd1' };
+
+  it('accepts a JSON array string (multipart field)', () => {
+    const parsed = RegisterDraftSchema.parse({ ...base, requiredEnvVars: '["OPENAI_API_KEY","SUPABASE_URL"]' });
+    expect(parsed.requiredEnvVars).toEqual(['OPENAI_API_KEY', 'SUPABASE_URL']);
+  });
+
+  it('accepts a comma-separated list', () => {
+    const parsed = RegisterDraftSchema.parse({ ...base, requiredEnvVars: 'OPENAI_API_KEY, SUPABASE_URL' });
+    expect(parsed.requiredEnvVars).toEqual(['OPENAI_API_KEY', 'SUPABASE_URL']);
+  });
+
+  it('rejects names that are not UPPER_SNAKE_CASE', () => {
+    expect(() => RegisterDraftSchema.parse({ ...base, requiredEnvVars: 'openai-key' })).toThrow();
+  });
+
+  it('rejects an empty list', () => {
+    expect(() => RegisterDraftSchema.parse({ ...base, requiredEnvVars: '' })).toThrow();
+  });
+});
+
+describe('AiAppsService.registerDraft', () => {
+  const DTO = {
+    appId: 'demo',
+    name: 'Demo',
+    description: 'desc',
+    deploymentId: 'd2',
+    requiredEnvVars: ['OPENAI_API_KEY', 'SUPABASE_URL'],
+  } as any;
+
+  it('rejects a missing ZIP', async () => {
+    const { service } = buildService();
+    await expect(service.registerDraft('creator-1', DTO, undefined as any)).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('uploads the bundle, stores the draft, and returns the LabOS page URL', async () => {
+    const { service, prisma, aws } = buildService();
+    const result = await service.registerDraft('creator-1', DTO, FILE);
+
+    expect(aws.uploadFileToS3).toHaveBeenCalledWith(
+      { buffer: FILE.buffer, mimetype: 'application/zip' },
+      'test-bucket',
+      'apps/demo/d2/app.zip'
+    );
+    expect(prisma.aiApp.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          status: 'DRAFT',
+          s3Key: 'apps/demo/d2/app.zip',
+          requiredEnvVars: DTO.requiredEnvVars,
+        }),
+      })
+    );
+    // Nothing is deployed at draft time.
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+    expect(eventTypes(prisma)).toEqual(['DRAFT_CREATED']);
+    expect(result.appPageUrl).toContain('/pl-infra/ai-apps/app-1');
+    expect(result.missingEnvVars).toEqual(['OPENAI_API_KEY', 'SUPABASE_URL']);
+  });
+
+  it('keeps already-provided vars out of missingEnvVars on re-registration', async () => {
+    const { service, prisma } = buildService();
+    prisma.aiApp.upsert.mockResolvedValue({ ...APP, providedEnvVars: ['OPENAI_API_KEY'] });
+    const result = await service.registerDraft('creator-1', DTO, FILE);
+    expect(result.missingEnvVars).toEqual(['SUPABASE_URL']);
+  });
+});
+
+describe('AiAppsService.deployDraft', () => {
+  const SECRETS = { OPENAI_API_KEY: 'sk-1', SUPABASE_URL: 'https://x.supabase.co' };
+
+  it('throws 404 when the app does not exist', async () => {
+    const { service } = buildService(null);
+    await expect(service.deployDraft('creator-1', 'missing', SECRETS)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('rejects a member who is neither creator nor directory admin', async () => {
+    const { service, prisma } = buildService();
+    prisma.member.findUnique.mockResolvedValue({ memberRoles: [] });
+    await expect(service.deployDraft('viewer-1', 'app-1', SECRETS)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rejects an app without an uploaded bundle', async () => {
+    const { service } = buildService({ ...APP, s3Key: null });
+    await expect(service.deployDraft('creator-1', 'app-1', SECRETS)).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('blocks the deploy and names the missing required vars', async () => {
+    const { service } = buildService();
+    await expect(service.deployDraft('creator-1', 'app-1', { OPENAI_API_KEY: 'sk-1' })).rejects.toThrow(
+      'Missing values for required environment variables: SUPABASE_URL'
+    );
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('saves secrets to the runner, then deploys the stored bundle', async () => {
+    const { service, prisma } = buildService();
+    mockRunnerOk();
+
+    const result = await service.deployDraft('creator-1', 'app-1', SECRETS);
+
+    const [secretsCall, deployCall] = mockedAxios.post.mock.calls;
+    expect(secretsCall[0]).toContain('/v1/projects/default/secrets');
+    expect(secretsCall[1]).toEqual(expect.objectContaining({ appId: 'demo', secrets: SECRETS }));
+    expect(deployCall[0]).toContain('/deploy');
+    expect(deployCall[1]).toEqual({ appId: 'demo', deploymentId: 'd1', s3Key: 'apps/demo/d1/app.zip' });
+
+    // Only the NAMES are remembered on the app record.
+    expect(prisma.aiApp.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { providedEnvVars: ['OPENAI_API_KEY', 'SUPABASE_URL'] } })
+    );
+    expect(eventTypes(prisma)).toEqual(['SECRETS_UPDATED', 'DEPLOY_STARTED', 'DEPLOY_SUCCEEDED']);
+    expect(result.status).toBe('READY');
+  });
+
+  it('redeploys without a secrets payload when all values were stored earlier', async () => {
+    const { service, prisma } = buildService({ ...APP, providedEnvVars: ['OPENAI_API_KEY', 'SUPABASE_URL'] });
+    mockRunnerOk();
+
+    await service.deployDraft('creator-1', 'app-1', undefined);
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.post.mock.calls[0][0]).toContain('/deploy');
+    expect(eventTypes(prisma)).toEqual(['DEPLOY_STARTED', 'DEPLOY_SUCCEEDED']);
+  });
+
+  it('fails with 502 and skips the deploy when the runner rejects the secrets', async () => {
+    const { service, prisma } = buildService();
+    mockedAxios.post.mockRejectedValue(Object.assign(new Error('boom'), { isAxiosError: true }));
+
+    await expect(service.deployDraft('creator-1', 'app-1', SECRETS)).rejects.toBeInstanceOf(BadGatewayException);
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1); // secrets call only
+    expect(eventTypes(prisma)).toEqual([]); // no SECRETS_UPDATED, no deploy events
+  });
+
+  it('marks the app ERROR when the runner deploy fails outright', async () => {
+    const { service, prisma } = buildService({ ...APP, providedEnvVars: ['OPENAI_API_KEY', 'SUPABASE_URL'] });
+    mockedAxios.post.mockRejectedValue(
+      Object.assign(new Error('build failed'), { isAxiosError: true, response: { status: 500, data: 'nope' } })
+    );
+
+    await expect(service.deployDraft('creator-1', 'app-1', undefined)).rejects.toBeInstanceOf(BadGatewayException);
+    expect(prisma.aiApp.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'ERROR' }) })
+    );
+    expect(eventTypes(prisma)).toEqual(['DEPLOY_STARTED', 'DEPLOY_FAILED']);
+  });
+});

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
@@ -7,6 +7,7 @@ import {
   AI_APPS_APP_DOMAIN,
   AI_APPS_CONNECT_ENDPOINT,
   AI_APPS_DEPLOY_ENDPOINT,
+  AI_APPS_DRAFT_ENDPOINT,
 } from './ai-apps.constants';
 
 /** Prebuilt PL Design System bundle, shipped verbatim inside the starter kit. */
@@ -119,9 +120,10 @@ to the Protocol Labs Network sandbox with a single instruction.
    first deploy can take a minute or two.
 4. Your app appears on the PL Infra → AI Apps dashboard, where you can open it.
 
-> **Don't copy passwords or secret keys into \`app/\`** — apps run on shared
-> infrastructure with no credentials provided. If your app needs them, ask your
-> agent how to handle it.
+> **Don't copy passwords or secret keys into \`app/\`.** If your app needs API keys
+> or other secrets, your agent registers it as a **draft** and gives you a LabOS
+> link — you enter the values there and click **Deploy**. Secrets never go into
+> the code, the chat, or the uploaded ZIP.
 
 ## Embedding in the dashboard
 Your app is shown inside the AI Apps dashboard. Apps built with this kit display
@@ -210,18 +212,39 @@ not the scaffold's shape or language.
    Node app with no build. If the app compiles (TypeScript, Go, a bundler, …), write
    an appropriate (e.g. multi-stage) Dockerfile. Only hard requirement: the image
    starts a server that listens on \`$PORT\`, binds \`0.0.0.0\`, and answers \`GET /health\`.
-3. **Assume no runtime config.** The sandbox injects NO env vars or secrets. Decide
-   how the app runs without its usual credentials — degrade to sample/mock data, or
-   clearly surface what's missing. Never hardcode real secrets to compensate.
+3. **Runtime config comes from the secrets flow, not the ZIP.** If the app needs
+   API keys or other secrets at runtime, use the draft flow ("Apps that need
+   secrets" below): declare the env var NAMES and let the member provide the
+   values in LabOS. Anything that isn't secret should ship sensible defaults.
 4. **Never ship secrets.** Keep real \`.env\` files, tokens, keys, and data dirs OUT of
    the uploaded zip: add them to \`.dockerignore\` and confirm they're absent before
-   deploying. The zip is built and stored server-side.
+   deploying. The zip is built and stored server-side. Secret VALUES are entered by
+   the member in LabOS — never ask the member to paste them into the chat or a file.
 5. **Verify before deploying:** \`cd app && npm install && npm start\` (or the app's
    equivalent), then confirm \`GET /health\` is 200 and \`GET /\` renders.
 
+## Apps that need secrets (API keys, tokens, …)
+If the app reads any secret from the environment (\`process.env.OPENAI_API_KEY\`,
+a database URL with credentials, …), do **NOT** deploy it directly and do **NOT**
+put values in the ZIP. Instead use the draft flow (full steps in the deploy skill):
+1. Get a deploy token via the connect flow as usual.
+2. POST the app ZIP to the \`draftEndpoint\` from \`pln-app.config.json\` with a
+   \`requiredEnvVars\` field listing the env var NAMES the app needs. This
+   registers the app as a **draft** — nothing runs yet.
+3. Give the member the \`appPageUrl\` from the response: they open it in LabOS,
+   enter the secret values, and click **Deploy** there. The deploy then runs
+   with the stored secrets.
+4. To ship a code update later, register the draft again (same \`appId\`, fresh
+   \`deploymentId\`) — already-stored secret values stay valid; the member just
+   clicks Deploy again in LabOS.
+
+Never ask the member for secret values in the chat, and never write them to any
+file — LabOS is the only place they should be entered.
+
 ## Deploying the app
 When the member asks you to deploy, use the **deploy-to-labs** skill in
-\`.claude/skills/deploy-to-labs/SKILL.md\`. In short:
+\`.claude/skills/deploy-to-labs/SKILL.md\`. If the app needs runtime secrets,
+follow "Apps that need secrets" above instead of deploying directly. In short:
 1. Read \`pln-app.config.json\` for the \`connectEndpoint\`, \`deployEndpoint\`, and
    (if present) a saved \`appId\`.
 2. **Get a deploy token via LabOS (the connect flow).** There is no token in the
@@ -264,10 +287,16 @@ description: Deploy the app in ./app to the Protocol Labs Network sandbox. Use w
 
 Deploys the app in \`app/\` to the PLN sandbox and returns its live URL.
 
+**Needs secrets?** If the app reads any secret from the environment (API keys,
+tokens, credentialed URLs), do steps 1–4 as written but then follow
+"**Apps that need secrets (draft flow)**" below instead of step 5 — you register
+a draft and the member deploys from LabOS after entering the values.
+
 ## Steps
-1. Read \`pln-app.config.json\` to get \`connectEndpoint\`, \`deployEndpoint\`, and (if
-   present) a saved \`appId\`. If no \`appId\` exists yet, pick a short, stable,
-   lowercase slug (e.g. \`hello-board\`) and save it back to the config.
+1. Read \`pln-app.config.json\` to get \`connectEndpoint\`, \`deployEndpoint\`,
+   \`draftEndpoint\`, and (if present) a saved \`appId\`. If no \`appId\` exists yet,
+   pick a short, stable, lowercase slug (e.g. \`hello-board\`) and save it back to
+   the config.
 2. **Get a deploy token via LabOS.** The kit has no token; obtain a short-lived one
    through the connect flow:
 
@@ -355,6 +384,36 @@ Deploys the app in \`app/\` to the PLN sandbox and returns its live URL.
    If either fails, the embed will show \`refused to connect\`. Fix the app's headers
    (see the framing rule in \`AGENTS.md\`) and redeploy before reporting success.
 
+## Apps that need secrets (draft flow)
+When the app needs runtime secrets, replace the upload in step 5 with a **draft
+registration** — same multipart shape, posted to \`draftEndpoint\`, plus
+\`requiredEnvVars\` (the env var NAMES the app reads; JSON array or
+comma-separated). Nothing is deployed yet:
+
+\`\`\`bash
+curl -X POST "<draftEndpoint>" \\
+  -H "${AI_APP_TOKEN_HEADER}: <deployToken>" \\
+  -F "appId=<your-app-id>" \\
+  -F "name=<human-friendly app name>" \\
+  -F "description=<one line about the app>" \\
+  -F "deploymentId=<unique id per upload, e.g. a timestamp>" \\
+  -F 'requiredEnvVars=["OPENAI_API_KEY","SUPABASE_URL"]' \\
+  -F "file=@app.zip;type=application/zip"
+# → { "status": "DRAFT", "appPageUrl": "https://…/pl-infra/ai-apps/<uid>", "missingEnvVars": [ … ] }
+\`\`\`
+
+Then **tell the member, in your chat:** open \`appPageUrl\` in their browser, enter
+the secret values there, and click **Deploy**. The deploy runs immediately with
+the stored secrets; the app then appears as usual on the AI Apps dashboard.
+
+- **Never** ask the member to paste secret values into the chat, and never write
+  them to a file — LabOS is the only place values are entered.
+- To ship a **code update** later, re-register the draft (same \`appId\`, fresh
+  \`deploymentId\`, updated \`requiredEnvVars\` if they changed) and send the member
+  back to \`appPageUrl\` to click Deploy. Stored secret values remain valid.
+- The member can also update secret values and redeploy entirely from LabOS —
+  no agent involvement needed.
+
 ## Keep the deployment URL private
 Do not print, link, or otherwise tell the member the deployment URL, host, or port —
 in your messages, summaries, or saved files. The member opens their app through the
@@ -384,9 +443,9 @@ verification steps. Only re-deploy if it stays unreachable.
   connect link. Keep it in memory only — never save it to a file or print it. Within
   the window you can redeploy without reconnecting; once it expires (deploy returns
   \`401\`), run the connect flow again to get a fresh token.
-- The sandbox injects no runtime env vars or secrets. An app that needs config must
-  ship sensible defaults or degrade gracefully (e.g. sample data) — see the
-  migration checklist in \`AGENTS.md\`.
+- Runtime secrets are supported only through the draft flow above — the sandbox
+  injects exactly the env vars the member provided in LabOS. Non-secret config
+  should ship sensible defaults — see the migration checklist in \`AGENTS.md\`.
 `;
   }
 
@@ -395,10 +454,11 @@ verification steps. Only re-deploy if it stays unreachable.
       {
         connectEndpoint: AI_APPS_CONNECT_ENDPOINT,
         deployEndpoint: AI_APPS_DEPLOY_ENDPOINT,
+        draftEndpoint: AI_APPS_DRAFT_ENDPOINT,
         deployTokenHeader: AI_APP_TOKEN_HEADER,
         appId: '',
         notes:
-          'No token is stored here. At deploy time the agent runs the LabOS connect flow (see .claude/skills/deploy-to-labs) to get a short-lived deploy token. Set appId to a stable lowercase slug on first deploy and reuse it.',
+          'No token is stored here. At deploy time the agent runs the LabOS connect flow (see .claude/skills/deploy-to-labs) to get a short-lived deploy token. Set appId to a stable lowercase slug on first deploy and reuse it. If the app needs runtime secrets, register it via draftEndpoint instead of deploying (see the deploy skill).',
       },
       null,
       2

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -43,6 +43,16 @@ export const AI_APPS_RUNNER_TOKEN = process.env.AI_APPS_RUNNER_TOKEN || '';
 /** S3 bucket the sandbox runner reads app bundles from. */
 export const AI_APPS_S3_BUCKET = process.env.AI_APPS_S3_BUCKET || '';
 
+/** Project scope for the runner's secrets/deployments API (`/v1/projects/<project>/…`). */
+export const AI_APPS_RUNNER_PROJECT = process.env.AI_APPS_RUNNER_PROJECT || 'default';
+
+/** Environment label the runner stores secrets under (e.g. `dev` on Dev, `prod` on Prod). */
+export const AI_APPS_RUNNER_ENVIRONMENT = process.env.AI_APPS_RUNNER_ENVIRONMENT || 'prod';
+
+/** Runner endpoint that saves (merge/upsert) an app's runtime secrets. */
+export const buildRunnerSecretsUrl = (): string =>
+  `${AI_APPS_RUNNER_URL}/v1/projects/${AI_APPS_RUNNER_PROJECT}/secrets`;
+
 /** Build the S3 key for an app bundle: apps/<appId>/<deploymentId>/app.zip */
 export const buildAppS3Key = (appId: string, deploymentId: string): string => `apps/${appId}/${deploymentId}/app.zip`;
 
@@ -75,6 +85,12 @@ export const AI_APPS_CONNECT_ENDPOINT =
   process.env.AI_APPS_CONNECT_ENDPOINT || 'https://api.plnetwork.io/v1/ai-apps/connect';
 
 /**
+ * Public URL of THIS API's draft-registration endpoint, written into the starter
+ * kit so the agent knows where to register apps that need runtime secrets.
+ */
+export const AI_APPS_DRAFT_ENDPOINT = process.env.AI_APPS_DRAFT_ENDPOINT || 'https://api.plnetwork.io/v1/ai-apps/draft';
+
+/**
  * Base URL of the LabOS portal that hosts the connect page the member opens to
  * approve a session. Combined with the session uid to build the connect link.
  */
@@ -83,3 +99,11 @@ export const AI_APPS_PORTAL_URL = process.env.AI_APPS_PORTAL_URL || 'https://dir
 /** The LabOS connect page URL a member opens to approve an agent's session. */
 export const buildConnectUrl = (sessionUid: string): string =>
   `${AI_APPS_PORTAL_URL}/pl-infra/ai-apps/connect?session=${encodeURIComponent(sessionUid)}`;
+
+/**
+ * The LabOS app detail page for one AI App — for a draft this is where the
+ * member enters secret values and clicks Deploy. The agent hands this link to
+ * the member after registering a draft.
+ */
+export const buildAppPageUrl = (appUid: string): string =>
+  `${AI_APPS_PORTAL_URL}/pl-infra/ai-apps/${encodeURIComponent(appUid)}`;

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -71,30 +71,31 @@ export const buildAppUrl = (appId: string): string => `https://${buildAppHost(ap
 export const buildAppHttpUrl = (appId: string): string => `http://${buildAppHost(appId)}`;
 
 /**
- * Public URL of THIS API's deploy endpoint, written into the starter kit so the
- * agent knows where to POST. Defaults to the conventional prod path.
+ * Public base URL of THIS API. The agent-facing endpoint URLs written into the
+ * starter kit are all derived from it (`<base>/v1/ai-apps/…`), so adding a new
+ * endpoint needs no new env var. The per-endpoint vars below remain as optional
+ * overrides for environments that already set them.
  */
-export const AI_APPS_DEPLOY_ENDPOINT =
-  process.env.AI_APPS_DEPLOY_ENDPOINT || 'https://api.plnetwork.io/v1/ai-apps/deploy';
+export const AI_APPS_BASE_URL = process.env.AI_APPS_BASE_URL;
 
-/**
- * Public URL of THIS API's connect-session endpoint, written into the starter
- * kit so the agent knows where to start a connect session.
- */
+/** Public URL of THIS API's deploy endpoint, written into the starter kit so the agent knows where to POST. */
+export const AI_APPS_DEPLOY_ENDPOINT = process.env.AI_APPS_DEPLOY_ENDPOINT || `${AI_APPS_BASE_URL}/v1/ai-apps/deploy`;
+
+/** Public URL of THIS API's connect-session endpoint, written into the starter kit. */
 export const AI_APPS_CONNECT_ENDPOINT =
-  process.env.AI_APPS_CONNECT_ENDPOINT || 'https://api.plnetwork.io/v1/ai-apps/connect';
+  process.env.AI_APPS_CONNECT_ENDPOINT || `${AI_APPS_BASE_URL}/v1/ai-apps/connect`;
 
 /**
- * Public URL of THIS API's draft-registration endpoint, written into the starter
- * kit so the agent knows where to register apps that need runtime secrets.
+ * Public URL of THIS API's draft-registration endpoint (apps that need runtime
+ * secrets), written into the starter kit.
  */
-export const AI_APPS_DRAFT_ENDPOINT = process.env.AI_APPS_DRAFT_ENDPOINT || 'https://api.plnetwork.io/v1/ai-apps/draft';
+export const AI_APPS_DRAFT_ENDPOINT = process.env.AI_APPS_DRAFT_ENDPOINT || `${AI_APPS_BASE_URL}/v1/ai-apps/draft`;
 
 /**
  * Base URL of the LabOS portal that hosts the connect page the member opens to
  * approve a session. Combined with the session uid to build the connect link.
  */
-export const AI_APPS_PORTAL_URL = process.env.AI_APPS_PORTAL_URL || 'https://directory.plnetwork.io';
+export const AI_APPS_PORTAL_URL = process.env.AI_APPS_PORTAL_URL;
 
 /** The LabOS connect page URL a member opens to approve an agent's session. */
 export const buildConnectUrl = (sessionUid: string): string =>

--- a/apps/web-api/src/ai-apps/ai-apps.controller.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.controller.ts
@@ -16,7 +16,7 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiConsumes } from '@nestjs/swagger';
-import { ZodValidationPipe } from 'nestjs-zod';
+import { ZodValidationPipe } from '@abitia/zod-dto';
 import { Response } from 'express';
 import { NoCache } from '../decorators/no-cache.decorator';
 import { UserTokenCheckGuard } from '../guards/user-token-check.guard';
@@ -29,6 +29,8 @@ import { AiAppsConnectService } from './ai-apps-connect.service';
 import { AiAppsStarterKitService } from './ai-apps-starter-kit.service';
 import { AiAppTokenGuard } from './guards/ai-app-token.guard';
 import { DeployAppDto } from './dto/deploy-app.dto';
+import { RegisterDraftDto } from './dto/register-draft.dto';
+import { DeployDraftDto } from './dto/deploy-draft.dto';
 import { StartConnectDto } from './dto/start-connect.dto';
 import { PollConnectDto } from './dto/poll-connect.dto';
 import { SubmitFeedbackDto } from './dto/submit-feedback.dto';
@@ -204,6 +206,38 @@ export class AiAppsController {
   @UsePipes(ZodValidationPipe)
   async deploy(@Req() req: any, @Body() body: DeployAppDto, @UploadedFile() file: Express.Multer.File) {
     return this.aiAppsService.deploy(req.aiAppMemberUid, body, file);
+  }
+
+  /**
+   * Register a DRAFT app that needs runtime secrets (agent, deploy-token auth).
+   * Same multipart shape as deploy plus `requiredEnvVars` (the env var NAMES).
+   * Nothing is deployed yet — the response carries `appPageUrl`, the LabOS page
+   * where the member enters the secret values and clicks Deploy.
+   */
+  @NoCache()
+  @Post('draft')
+  @UseGuards(AiAppTokenGuard)
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: AI_APPS_MAX_ZIP_BYTES } }))
+  @UsePipes(ZodValidationPipe)
+  async registerDraft(@Req() req: any, @Body() body: RegisterDraftDto, @UploadedFile() file: Express.Multer.File) {
+    return this.aiAppsService.registerDraft(req.aiAppMemberUid, body, file);
+  }
+
+  /**
+   * Member-triggered deploy from the LabOS app page (draft flow + redeploys
+   * after secret updates). Optionally carries `secrets` (name → value) which are
+   * forwarded to the sandbox runner's secret store — never persisted here.
+   * Blocks with a 400 listing the missing names if a required var has no value.
+   */
+  @NoCache()
+  @Post(':uid/deploy')
+  @UseGuards(UserTokenCheckGuard, RbacGuard)
+  @RequirePermissions(WRITE)
+  @UsePipes(ZodValidationPipe)
+  async deployDraft(@Param('uid') uid: string, @Body() body: DeployDraftDto, @Req() req: any) {
+    const memberUid = await this.resolveMemberUid(req);
+    return this.aiAppsService.deployDraft(memberUid, uid, body.secrets);
   }
 
   private async resolveMemberUid(req: any): Promise<string> {

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -1,5 +1,6 @@
 import {
   BadGatewayException,
+  BadRequestException,
   ForbiddenException,
   Injectable,
   InternalServerErrorException,
@@ -12,14 +13,18 @@ import { PrismaService } from '../shared/prisma.service';
 import { isDirectoryAdmin } from '../utils/constants';
 import { AwsService } from '../utils/aws/aws.service';
 import { DeployAppDto } from './dto/deploy-app.dto';
+import { RegisterDraftDto } from './dto/register-draft.dto';
 import {
+  AI_APPS_RUNNER_ENVIRONMENT,
   AI_APPS_RUNNER_TOKEN,
   AI_APPS_RUNNER_URL,
   AI_APPS_S3_BUCKET,
   buildAppHost,
   buildAppHttpUrl,
+  buildAppPageUrl,
   buildAppS3Key,
   buildAppUrl,
+  buildRunnerSecretsUrl,
 } from './ai-apps.constants';
 
 /** Edge/gateway statuses that mean "the runner may still have finished" — verify, don't fail. */
@@ -134,20 +139,26 @@ export class AiAppsService {
     if (!app) {
       throw new NotFoundException(`AI App not found: ${appUid}`);
     }
-    if (app.memberUid !== requesterUid) {
-      const requester = await this.prisma.member.findUnique({
-        where: { uid: requesterUid },
-        select: { memberRoles: { select: { name: true } } },
-      });
-      if (!requester || !isDirectoryAdmin(requester)) {
-        throw new ForbiddenException('Only the app creator or a directory admin can view feedback');
-      }
+    if (!(await this.isCreatorOrDirectoryAdmin(requesterUid, app))) {
+      throw new ForbiddenException('Only the app creator or a directory admin can view feedback');
     }
     const feedback = await this.prisma.aiAppFeedback.findMany({
       where: { appUid: app.uid },
       orderBy: { createdAt: 'desc' },
     });
     return this.withMember(feedback);
+  }
+
+  /** True when the requester created the app or is a directory admin. */
+  private async isCreatorOrDirectoryAdmin(requesterUid: string, app: Pick<AiApp, 'memberUid'>): Promise<boolean> {
+    if (app.memberUid === requesterUid) {
+      return true;
+    }
+    const requester = await this.prisma.member.findUnique({
+      where: { uid: requesterUid },
+      select: { memberRoles: { select: { name: true } } },
+    });
+    return !!requester && isDirectoryAdmin(requester);
   }
 
   /**
@@ -178,6 +189,7 @@ export class AiAppsService {
         description: dto.description,
         status: 'DEPLOYING',
         deploymentId: dto.deploymentId,
+        s3Key,
         url,
         httpUrl,
         host,
@@ -187,6 +199,7 @@ export class AiAppsService {
         description: dto.description,
         status: 'DEPLOYING',
         deploymentId: dto.deploymentId,
+        s3Key,
         url,
         httpUrl,
         host,
@@ -196,6 +209,185 @@ export class AiAppsService {
 
     const eventContext = { appUid: app.uid, appId: dto.appId, deploymentId: dto.deploymentId };
     await this.recordEvent('DEPLOY_STARTED', memberUid, eventContext);
+
+    try {
+      await this.awsService.uploadFileToS3(
+        { buffer: file.buffer, mimetype: 'application/zip' },
+        AI_APPS_S3_BUCKET,
+        s3Key
+      );
+    } catch (error) {
+      const message = `Deploy failed: ${(error as Error).message}`;
+      await this.failDeploy(app.uid, memberUid, eventContext, message);
+      throw new BadGatewayException('Failed to store the app bundle');
+    }
+
+    return this.proxyDeploy(memberUid, app, dto.deploymentId, s3Key);
+  }
+
+  /**
+   * Registers a DRAFT app for the agent (deploy-token auth): the app needs
+   * runtime secrets, so instead of deploying we store the bundle in S3 and the
+   * required env var NAMES, and hand back the LabOS app page URL where the
+   * member enters the values and triggers the deploy.
+   */
+  async registerDraft(
+    memberUid: string,
+    dto: RegisterDraftDto,
+    file: Express.Multer.File
+  ): Promise<WithMember<AiApp> & { appPageUrl: string; missingEnvVars: string[] }> {
+    if (!file?.buffer?.length) {
+      throw new BadRequestException('Missing app ZIP file');
+    }
+    if (!AI_APPS_S3_BUCKET) {
+      throw new InternalServerErrorException('AI_APPS_S3_BUCKET is not configured');
+    }
+
+    const s3Key = buildAppS3Key(dto.appId, dto.deploymentId);
+    try {
+      await this.awsService.uploadFileToS3(
+        { buffer: file.buffer, mimetype: 'application/zip' },
+        AI_APPS_S3_BUCKET,
+        s3Key
+      );
+    } catch (error) {
+      this.logger.error(`AI App draft upload failed for ${dto.appId}: ${(error as Error).message}`);
+      throw new BadGatewayException('Failed to store the app bundle');
+    }
+
+    // `providedEnvVars` is intentionally left untouched on update: values the
+    // member already stored on the runner stay valid across draft re-registrations.
+    const app = await this.prisma.aiApp.upsert({
+      where: { memberUid_appId: { memberUid, appId: dto.appId } },
+      create: {
+        memberUid,
+        appId: dto.appId,
+        name: dto.name,
+        description: dto.description,
+        status: 'DRAFT',
+        deploymentId: dto.deploymentId,
+        s3Key,
+        requiredEnvVars: dto.requiredEnvVars,
+      },
+      update: {
+        name: dto.name,
+        description: dto.description,
+        status: 'DRAFT',
+        deploymentId: dto.deploymentId,
+        s3Key,
+        requiredEnvVars: dto.requiredEnvVars,
+        notes: null,
+      },
+    });
+
+    await this.recordEvent('DRAFT_CREATED', memberUid, {
+      appUid: app.uid,
+      appId: dto.appId,
+      deploymentId: dto.deploymentId,
+      message: `Required env vars: ${dto.requiredEnvVars.join(', ')}`,
+    });
+
+    const provided = new Set(app.providedEnvVars);
+    return {
+      ...(await this.withMember([app]))[0],
+      appPageUrl: buildAppPageUrl(app.uid),
+      missingEnvVars: app.requiredEnvVars.filter((name) => !provided.has(name)),
+    };
+  }
+
+  /**
+   * Member-triggered deploy from the LabOS app page (draft flow + redeploys).
+   * Optionally saves the submitted secret values to the sandbox runner first
+   * (merge/upsert — values never touch our DB), validates every required env
+   * var has a value, then redeploys the stored bundle.
+   */
+  async deployDraft(requesterUid: string, uid: string, secrets?: Record<string, string>): Promise<WithMember<AiApp>> {
+    const app = await this.prisma.aiApp.findUnique({ where: { uid } });
+    if (!app) {
+      throw new NotFoundException(`AI App not found: ${uid}`);
+    }
+    if (!(await this.isCreatorOrDirectoryAdmin(requesterUid, app))) {
+      throw new ForbiddenException('Only the app creator or a directory admin can deploy this app');
+    }
+    if (app.status === 'DELETED' || app.status === 'DELETING') {
+      throw new BadRequestException('This app has been deleted');
+    }
+    if (!app.s3Key || !app.deploymentId) {
+      throw new BadRequestException('This app has no uploaded bundle yet — ask your AI agent to register it first');
+    }
+
+    const submittedNames = Object.keys(secrets ?? {});
+    const provided = new Set([...app.providedEnvVars, ...submittedNames]);
+    const missing = app.requiredEnvVars.filter((name) => !provided.has(name));
+    if (missing.length) {
+      throw new BadRequestException(`Missing values for required environment variables: ${missing.join(', ')}`);
+    }
+
+    if (secrets && submittedNames.length) {
+      await this.saveSecrets(requesterUid, app, secrets);
+    }
+
+    await this.recordEvent('DEPLOY_STARTED', requesterUid, {
+      appUid: app.uid,
+      appId: app.appId,
+      deploymentId: app.deploymentId,
+    });
+    return this.proxyDeploy(requesterUid, app, app.deploymentId, app.s3Key);
+  }
+
+  /**
+   * Saves secret VALUES to the sandbox runner's secret store (merge/upsert per
+   * the runner's `/v1/projects/<project>/secrets` contract) and remembers only
+   * the NAMES on the app record. Never log or persist the values.
+   */
+  private async saveSecrets(memberUid: string, app: AiApp, secrets: Record<string, string>): Promise<void> {
+    const names = Object.keys(secrets);
+    try {
+      this.logger.log(`Runner secrets request for ${app.appId}: POST ${buildRunnerSecretsUrl()} (${names.join(', ')})`);
+      const response = await axios.post(
+        buildRunnerSecretsUrl(),
+        { appId: app.appId, environment: AI_APPS_RUNNER_ENVIRONMENT, secrets },
+        { headers: { 'Content-Type': 'application/json', 'x-runner-token': AI_APPS_RUNNER_TOKEN } }
+      );
+      // Log only the status — the request/response may echo secret values.
+      this.logger.log(`Runner secrets response for ${app.appId}: status=${response.status}`);
+    } catch (error) {
+      const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+      this.logger.error(`Runner secrets error for ${app.appId}: status=${status ?? 'n/a'}`);
+      throw new BadGatewayException('Failed to store secrets on the sandbox runner');
+    }
+
+    await this.prisma.aiApp.update({
+      where: { uid: app.uid },
+      data: { providedEnvVars: Array.from(new Set([...app.providedEnvVars, ...names])) },
+    });
+    await this.recordEvent('SECRETS_UPDATED', memberUid, {
+      appUid: app.uid,
+      appId: app.appId,
+      message: `Updated: ${names.join(', ')}`,
+    });
+  }
+
+  /**
+   * Shared deploy proxy: flips the app to DEPLOYING, asks the runner to build
+   * and start the bundle at `s3Key`, and settles READY/ERROR (with the timeout
+   * verification below). Callers record DEPLOY_STARTED themselves.
+   */
+  private async proxyDeploy(
+    memberUid: string,
+    app: Pick<AiApp, 'uid' | 'appId'>,
+    deploymentId: string,
+    s3Key: string
+  ): Promise<WithMember<AiApp>> {
+    const host = buildAppHost(app.appId);
+    const url = buildAppUrl(app.appId);
+    const httpUrl = buildAppHttpUrl(app.appId);
+    await this.prisma.aiApp.update({
+      where: { uid: app.uid },
+      data: { status: 'DEPLOYING', deploymentId, s3Key, url, httpUrl, host, notes: null },
+    });
+
+    const eventContext = { appUid: app.uid, appId: app.appId, deploymentId };
 
     const markReady = async (port: number | null) => {
       const updated = await this.prisma.aiApp.update({
@@ -207,25 +399,19 @@ export class AiAppsService {
     };
 
     try {
-      await this.awsService.uploadFileToS3(
-        { buffer: file.buffer, mimetype: 'application/zip' },
-        AI_APPS_S3_BUCKET,
-        s3Key
-      );
-
       this.logger.log(
-        `Runner deploy request for ${dto.appId}: POST ${AI_APPS_RUNNER_URL}/deploy ` +
-          `(deploymentId=${dto.deploymentId}, s3Key=${s3Key})`
+        `Runner deploy request for ${app.appId}: POST ${AI_APPS_RUNNER_URL}/deploy ` +
+          `(deploymentId=${deploymentId}, s3Key=${s3Key})`
       );
       const response = await axios.post<RunnerDeployResponse>(
         `${AI_APPS_RUNNER_URL}/deploy`,
-        { appId: dto.appId, deploymentId: dto.deploymentId, s3Key },
+        { appId: app.appId, deploymentId, s3Key },
         { headers: { 'Content-Type': 'application/json', 'x-runner-token': AI_APPS_RUNNER_TOKEN } }
       );
-      this.logRunnerResponse('deploy', dto.appId, response.status, response.data);
+      this.logRunnerResponse('deploy', app.appId, response.status, response.data);
       return markReady(response.data.port ?? null);
     } catch (error) {
-      this.logRunnerError('deploy', dto.appId, error);
+      this.logRunnerError('deploy', app.appId, error);
       const message = axios.isAxiosError(error)
         ? `Runner error: ${error.response?.status ?? ''} ${JSON.stringify(error.response?.data ?? error.message)}`
         : `Deploy failed: ${(error as Error).message}`;
@@ -234,21 +420,31 @@ export class AiAppsService {
       // deploy failed — the long-running build often completes on the origin. Verify
       // by checking whether the app is actually reachable before declaring failure.
       if (this.isUncertainRunnerError(error)) {
-        this.logger.warn(`Runner timed out for ${dto.appId}; verifying app at ${url}. (${message})`);
+        this.logger.warn(`Runner timed out for ${app.appId}; verifying app at ${url}. (${message})`);
         if (await this.verifyAppLive(url)) {
-          this.logger.log(`AI App ${dto.appId} is live despite runner timeout — marking READY`);
+          this.logger.log(`AI App ${app.appId} is live despite runner timeout — marking READY`);
           return markReady(null);
         }
       }
 
-      this.logger.error(`AI App deploy failed for ${dto.appId}: ${message}`);
-      await this.prisma.aiApp.update({
-        where: { uid: app.uid },
-        data: { status: 'ERROR', notes: message.slice(0, 2000) },
-      });
-      await this.recordEvent('DEPLOY_FAILED', memberUid, { ...eventContext, message: message.slice(0, 2000) });
+      this.logger.error(`AI App deploy failed for ${app.appId}: ${message}`);
+      await this.failDeploy(app.uid, memberUid, eventContext, message);
       throw new BadGatewayException('Failed to deploy app to the sandbox runner');
     }
+  }
+
+  /** Marks a failed deploy: status ERROR with the trimmed message + DEPLOY_FAILED event. */
+  private async failDeploy(
+    appUid: string,
+    memberUid: string,
+    eventContext: { appUid: string; appId: string; deploymentId: string },
+    message: string
+  ): Promise<void> {
+    await this.prisma.aiApp.update({
+      where: { uid: appUid },
+      data: { status: 'ERROR', notes: message.slice(0, 2000) },
+    });
+    await this.recordEvent('DEPLOY_FAILED', memberUid, { ...eventContext, message: message.slice(0, 2000) });
   }
 
   /**

--- a/apps/web-api/src/ai-apps/dto/deploy-draft.dto.ts
+++ b/apps/web-api/src/ai-apps/dto/deploy-draft.dto.ts
@@ -1,0 +1,16 @@
+import { createZodDto } from '@abitia/zod-dto';
+import { z } from 'zod';
+import { EnvVarNameSchema } from './register-draft.dto';
+
+/**
+ * Body of the member-triggered deploy (`POST /v1/ai-apps/:uid/deploy`).
+ * `secrets` maps env var names to the values the member entered in LabOS; the
+ * values are forwarded to the sandbox runner's secret store (merge/upsert) and
+ * never persisted in our database. Omit it to redeploy with already-stored
+ * secrets.
+ */
+export const DeployDraftSchema = z.object({
+  secrets: z.record(EnvVarNameSchema, z.string().min(1).max(10000)).optional(),
+});
+
+export class DeployDraftDto extends createZodDto(DeployDraftSchema) {}

--- a/apps/web-api/src/ai-apps/dto/register-draft.dto.ts
+++ b/apps/web-api/src/ai-apps/dto/register-draft.dto.ts
@@ -1,0 +1,41 @@
+import { createZodDto } from '@abitia/zod-dto';
+import { z } from 'zod';
+import { DeployAppSchema } from './deploy-app.dto';
+
+/** Conventional env-var name: uppercase letters, digits, underscores. */
+export const ENV_VAR_NAME_REGEX = /^[A-Z][A-Z0-9_]*$/;
+
+export const EnvVarNameSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .regex(ENV_VAR_NAME_REGEX, 'env var names must be UPPER_SNAKE_CASE');
+
+/**
+ * Multipart fields the AI agent posts to `/v1/ai-apps/draft` alongside the app
+ * ZIP when the app needs runtime secrets. Same shape as a deploy, plus the env
+ * var NAMES the app requires — the member supplies the values later in LabOS.
+ * Multipart delivers `requiredEnvVars` as a string, so accept a JSON array
+ * (`["A","B"]`) or a comma-separated list (`A,B`).
+ */
+export const RegisterDraftSchema = DeployAppSchema.extend({
+  requiredEnvVars: z.preprocess((value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    const trimmed = value.trim();
+    if (trimmed.startsWith('[')) {
+      try {
+        return JSON.parse(trimmed);
+      } catch {
+        return trimmed;
+      }
+    }
+    return trimmed
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean);
+  }, z.array(EnvVarNameSchema).min(1).max(50)),
+});
+
+export class RegisterDraftDto extends createZodDto(RegisterDraftSchema) {}

--- a/apps/web-api/src/app.module.ts
+++ b/apps/web-api/src/app.module.ts
@@ -211,6 +211,7 @@ export class AppModule {
         { path: 'v1/images', method: RequestMethod.POST },
         { path: 'v1/uploads', method: RequestMethod.POST },
         { path: 'v1/ai-apps/deploy', method: RequestMethod.POST },
+        { path: 'v1/ai-apps/draft', method: RequestMethod.POST },
         { path: 'v1/demo-days/current/fundraising-profile/one-pager', method: RequestMethod.PUT },
         { path: 'v1/demo-days/current/fundraising-profile/video', method: RequestMethod.PUT },
         { path: 'v1/admin/demo-days/current/teams/:teamUid/fundraising-profile/one-pager', method: RequestMethod.PUT },

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -312,9 +312,8 @@ badges, tables, tabs, dropdowns, or sidebars from scratch.
 | `AI_APPS_RUNNER_TOKEN` | _(empty)_ | **Required** for real deploys; `x-runner-token` to the runner |
 | `AI_APPS_S3_BUCKET` | _(empty)_ | **Required** for real deploys; bucket the runner reads app bundles from (e.g. `sandbox-apps-pln-dev-013228333448`) |
 | `AI_APPS_APP_DOMAIN` | `prod.plnetwork.io` | Base domain deployed apps are served under (app URL = `https://<appId>.<domain>`); set `dev.plnetwork.io` on Dev, `prod.plnetwork.io` on Prod |
-| `AI_APPS_DEPLOY_ENDPOINT` | `https://api.plnetwork.io/v1/ai-apps/deploy` | Written into the kit so the agent knows where to POST |
-| `AI_APPS_CONNECT_ENDPOINT` | `https://api.plnetwork.io/v1/ai-apps/connect` | Written into the kit so the agent knows where to start a connect session |
-| `AI_APPS_DRAFT_ENDPOINT` | `https://api.plnetwork.io/v1/ai-apps/draft` | Written into the kit so the agent knows where to register drafts (secrets flow) |
+| `AI_APPS_BASE_URL` | `https://api.plnetwork.io` | Public base URL of this API; the agent-facing endpoint URLs written into the kit (deploy/connect/draft) are derived from it as `<base>/v1/ai-apps/<endpoint>` |
+| `AI_APPS_DEPLOY_ENDPOINT` / `AI_APPS_CONNECT_ENDPOINT` / `AI_APPS_DRAFT_ENDPOINT` | _derived from `AI_APPS_BASE_URL`_ | Optional per-endpoint overrides; rarely needed |
 | `AI_APPS_PORTAL_URL` | `https://directory.plnetwork.io` | Base URL of the LabOS portal hosting the connect/approval page (used to build `connectUrl` and `appPageUrl`) |
 | `AI_APPS_RUNNER_PROJECT` | `default` | Project scope of the runner's secrets API (`/v1/projects/<project>/secrets`) |
 | `AI_APPS_RUNNER_ENVIRONMENT` | `prod` | Environment label secrets are stored under on the runner (`dev` on Dev, `prod` on Prod) |

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -10,6 +10,7 @@ PLN members "vibe-code" a small web app locally with an AI assistant (Claude Cod
 2. They unzip it into their AI coding tool and describe what to build. The agent edits files under `app/`, reusing the bundled **PL Design System** (`pl-design-system/`) for on-brand UI instead of hand-rolling components.
 3. When ready, the member says "deploy". The agent has no stored token, so it **starts a LabOS connect session**, gives the member a link + confirmation code to open and approve, then polls until it receives a **short-lived deploy token**.
 4. The agent packages `app/` and POSTs to our deploy endpoint with that short-lived token. The backend proxies the deploy to the sandbox runner, stores the result, and the app shows up on the dashboard with its live URL.
+5. **Apps that need runtime secrets** (API keys etc.) take a detour: instead of deploying, the agent registers a **draft** (same upload + the required env var *names*), then hands the member a LabOS link. The member enters the secret *values* there and clicks **Deploy** — see "Draft apps & runtime secrets" below.
 
 ## Architecture
 
@@ -98,6 +99,8 @@ The `deployToken` is held in agent memory only and never written into the kit, s
 | GET    | `/v1/ai-apps/connect/:uid`       | `UserTokenCheckGuard`         | —                 | Connect-session display info for the LabOS page (no secrets) |
 | POST   | `/v1/ai-apps/connect/:uid/approve` | `UserTokenCheckGuard`       | `ai_apps.write` (checked in service) | Approve → mint deploy token; else mark `DENIED` (both audited) |
 | POST   | `/v1/ai-apps/deploy`              | `AiAppTokenGuard` (`x-app-token` = short-lived deploy token) | — (token = member) | Upload app ZIP → S3 → sandbox runner |
+| POST   | `/v1/ai-apps/draft`               | `AiAppTokenGuard` (`x-app-token`) | — (token = member) | Register a DRAFT app that needs runtime secrets: upload ZIP → S3, store required env var names; nothing deployed yet |
+| POST   | `/v1/ai-apps/:uid/deploy`         | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.write` + creator/directory-admin (checked in service) | Member-triggered deploy: save submitted secret values to the runner, validate required vars, deploy the stored bundle |
 | DELETE | `/v1/ai-apps/:uid`               | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.write`   | Tear down on the runner → mark `DELETED` |
 
 ### Deploy request
@@ -120,6 +123,40 @@ The backend uploads the ZIP to `s3://<AI_APPS_S3_BUCKET>/apps/<appId>/<deploymen
 
 **Timeout handling:** the runner build can exceed the edge (Cloudflare) timeout and return `504`/`524` even though the deploy actually completes. On a gateway timeout (or no response), the backend does **not** fail blindly — it polls the app URL (`buildAppUrl(appId)`) for ~1 min and marks the app `READY` if it becomes reachable (any non-gateway HTTP status counts, including `404` from the app). Only if it stays unreachable — or the runner returns a non-timeout error (e.g. `400`/auth) — is it marked `ERROR` / `DEPLOY_FAILED`. This prevents false failures for slow-but-successful deploys.
 
+## Draft apps & runtime secrets
+
+Apps that read secrets from the environment (`OPENAI_API_KEY`, credentialed URLs, …) must never ship the values in the ZIP, and the agent must never see them. The **draft flow** splits responsibilities: the agent declares which env var *names* the app needs; the member supplies the *values* in LabOS; the backend forwards the values straight to the sandbox runner's secret store (they are **never persisted in our DB** — only the names are tracked, in `requiredEnvVars` / `providedEnvVars`).
+
+1. **Register (agent, deploy token)** — `POST /v1/ai-apps/draft`, same multipart shape as deploy plus `requiredEnvVars` (JSON array or comma-separated string; names must be `UPPER_SNAKE_CASE`):
+
+```bash
+curl -X POST "$AI_APPS_DRAFT_ENDPOINT" \
+  -H "x-app-token: $DEPLOY_TOKEN" \
+  -F "appId=my-ai-helper" \
+  -F "name=My AI Helper" \
+  -F "description=Chat helper that calls OpenAI" \
+  -F "deploymentId=draft-1751900000" \
+  -F 'requiredEnvVars=["OPENAI_API_KEY","SUPABASE_URL"]' \
+  -F "file=@app.zip;type=application/zip"
+```
+
+The ZIP goes to S3 as usual, the app is upserted with status **`DRAFT`** (`s3Key` + `requiredEnvVars` stored, `DRAFT_CREATED` audited), and the response carries `appPageUrl` — the LabOS app detail page (`/pl-infra/ai-apps/<uid>`) — plus `missingEnvVars`. The agent gives `appPageUrl` to the member. Nothing runs yet; a draft is not live and not iframe-ready, and the dashboard shows it with the distinct `DRAFT` status.
+
+2. **Deploy (member, LabOS)** — the member opens the page, enters the values, and clicks Deploy, which calls:
+
+```bash
+curl -X POST "https://api.plnetwork.io/v1/ai-apps/<uid>/deploy" \
+  -H "Authorization: Bearer $MEMBER_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"secrets":{"OPENAI_API_KEY":"sk-…","SUPABASE_URL":"https://…"}}'
+```
+
+The backend (creator or directory admin only) first checks every name in `requiredEnvVars` has a value — stored earlier or submitted now — and otherwise rejects with a 400 naming the missing vars. It then saves the submitted values to the runner's secret store (`POST <AI_APPS_RUNNER_URL>/v1/projects/<AI_APPS_RUNNER_PROJECT>/secrets` with `{ appId, environment, secrets }` — merge/upsert semantics, `SECRETS_UPDATED` audited with names only) and redeploys the stored bundle through the normal runner `/deploy` proxy (status `DEPLOYING` → `READY`/`ERROR`).
+
+3. **Update & redeploy** — the member can reopen the same page any time, change one or more values (`secrets` may be a subset — the runner merges), and Deploy again. `secrets` may also be omitted entirely to redeploy with the already-stored values. For a code update the agent re-registers the draft (same `appId`, fresh `deploymentId`); stored values stay valid.
+
+> **Runner contract assumption:** the deploy step assumes the runner injects the secrets stored under `appId`/`environment` when `/deploy` builds and starts the container (per the "Runtime Secrets" Postman collection, whose `deployments*` endpoints only cover already-built images). All runner calls are isolated in `AiAppsService.saveSecrets` / `proxyDeploy`, so if the contract turns out to require an explicit `deployments:with-secrets` call after build, only those methods change.
+
 ### Delete request
 
 `DELETE /v1/ai-apps/:uid` (member JWT, `ai_apps.write`). The backend looks up the app by `uid`, calls the runner to tear it down, then marks the record `DELETED`:
@@ -134,7 +171,7 @@ Flow: set status `DELETING` + log `DELETE_STARTED` → call the runner → on su
 ## Data model
 
 ```prisma
-enum AiAppStatus { IN_DEVELOPMENT  DEPLOYING  READY  ERROR  DELETING  DELETED }
+enum AiAppStatus { IN_DEVELOPMENT  DRAFT  DEPLOYING  READY  ERROR  DELETING  DELETED }
 
 model AiApp {
   uid          String  @unique
@@ -146,6 +183,9 @@ model AiApp {
   notes        String?         // error detail on failed deploys
   url / httpUrl / host / port  // hosting details from the runner
   deploymentId String?
+  s3Key        String?         // last uploaded bundle (lets a member redeploy a draft)
+  requiredEnvVars String[]     // env var NAMES the agent declared (draft flow)
+  providedEnvVars String[]     // NAMES the member gave values for — values live only on the runner
   @@unique([memberUid, appId])
 }
 
@@ -167,6 +207,7 @@ model AiAppConnectSession {     // short-lived connect handshake (replaces AiApp
 
 enum AiAppEventType {
   KIT_DOWNLOADED  CONNECT_APPROVED  CONNECT_DENIED
+  DRAFT_CREATED   SECRETS_UPDATED
   DEPLOY_STARTED  DEPLOY_SUCCEEDED  DEPLOY_FAILED
   DELETE_STARTED  DELETE_SUCCEEDED  DELETE_FAILED
 }
@@ -191,7 +232,7 @@ model AiAppEvent {            // append-only audit log — one row per event, ne
 }
 ```
 
-Apps are **lazy-created on first deploy** — there is no registration form.
+Apps are **lazy-created on first deploy** — there is no registration form. (A draft registration counts: it upserts the same record with status `DRAFT`.)
 
 **Response shape:** every AI Apps endpoint (`list`, detail, `events`, and the `deploy` result) returns the owner as `member: { uid, name }` and omits the raw `memberUid` (the uid lives in `member.uid`, so it isn't duplicated). `memberUid` remains a column on the DB models above.
 
@@ -273,7 +314,10 @@ badges, tables, tabs, dropdowns, or sidebars from scratch.
 | `AI_APPS_APP_DOMAIN` | `prod.plnetwork.io` | Base domain deployed apps are served under (app URL = `https://<appId>.<domain>`); set `dev.plnetwork.io` on Dev, `prod.plnetwork.io` on Prod |
 | `AI_APPS_DEPLOY_ENDPOINT` | `https://api.plnetwork.io/v1/ai-apps/deploy` | Written into the kit so the agent knows where to POST |
 | `AI_APPS_CONNECT_ENDPOINT` | `https://api.plnetwork.io/v1/ai-apps/connect` | Written into the kit so the agent knows where to start a connect session |
-| `AI_APPS_PORTAL_URL` | `https://directory.plnetwork.io` | Base URL of the LabOS portal hosting the connect/approval page (used to build `connectUrl`) |
+| `AI_APPS_DRAFT_ENDPOINT` | `https://api.plnetwork.io/v1/ai-apps/draft` | Written into the kit so the agent knows where to register drafts (secrets flow) |
+| `AI_APPS_PORTAL_URL` | `https://directory.plnetwork.io` | Base URL of the LabOS portal hosting the connect/approval page (used to build `connectUrl` and `appPageUrl`) |
+| `AI_APPS_RUNNER_PROJECT` | `default` | Project scope of the runner's secrets API (`/v1/projects/<project>/secrets`) |
+| `AI_APPS_RUNNER_ENVIRONMENT` | `prod` | Environment label secrets are stored under on the runner (`dev` on Dev, `prod` on Prod) |
 
 S3 uploads reuse the shared `AwsService`, so the standard `AWS_REGION` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` credentials must also be present.
 
@@ -285,6 +329,7 @@ S3 uploads reuse the shared `AwsService`, so the standard `AWS_REGION` / `AWS_AC
 - `apps/web-api/prisma/migrations/20260623150000_ai_app_events/` — event log table.
 - `apps/web-api/prisma/migrations/20260625120000_ai_apps_delete/` — `DELETING`/`DELETED` + delete event enum values.
 - `apps/web-api/prisma/migrations/20260630120000_ai_apps_connect/` — connect session table + connect event values; drops `AiAppToken`.
+- `apps/web-api/prisma/migrations/20260707120000_ai_apps_draft_secrets/` — `DRAFT` status, `s3Key`/`requiredEnvVars`/`providedEnvVars`, draft/secrets event values.
 - LabOS UI (`pln-directory-portal-v2`): `app/pl-infra/ai-apps/connect/page.tsx` + `components/page/ai-apps/AiAppsConnectPage/` — the approval page; connect calls in `services/ai-apps/ai-apps.service.ts`.
 - `.claude/skills/ai-apps/SKILL.md` — agent guidance for working on this feature.
 


### PR DESCRIPTION
## Description

AI Apps that need API keys or other runtime secrets now have a supported path: the agent registers a **draft** app declaring the required env variable *names*, and the member enters the *values* in LabOS and deploys from there.

- New agent endpoint registers a draft: it stores the app bundle and the required env var names, and returns the LabOS app page link the agent gives to the member. Nothing is deployed yet.
- Draft apps appear on the AI Apps dashboard with a distinct `DRAFT` status and are not treated as live or iframe-ready.
- New member endpoint deploys the draft: it saves the entered secret values to the sandbox runner's secret store and deploys the stored bundle right away.
- Deploy is blocked with a clear `400` naming any required variable that still has no value.
- Members can update secret values later and redeploy from the same LabOS page; agents ship code updates by re-registering the draft while stored values stay valid.
- Secret values are never stored in the directory database or logs — only the variable names are tracked and audited (`DRAFT_CREATED`, `SECRETS_UPDATED` events).
- The starter kit instructions and the `deploy-to-labs` skill now tell agents to use the draft flow whenever the app needs runtime secrets (never put values in the ZIP or ask for them in chat).
- Includes a DB migration (`DRAFT` status + env-var name fields), unit tests for the ticket scenarios, and updates to `docs/AI_APPS.md` / `.env.example`.
- Two integration fixes surfaced by a real E2E run: the new multipart route is excluded from the JSON-only content-type middleware, and the AI Apps request validation pipe now actually validates (it was silently skipped before).

New env vars: `AI_APPS_BASE_URL` (public API base; the deploy/connect/draft endpoint URLs written into the starter kit derive from it, so future endpoints need no new vars — the existing per-endpoint `AI_APPS_*_ENDPOINT` vars still work as optional overrides), `AI_APPS_RUNNER_PROJECT`, `AI_APPS_RUNNER_ENVIRONMENT` (runner secrets API scope).

### New endpoints

Register a draft (agent, short-lived deploy token from the connect flow):

```bash
curl -X POST "https://api.plnetwork.io/v1/ai-apps/draft" \
  -H "x-app-token: $DEPLOY_TOKEN" \
  -F "appId=my-ai-helper" \
  -F "name=My AI Helper" \
  -F "description=Chat helper that calls OpenAI" \
  -F "deploymentId=draft-1751900000" \
  -F 'requiredEnvVars=["OPENAI_API_KEY","SUPABASE_URL"]' \
  -F "file=@app.zip;type=application/zip"
# → { "status": "DRAFT", "appPageUrl": "https://…/pl-infra/ai-apps/<uid>", "missingEnvVars": ["OPENAI_API_KEY", "SUPABASE_URL"], … }
```

Deploy a draft with secrets (member JWT with `ai_apps.write`, creator or directory admin — called by the LabOS app page):

```bash
curl -X POST "https://api.plnetwork.io/v1/ai-apps/<appUid>/deploy" \
  -H "Authorization: Bearer $MEMBER_JWT" \
  -H "Content-Type: application/json" \
  -d '{"secrets":{"OPENAI_API_KEY":"sk-...","SUPABASE_URL":"https://example.supabase.co"}}'
# secrets may be a subset (runner merges) or omitted entirely to redeploy with already-stored values
# → 400 "Missing values for required environment variables: …" if a required var has no value yet
```

### Validation

Verified end-to-end against the dev deployment-orchestrator: starter-kit download → connect approval → draft registration → secret entry + deploy from the LabOS page → runner build → `READY` → secret update → redeploy. UI counterpart: memser-spaceport/pln-directory-portal-v2#2609.

## Ticket

[LAB-2099](https://linear.app/plrs-labos/issue/LAB-2099/ai-apps-support-draft-apps-with-required-secrets-and-deploy-with)
