### PR TITLE
[AI Apps] Updates and improvements for AI Apps

### DIFF
--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -111,7 +111,13 @@ export class AiAppsService {
     }
     try {
       const res = await axios.get(app.url, { timeout: 8000, validateStatus: () => true, maxRedirects: 0 });
-      return { live: !!res.status && !GATEWAY_TIMEOUT_STATUSES.includes(res.status) };
+      // 404 counts as DOWN here: right after a first deploy the ingress serves
+      // 404 until the app's route/pod is ready, and the kit contract requires a
+      // usable `GET /` anyway — reporting live on 404 makes the detail page
+      // iframe a blank error document. (Unlike `verifyAppLive`, which keeps
+      // 404-counts-as-up because it only asks whether the *server* survived a
+      // gateway timeout during the deploy flow.)
+      return { live: !!res.status && res.status !== 404 && !GATEWAY_TIMEOUT_STATUSES.includes(res.status) };
     } catch {
       return { live: false };
     }

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -91,7 +91,7 @@ The `deployToken` is held in agent memory only and never written into the kit, s
 | GET    | `/v1/ai-apps/events`             | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Event log (audit feed); `?appUid=` to scope, `?limit=` (default 100, max 500) |
 | GET    | `/v1/ai-apps/:uid`               | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Single app detail |
 | GET    | `/v1/ai-apps/:uid/events`        | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Full event/status history for one app (404 if app missing) |
-| GET    | `/v1/ai-apps/:uid/live`          | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Liveness probe: one server-side reachability check of the app URL → `{ live }`; the LabOS detail page polls it so the iframe never shows a raw gateway error |
+| GET    | `/v1/ai-apps/:uid/live`          | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Liveness probe: one server-side reachability check of the app URL → `{ live }`; gateway timeouts AND 404 count as down (the ingress 404s until a first deploy's route is ready). The LabOS detail page polls it so the iframe never shows a raw gateway/404 error |
 | POST   | `/v1/ai-apps/:uid/feedback`      | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Submit free-text feedback on an app (multiple entries per member allowed) |
 | GET    | `/v1/ai-apps/:uid/feedback`      | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` + creator/directory-admin (checked in service) | All feedback for one app, newest first, with submitter info |
 | GET    | `/v1/ai-apps/starter-kit/download` | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.write`   | Stream the starter-kit ZIP (no token inside) |


### PR DESCRIPTION
## Summary

Fixed the empty screen that appeared right after deploying a secrets app for the very first time from its LabOS page.
The liveness check now counts a 404 from the app address as "not ready yet", because the sandbox briefly answers 404 while a first deploy's route comes online.
The detail page therefore keeps showing its progress state and only loads the app once it truly responds, instead of embedding a blank 404 page.
Redeploys were already unaffected because the previous version keeps serving during the switch.
No new endpoints were added.
