### PR TITLE
LAB-2099 [AI Apps] Updates and improvements for AI Apps

### DIFF
--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
@@ -120,10 +120,24 @@ to the Protocol Labs Network sandbox with a single instruction.
    first deploy can take a minute or two.
 4. Your app appears on the PL Infra → AI Apps dashboard, where you can open it.
 
-> **Don't copy passwords or secret keys into \`app/\`.** If your app needs API keys
-> or other secrets, your agent registers it as a **draft** and gives you a LabOS
-> link — you enter the values there and click **Deploy**. Secrets never go into
-> the code, the chat, or the uploaded ZIP.
+## Apps that need an API key or password (secrets)
+Some apps need a secret to work — for example an app that talks to ChatGPT/OpenAI,
+sends emails, or connects to a database needs an **API key** or password for that
+service. If yours does, the flow is slightly different, and your agent handles it
+for you:
+
+1. Build your app as usual — just tell your agent what you want (e.g. "an app that
+   summarizes news with ChatGPT"). It knows the app will need a key.
+2. **Never paste your API key into the chat** (and don't put it in any file). If
+   you do it by accident, your agent will ask you to use the secure page instead.
+3. When it's time to deploy, your agent registers the app as a **draft** and gives
+   you a LabOS link. Open it, enter your key(s) in the form there, and click
+   **Deploy** — that page is the only place your secrets should ever go.
+4. Updating a key later? Open your app's page in LabOS (PL Infra → AI Apps → your
+   app), click **Update secrets & redeploy**, enter the new value, and Deploy.
+
+Secrets never go into the code, the chat, or the uploaded ZIP — they are stored
+securely on the sandbox and injected into your app when it runs.
 
 ## Embedding in the dashboard
 Your app is shown inside the AI Apps dashboard. Apps built with this kit display
@@ -224,9 +238,32 @@ not the scaffold's shape or language.
    equivalent), then confirm \`GET /health\` is 200 and \`GET /\` renders.
 
 ## Apps that need secrets (API keys, tokens, …)
-If the app reads any secret from the environment (\`process.env.OPENAI_API_KEY\`,
-a database URL with credentials, …), do **NOT** deploy it directly and do **NOT**
-put values in the ZIP. Instead use the draft flow (full steps in the deploy skill):
+The member is usually **not a developer** — they will never say "environment
+variable" or "secret". It is YOUR job to recognize when the app needs one and to
+route the deploy through the **draft flow** instead of deploying directly.
+
+**Recognize the need yourself.** The app needs the draft flow whenever it (will)
+talk to any external service that requires a credential — an AI/LLM API (OpenAI,
+Anthropic, …), email/SMS sending, a database, a paid data API, a webhook with a
+signing secret, and so on. If the member asks for a feature like "summarize with
+ChatGPT" or "send me an email", that IS a secrets app: wire the code to read the
+credential from an env var (e.g. \`process.env.OPENAI_API_KEY\`), pick a clear
+UPPER_SNAKE_CASE name, and plan for the draft flow. Before any deploy, double-check
+the code for \`process.env.*\` reads (or the language's equivalent) you may have
+added along the way.
+
+**Explain it in plain words.** Tell the member something like: *"This app needs
+your OpenAI API key to work. I never handle keys directly — I'll register the app
+and give you a secure LabOS link where you paste the key and click Deploy."*
+Don't use the words "env var", "draft registration", or "runtime injection" with
+the member.
+
+**If the member pastes a secret into the chat**, do not use it, do not echo it
+back, and do not write it anywhere. Tell them the chat isn't a safe place for
+keys, ask them to revoke/rotate it if it's sensitive, and point them to the LabOS
+page from step 3 below — that form is the only place values should be entered.
+
+The flow (full steps in the deploy skill):
 1. Get a deploy token via the connect flow as usual.
 2. POST the app ZIP to the \`draftEndpoint\` from \`pln-app.config.json\` with a
    \`requiredEnvVars\` field listing the env var NAMES the app needs. This
@@ -237,6 +274,8 @@ put values in the ZIP. Instead use the draft flow (full steps in the deploy skil
 4. To ship a code update later, register the draft again (same \`appId\`, fresh
    \`deploymentId\`) — already-stored secret values stay valid; the member just
    clicks Deploy again in LabOS.
+5. To change a key later, the member doesn't need you at all: on the app's LabOS
+   page they click **Update secrets & redeploy**, enter the new value, and Deploy.
 
 Never ask the member for secret values in the chat, and never write them to any
 file — LabOS is the only place they should be entered.
@@ -287,10 +326,21 @@ description: Deploy the app in ./app to the Protocol Labs Network sandbox. Use w
 
 Deploys the app in \`app/\` to the PLN sandbox and returns its live URL.
 
-**Needs secrets?** If the app reads any secret from the environment (API keys,
-tokens, credentialed URLs), do steps 1–4 as written but then follow
-"**Apps that need secrets (draft flow)**" below instead of step 5 — you register
-a draft and the member deploys from LabOS after entering the values.
+**Needs secrets? Decide BEFORE deploying — don't wait for the member to say so.**
+The member usually has no coding background and won't know their app "has secrets".
+Check for it yourself: does the app read any credential from the environment
+(\`process.env.*\` or equivalent), or call any external service that needs an API
+key (OpenAI/Anthropic, email/SMS, a database, a paid API)? A quick check:
+
+\`\`\`bash
+grep -rniE 'process\\.env\\.|os\\.environ|getenv' app --include='*.js' --include='*.ts' --include='*.py' | grep -viE 'PORT|NODE_ENV'
+\`\`\`
+
+If anything secret shows up (or you wrote code that needs a key), do steps 1–4 as
+written but then follow "**Apps that need secrets (draft flow)**" below instead of
+step 5 — you register a draft and the member deploys from LabOS after entering the
+values there. Never deploy a secrets app directly and never accept key values in
+the chat.
 
 ## Steps
 1. Read \`pln-app.config.json\` to get \`connectEndpoint\`, \`deployEndpoint\`,
@@ -402,12 +452,17 @@ curl -X POST "<draftEndpoint>" \\
 # → { "status": "DRAFT", "appPageUrl": "https://…/pl-infra/ai-apps/<uid>", "missingEnvVars": [ … ] }
 \`\`\`
 
-Then **tell the member, in your chat:** open \`appPageUrl\` in their browser, enter
-the secret values there, and click **Deploy**. The deploy runs immediately with
-the stored secrets; the app then appears as usual on the AI Apps dashboard.
+Then **tell the member, in your chat, in plain non-technical language** — e.g.
+*"Your app is registered. Open this link, paste your OpenAI API key into the form,
+and click Deploy — that page is the only safe place for your key."* Give them
+\`appPageUrl\`; they enter the values there and click **Deploy**. The deploy runs
+immediately with the stored secrets; the app then appears as usual on the AI Apps
+dashboard.
 
 - **Never** ask the member to paste secret values into the chat, and never write
-  them to a file — LabOS is the only place values are entered.
+  them to a file — LabOS is the only place values are entered. If they paste a
+  key into the chat anyway, don't use or repeat it — point them to \`appPageUrl\`
+  (and suggest rotating the key if it's sensitive).
 - To ship a **code update** later, re-register the draft (same \`appId\`, fresh
   \`deploymentId\`, updated \`requiredEnvVars\` if they changed) and send the member
   back to \`appPageUrl\` to click Deploy. Stored secret values remain valid.

--- a/apps/web-api/src/ai-apps/ai-apps.controller.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.controller.ts
@@ -126,6 +126,19 @@ export class AiAppsController {
     return this.aiAppsService.getApp(uid, memberUid);
   }
 
+  /**
+   * Liveness probe for the LabOS detail page: one server-side reachability
+   * check of the app's public URL (a gateway timeout counts as down). The page
+   * polls this while a deploy settles so the iframe never shows a raw 504.
+   */
+  @NoCache()
+  @Get(':uid/live')
+  @UseGuards(UserTokenCheckGuard, RbacGuard)
+  @RequirePermissions(READ)
+  async checkAppLive(@Param('uid') uid: string) {
+    return this.aiAppsService.checkAppLive(uid);
+  }
+
   /** Full event/status history for a single app, newest first. */
   @NoCache()
   @Get(':uid/events')

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -95,6 +95,29 @@ export class AiAppsService {
   }
 
   /**
+   * Single reachability probe of the app's public URL, for the LabOS detail
+   * page: it polls this while a redeploy settles so it can hold its own loading
+   * state instead of iframing a raw gateway error page. One attempt per call —
+   * the polling cadence belongs to the client (unlike `verifyAppLive`, which
+   * does its own retry loop inside the deploy flow).
+   */
+  async checkAppLive(uid: string): Promise<{ live: boolean }> {
+    const app = await this.prisma.aiApp.findUnique({ where: { uid } });
+    if (!app) {
+      throw new NotFoundException(`AI App not found: ${uid}`);
+    }
+    if (!app.url) {
+      return { live: false };
+    }
+    try {
+      const res = await axios.get(app.url, { timeout: 8000, validateStatus: () => true, maxRedirects: 0 });
+      return { live: !!res.status && !GATEWAY_TIMEOUT_STATUSES.includes(res.status) };
+    } catch {
+      return { live: false };
+    }
+  }
+
+  /**
    * Append an event to the audit log. Never throws — event logging must not
    * break the primary flow (download/deploy).
    */

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -91,6 +91,7 @@ The `deployToken` is held in agent memory only and never written into the kit, s
 | GET    | `/v1/ai-apps/events`             | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Event log (audit feed); `?appUid=` to scope, `?limit=` (default 100, max 500) |
 | GET    | `/v1/ai-apps/:uid`               | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Single app detail |
 | GET    | `/v1/ai-apps/:uid/events`        | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Full event/status history for one app (404 if app missing) |
+| GET    | `/v1/ai-apps/:uid/live`          | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Liveness probe: one server-side reachability check of the app URL → `{ live }`; the LabOS detail page polls it so the iframe never shows a raw gateway error |
 | POST   | `/v1/ai-apps/:uid/feedback`      | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Submit free-text feedback on an app (multiple entries per member allowed) |
 | GET    | `/v1/ai-apps/:uid/feedback`      | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` + creator/directory-admin (checked in service) | All feedback for one app, newest first, with submitter info |
 | GET    | `/v1/ai-apps/starter-kit/download` | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.write`   | Stream the starter-kit ZIP (no token inside) |
@@ -154,10 +155,6 @@ curl -X POST "https://api.plnetwork.io/v1/ai-apps/<uid>/deploy" \
 The backend (creator or directory admin only) first checks every name in `requiredEnvVars` has a value — stored earlier or submitted now — and otherwise rejects with a 400 naming the missing vars. It then saves the submitted values to the runner's secret store (`POST <AI_APPS_RUNNER_URL>/v1/projects/<AI_APPS_RUNNER_PROJECT>/secrets` with `{ appId, environment, secrets }` — merge/upsert semantics, `SECRETS_UPDATED` audited with names only) and redeploys the stored bundle through the normal runner `/deploy` proxy (status `DEPLOYING` → `READY`/`ERROR`).
 
 3. **Update & redeploy** — the member can reopen the same page any time, change one or more values (`secrets` may be a subset — the runner merges), and Deploy again. `secrets` may also be omitted entirely to redeploy with the already-stored values. For a code update the agent re-registers the draft (same `appId`, fresh `deploymentId`); stored values stay valid.
-
-> **Runner contract (verified 2026-07-08):** the legacy `/deploy` (s3Key build) does **NOT** inject stored secrets — the container comes up without them. The backend therefore runs a second call after a successful build: `GET /apps` to resolve the built image, then `POST /v1/projects/<project>/deployments` with `{ appId, environment, image, secretNames }` to redeploy it with the secrets injected (`AiAppsService.deployImageWithSecrets`, called from `proxyDeploy`; injection failure marks the app `ERROR` rather than shipping a broken "READY" app).
->
-> ⚠️ **Currently blocked by a runner-side conflict:** `/deploy` installs helm release `sandbox-<appId>` while the deployments endpoint installs `<environment>-<appId>` (with host `<environment>-<appId>.<domain>`), and both own a Service named `<appId>` — so the second call fails with helm "invalid ownership metadata". The runner team needs to align the release naming (or accept `secretNames` on `/deploy` — its chart already supports `runtimeSecrets`). All of this is isolated in `saveSecrets` / `deployImageWithSecrets` / `proxyDeploy`.
 
 ### Delete request
 
@@ -318,7 +315,7 @@ badges, tables, tabs, dropdowns, or sidebars from scratch.
 | `AI_APPS_DEPLOY_ENDPOINT` / `AI_APPS_CONNECT_ENDPOINT` / `AI_APPS_DRAFT_ENDPOINT` | _derived from `AI_APPS_BASE_URL`_ | Optional per-endpoint overrides; rarely needed |
 | `AI_APPS_PORTAL_URL` | `https://directory.plnetwork.io` | Base URL of the LabOS portal hosting the connect/approval page (used to build `connectUrl` and `appPageUrl`) |
 | `AI_APPS_RUNNER_PROJECT` | `default` | Project scope of the runner's secrets API (`/v1/projects/<project>/secrets`) |
