### PR TITLE
LAB-2099 [AI Apps] Support draft apps with required secrets and deploy-with-secrets

### DIFF
--- a/apps/web-api/src/ai-apps/ai-apps-draft.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-draft.spec.ts
@@ -53,13 +53,19 @@ function buildService(app: Record<string, any> | null = APP) {
   return { service: new AiAppsService(prisma as any, aws as any), prisma, aws };
 }
 
-/** Route runner calls by URL: secrets store + deploy both answer 200 by default. */
+/** Route runner calls by URL: secrets store, build, and secrets-deploy all answer 200 by default. */
 function mockRunnerOk() {
-  mockedAxios.post.mockImplementation((url: string) =>
-    url.includes('/secrets')
-      ? Promise.resolve({ status: 200, data: { ok: true } })
-      : Promise.resolve({ status: 200, data: { port: 31001 } })
-  );
+  // GET /apps — the registry lookup that resolves the built image for injection.
+  mockedAxios.get.mockResolvedValue({ status: 200, data: { apps: [{ app_id: 'demo', image: 'ecr/apps:demo-d1' }] } });
+  mockedAxios.post.mockImplementation((url: string) => {
+    if (url.includes('/secrets')) {
+      return Promise.resolve({ status: 200, data: { ok: true } });
+    }
+    if (url.includes('/deployments')) {
+      return Promise.resolve({ status: 200, data: { status: 'success' } });
+    }
+    return Promise.resolve({ status: 200, data: { port: 31001 } });
+  });
 }
 
 function eventTypes(prisma: any): string[] {
@@ -139,6 +145,24 @@ describe('AiAppsService.registerDraft', () => {
   });
 });
 