-| `AI_APPS_RUNNER_ENVIRONMENT` | `prod` | Environment label secrets are stored under on the runner (`dev` on Dev, `prod` on Prod) |
+| `AI_APPS_RUNNER_ENVIRONMENT` | `prod` | Environment label for the runner secrets/deployments API. **Must match the environment the runner's `/deploy` build registers under** (its helm release is `<environment>-<appId>`; the legacy-compat build path registers as `sandbox`) — a mismatch makes the secrets-injection deploy collide with the build's release |
 
 S3 uploads reuse the shared `AwsService`, so the standard `AWS_REGION` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` credentials must also be present.
 


### PR DESCRIPTION
## Summary

The AI Apps dashboard create card now says "Create AI App" with "Start building your AI app here" as the helper text.
Redeploying an app from its detail page now shows an animated progress indicator instead of a plain text message.
The app iframe is no longer mounted until the backend confirms the app is reachable, so members never see a raw "504 Gateway Time-out" page after a redeploy.
The detail page polls a new liveness endpoint after every deploy and on first load, and shows a friendly retry screen if the app stays unreachable for a few minutes.
The starter-kit instructions now teach the AI agent to recognize on its own when an app needs API keys, route the deploy through the draft flow, refuse secrets pasted into the chat, and explain everything to non-technical members in plain language.
The kit README gained a plain-language section telling members how API keys are entered securely in LabOS and how to update them later.
The secrets form on the app detail page now uses the same left spacing as the header logo, so it no longer hugs the page edge.

## New endpoint

Liveness probe for one app (returns `{ "live": true | false }`):

```bash
curl -s "https://api.plnetwork.io/v1/ai-apps/<appUid>/live" \
  -H "Authorization: Bearer $MEMBER_JWT"
```


## Ticket

[LAB-2099](https://linear.app/plrs-labos/issue/LAB-2099/ai-apps-support-draft-apps-with-required-secrets-and-deploy-with)