+describe('AiAppsService.getApp', () => {
+  it('sets canManage=true for the creator', async () => {
+    const { service } = buildService();
+    expect((await service.getApp('app-1', 'creator-1')).canManage).toBe(true);
+  });
+
+  it('sets canManage=false for a viewer who is neither creator nor admin', async () => {
+    const { service, prisma } = buildService();
+    prisma.member.findUnique.mockResolvedValue({ memberRoles: [] });
+    expect((await service.getApp('app-1', 'viewer-1')).canManage).toBe(false);
+  });
+
+  it('omits canManage when no requester is given', async () => {
+    const { service } = buildService();
+    expect('canManage' in (await service.getApp('app-1'))).toBe(false);
+  });
+});
+
 describe('AiAppsService.deployDraft', () => {
   const SECRETS = { OPENAI_API_KEY: 'sk-1', SUPABASE_URL: 'https://x.supabase.co' };
 
@@ -166,17 +190,27 @@ describe('AiAppsService.deployDraft', () => {
     expect(mockedAxios.post).not.toHaveBeenCalled();
   });
 
-  it('saves secrets to the runner, then deploys the stored bundle', async () => {
+  it('saves secrets, builds the bundle, then redeploys the image with the secrets injected', async () => {
     const { service, prisma } = buildService();
     mockRunnerOk();
 
     const result = await service.deployDraft('creator-1', 'app-1', SECRETS);
 
-    const [secretsCall, deployCall] = mockedAxios.post.mock.calls;
+    const [secretsCall, deployCall, injectCall] = mockedAxios.post.mock.calls;
     expect(secretsCall[0]).toContain('/v1/projects/default/secrets');
     expect(secretsCall[1]).toEqual(expect.objectContaining({ appId: 'demo', secrets: SECRETS }));
     expect(deployCall[0]).toContain('/deploy');
     expect(deployCall[1]).toEqual({ appId: 'demo', deploymentId: 'd1', s3Key: 'apps/demo/d1/app.zip' });
+    // The legacy /deploy build does not inject secrets — a follow-up deployments
+    // call must run the built image with the stored secret names.
+    expect(injectCall[0]).toContain('/v1/projects/default/deployments');
+    expect(injectCall[1]).toEqual(
+      expect.objectContaining({
+        appId: 'demo',
+        image: 'ecr/apps:demo-d1',
+        secretNames: ['OPENAI_API_KEY', 'SUPABASE_URL'],
+      })
+    );
 
     // Only the NAMES are remembered on the app record.
     expect(prisma.aiApp.update).toHaveBeenCalledWith(
@@ -192,9 +226,29 @@ describe('AiAppsService.deployDraft', () => {
 
     await service.deployDraft('creator-1', 'app-1', undefined);
 
-    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    // No secrets-store call — straight to build + inject.
+    expect(mockedAxios.post).toHaveBeenCalledTimes(2);
     expect(mockedAxios.post.mock.calls[0][0]).toContain('/deploy');
+    expect(mockedAxios.post.mock.calls[1][0]).toContain('/deployments');
     expect(eventTypes(prisma)).toEqual(['DEPLOY_STARTED', 'DEPLOY_SUCCEEDED']);
+  });
+
+  it('marks the app ERROR when the secrets injection fails after the build', async () => {
+    const { service, prisma } = buildService({ ...APP, providedEnvVars: ['OPENAI_API_KEY', 'SUPABASE_URL'] });
+    mockedAxios.get.mockResolvedValue({ status: 200, data: { apps: [{ app_id: 'demo', image: 'img' }] } });
+    mockedAxios.post.mockImplementation((url: string) =>
+      url.includes('/deployments')
+        ? Promise.reject(Object.assign(new Error('nope'), { isAxiosError: true, response: { status: 500, data: 'x' } }))
+        : Promise.resolve({ status: 200, data: { port: 31001 } })
+    );
+
+    await expect(service.deployDraft('creator-1', 'app-1', undefined)).rejects.toBeInstanceOf(BadGatewayException);
+    expect(prisma.aiApp.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'ERROR', notes: expect.stringContaining('Secrets injection failed') }),
+      })
+    );
+    expect(eventTypes(prisma)).toEqual(['DEPLOY_STARTED', 'DEPLOY_FAILED']);
   });
 
   it('fails with 502 and skips the deploy when the runner rejects the secrets', async () => {

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -53,6 +53,14 @@ export const AI_APPS_RUNNER_ENVIRONMENT = process.env.AI_APPS_RUNNER_ENVIRONMENT
 export const buildRunnerSecretsUrl = (): string =>
   `${AI_APPS_RUNNER_URL}/v1/projects/${AI_APPS_RUNNER_PROJECT}/secrets`;
 
+/**
+ * Runner endpoint that (re)deploys an already-built image with the named stored
+ * secrets injected. The legacy `/deploy` (s3Key build) does NOT inject secrets,
+ * so secret-bearing apps need this second call after the build.
+ */
+export const buildRunnerDeploymentsUrl = (): string =>
+  `${AI_APPS_RUNNER_URL}/v1/projects/${AI_APPS_RUNNER_PROJECT}/deployments`;
+
 /** Build the S3 key for an app bundle: apps/<appId>/<deploymentId>/app.zip */
 export const buildAppS3Key = (appId: string, deploymentId: string): string => `apps/${appId}/${deploymentId}/app.zip`;
 

--- a/apps/web-api/src/ai-apps/ai-apps.controller.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.controller.ts
@@ -116,13 +116,14 @@ export class AiAppsController {
     return this.aiAppsService.listEvents(appUid, limit ? Number(limit) : undefined);
   }
 
-  /** Single AI App detail. */
+  /** Single AI App detail (includes `canManage` for the requesting member). */
   @NoCache()
   @Get(':uid')
   @UseGuards(UserTokenCheckGuard, RbacGuard)
   @RequirePermissions(READ)
-  async getApp(@Param('uid') uid: string) {
-    return this.aiAppsService.getApp(uid);
+  async getApp(@Param('uid') uid: string, @Req() req: any) {
+    const memberUid = await this.resolveMemberUid(req).catch(() => undefined);
+    return this.aiAppsService.getApp(uid, memberUid);
   }
 
   /** Full event/status history for a single app, newest first. */

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -24,6 +24,7 @@ import {
   buildAppPageUrl,
   buildAppS3Key,
   buildAppUrl,
+  buildRunnerDeploymentsUrl,
   buildRunnerSecretsUrl,
 } from './ai-apps.constants';
 
@@ -76,12 +77,21 @@ export class AiAppsService {
     return this.withMember(apps);
   }
 
-  async getApp(uid: string): Promise<WithMember<AiApp>> {
+  /**
+   * Single app detail. When the requester is known, the response carries
+   * `canManage` (creator or directory admin) — computed server-side so the UI
+   * never has to compare member uids from a possibly stale login cookie.
+   */
+  async getApp(uid: string, requesterUid?: string): Promise<WithMember<AiApp> & { canManage?: boolean }> {
     const app = await this.prisma.aiApp.findUnique({ where: { uid } });
     if (!app) {
       throw new NotFoundException(`AI App not found: ${uid}`);
     }
-    return (await this.withMember([app]))[0];
+    const result = (await this.withMember([app]))[0];
+    if (!requesterUid) {
+      return result;
+    }
+    return { ...result, canManage: await this.isCreatorOrDirectoryAdmin(requesterUid, app) };
   }
 
   /**
@@ -222,7 +232,9 @@ export class AiAppsService {
       throw new BadGatewayException('Failed to store the app bundle');
     }
 
-    return this.proxyDeploy(memberUid, app, dto.deploymentId, s3Key);
+    // Apps that went through the draft flow keep their stored secrets across
+    // agent-initiated redeploys.
+    return this.proxyDeploy(memberUid, app, dto.deploymentId, s3Key, app.providedEnvVars);
   }
 
   /**
@@ -332,7 +344,7 @@ export class AiAppsService {
       appId: app.appId,
       deploymentId: app.deploymentId,
     });
-    return this.proxyDeploy(requesterUid, app, app.deploymentId, app.s3Key);
+    return this.proxyDeploy(requesterUid, app, app.deploymentId, app.s3Key, Array.from(provided));
   }
 
   /**
@@ -370,14 +382,17 @@ export class AiAppsService {
 
   /**
    * Shared deploy proxy: flips the app to DEPLOYING, asks the runner to build
-   * and start the bundle at `s3Key`, and settles READY/ERROR (with the timeout
+   * and start the bundle at `s3Key`, then — when the app has stored secrets —
+   * redeploys the built image with those secrets injected (the legacy `/deploy`
+   * build does NOT inject them), and settles READY/ERROR (with the timeout
    * verification below). Callers record DEPLOY_STARTED themselves.
    */
   private async proxyDeploy(
     memberUid: string,
     app: Pick<AiApp, 'uid' | 'appId'>,
     deploymentId: string,
-    s3Key: string
+    s3Key: string,
+    secretNames: string[] = []
   ): Promise<WithMember<AiApp>> {
     const host = buildAppHost(app.appId);
     const url = buildAppUrl(app.appId);
@@ -398,6 +413,7 @@ export class AiAppsService {
       return (await this.withMember([updated]))[0];
     };
 
+    let port: number | null = null;
     try {
       this.logger.log(
         `Runner deploy request for ${app.appId}: POST ${AI_APPS_RUNNER_URL}/deploy ` +
@@ -409,7 +425,7 @@ export class AiAppsService {
         { headers: { 'Content-Type': 'application/json', 'x-runner-token': AI_APPS_RUNNER_TOKEN } }
       );
       this.logRunnerResponse('deploy', app.appId, response.status, response.data);
-      return markReady(response.data.port ?? null);
+      port = response.data.port ?? null;
     } catch (error) {
       this.logRunnerError('deploy', app.appId, error);
       const message = axios.isAxiosError(error)
@@ -419,17 +435,73 @@ export class AiAppsService {
       // A gateway timeout (Cloudflare 504/524, etc.) or no response doesn't mean the
       // deploy failed — the long-running build often completes on the origin. Verify
       // by checking whether the app is actually reachable before declaring failure.
+      let survivedTimeout = false;
       if (this.isUncertainRunnerError(error)) {
         this.logger.warn(`Runner timed out for ${app.appId}; verifying app at ${url}. (${message})`);
-        if (await this.verifyAppLive(url)) {
-          this.logger.log(`AI App ${app.appId} is live despite runner timeout — marking READY`);
-          return markReady(null);
-        }
+        survivedTimeout = await this.verifyAppLive(url);
       }
+      if (!survivedTimeout) {
+        this.logger.error(`AI App deploy failed for ${app.appId}: ${message}`);
+        await this.failDeploy(app.uid, memberUid, eventContext, message);
+        throw new BadGatewayException('Failed to deploy app to the sandbox runner');
+      }
+      this.logger.log(`AI App ${app.appId} is live despite runner timeout — continuing`);
+    }
 
-      this.logger.error(`AI App deploy failed for ${app.appId}: ${message}`);
-      await this.failDeploy(app.uid, memberUid, eventContext, message);
-      throw new BadGatewayException('Failed to deploy app to the sandbox runner');
+    // The build ran the app WITHOUT its secrets — redeploy the built image with
+    // the stored secret names injected. A secrets app that can't get its values
+    // must fail loudly rather than go READY in a broken state.
+    if (secretNames.length) {
+      try {
+        await this.deployImageWithSecrets(app.appId, secretNames, url);
+      } catch (error) {
+        const message = `Secrets injection failed: ${(error as Error).message}`;
+        this.logger.error(`AI App deploy failed for ${app.appId}: ${message}`);
+        await this.failDeploy(app.uid, memberUid, eventContext, message);
+        throw new BadGatewayException('Failed to inject secrets on the sandbox runner');
+      }
+    }
+
+    return markReady(port);
+  }
+
+  /**
+   * Redeploys an app's already-built image with the named stored secrets
+   * injected (`POST /v1/projects/<project>/deployments`). The image reference
+   * comes from the runner's own app registry (`GET /apps`).
+   */
+  private async deployImageWithSecrets(appId: string, secretNames: string[], appUrl: string): Promise<void> {
+    const headers = { 'Content-Type': 'application/json', 'x-runner-token': AI_APPS_RUNNER_TOKEN };
+
+    const registry = await axios.get<{ apps?: Array<{ app_id?: string; image?: string }> }>(
+      `${AI_APPS_RUNNER_URL}/apps`,
+      { headers: { 'x-runner-token': AI_APPS_RUNNER_TOKEN } }
+    );
+    const image = registry.data?.apps?.find((entry) => entry.app_id === appId)?.image;
+    if (!image) {
+      throw new Error(`runner /apps has no image for ${appId}`);
+    }
+
+    try {
+      this.logger.log(
+        `Runner secrets-deploy request for ${appId}: POST ${buildRunnerDeploymentsUrl()} ` +
+          `(image=${image}, secretNames=${secretNames.join(', ')})`
+      );
+      const response = await axios.post(
+        buildRunnerDeploymentsUrl(),
+        { appId, environment: AI_APPS_RUNNER_ENVIRONMENT, image, secretNames },
+        { headers }
+      );
+      this.logRunnerResponse('secrets-deploy', appId, response.status, response.data);
+    } catch (error) {
+      this.logRunnerError('secrets-deploy', appId, error);
+      // Same edge-timeout caveat as the build: verify before declaring failure.
+      if (this.isUncertainRunnerError(error) && (await this.verifyAppLive(appUrl))) {
+        this.logger.warn(`Secrets deploy timed out for ${appId} but the app is reachable — continuing`);
+        return;
+      }
+      const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+      throw new Error(`runner deployments call failed (status=${status ?? 'n/a'})`);
     }
   }
 

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -155,7 +155,9 @@ The backend (creator or directory admin only) first checks every name in `requir
 
 3. **Update & redeploy** — the member can reopen the same page any time, change one or more values (`secrets` may be a subset — the runner merges), and Deploy again. `secrets` may also be omitted entirely to redeploy with the already-stored values. For a code update the agent re-registers the draft (same `appId`, fresh `deploymentId`); stored values stay valid.
 
-> **Runner contract assumption:** the deploy step assumes the runner injects the secrets stored under `appId`/`environment` when `/deploy` builds and starts the container (per the "Runtime Secrets" Postman collection, whose `deployments*` endpoints only cover already-built images). All runner calls are isolated in `AiAppsService.saveSecrets` / `proxyDeploy`, so if the contract turns out to require an explicit `deployments:with-secrets` call after build, only those methods change.
+> **Runner contract (verified 2026-07-08):** the legacy `/deploy` (s3Key build) does **NOT** inject stored secrets — the container comes up without them. The backend therefore runs a second call after a successful build: `GET /apps` to resolve the built image, then `POST /v1/projects/<project>/deployments` with `{ appId, environment, image, secretNames }` to redeploy it with the secrets injected (`AiAppsService.deployImageWithSecrets`, called from `proxyDeploy`; injection failure marks the app `ERROR` rather than shipping a broken "READY" app).
+>
+> ⚠️ **Currently blocked by a runner-side conflict:** `/deploy` installs helm release `sandbox-<appId>` while the deployments endpoint installs `<environment>-<appId>` (with host `<environment>-<appId>.<domain>`), and both own a Service named `<appId>` — so the second call fails with helm "invalid ownership metadata". The runner team needs to align the release naming (or accept `secretNames` on `/deploy` — its chart already supports `runtimeSecrets`). All of this is isolated in `saveSecrets` / `deployImageWithSecrets` / `proxyDeploy`.
 
 ### Delete request
 
@@ -234,7 +236,7 @@ model AiAppEvent {            // append-only audit log — one row per event, ne
 
 Apps are **lazy-created on first deploy** — there is no registration form. (A draft registration counts: it upserts the same record with status `DRAFT`.)
 
-**Response shape:** every AI Apps endpoint (`list`, detail, `events`, and the `deploy` result) returns the owner as `member: { uid, name }` and omits the raw `memberUid` (the uid lives in `member.uid`, so it isn't duplicated). `memberUid` remains a column on the DB models above.
+**Response shape:** every AI Apps endpoint (`list`, detail, `events`, and the `deploy` result) returns the owner as `member: { uid, name }` and omits the raw `memberUid` (the uid lives in `member.uid`, so it isn't duplicated). `memberUid` remains a column on the DB models above. The detail endpoint additionally returns `canManage` — whether the requesting member is the creator or a directory admin — computed server-side so the UI never compares member uids from a possibly stale login cookie.
 
 `AiApp.status` is the current-state snapshot for the dashboard; `AiAppEvent` is the immutable event flow. A row is appended on kit download (`KIT_DOWNLOADED`), on each connect approval/denial (`CONNECT_APPROVED` / `CONNECT_DENIED` — the `userCode` is recorded in `message`), at the start of every deploy (`DEPLOY_STARTED`) and its outcome (`DEPLOY_SUCCEEDED` / `DEPLOY_FAILED`), and likewise for deletes (`DELETE_STARTED` → `DELETE_SUCCEEDED` / `DELETE_FAILED`). Event logging never throws — a logging failure won't break a download, connect, deploy, or delete.
 


### PR DESCRIPTION
## Description

The draft route was rejected with a 415 because multipart uploads must be excluded from the JSON-only content-type middleware; the exclusion was added.
Request validation for all AI Apps endpoints was silently skipped due to a wrong validation-pipe import; it now actually validates, which also fixes required-env-var parsing.
The app detail endpoint now returns a server-computed `canManage` flag (creator or directory admin), and the LabOS page uses it instead of comparing member uids client-side — a stale or duplicate login cookie was hiding the secrets form from the app's own creator.
Deploys of secret-bearing apps verified that the runner's build endpoint does not inject stored secrets, so after a successful build the backend now redeploys the built image with the stored secret names injected, and a failed injection marks the app ERROR instead of leaving it READY without its secrets.
The secrets-injection step is currently blocked by a runner-side helm release-naming conflict between its build and deployments endpoints; the runner team needs to align release names or accept secret names on the build endpoint.
On the LabOS side, the app iframe is replaced with a "Redeploying…" placeholder while a deploy is in flight and reloads afterwards, so members no longer see a raw gateway error page during container restarts.


## Ticket

[LAB-2099](https://linear.app/plrs-labos/issue/LAB-2099/ai-apps-support-draft-apps-with-required-secrets-and-deploy-with)