### PR TITLE
LAB-2107 [Team News] Digest content toggles + digest for users without forum access

### DIFF
--- a/apps/web-api/src/admin/member.service.ts
+++ b/apps/web-api/src/admin/member.service.ts
@@ -27,7 +27,7 @@ import {
 import { ForestAdminService } from '../utils/forest-admin/forest-admin.service';
 import { MembersHooksService } from '../members/members.hooks.service';
 import { ParticipantsRequest } from './members.dto';
-import { MEMBER_PERMISSIONS } from '../access-control-v2/access-control-v2.constants';
+import { FORUM_PERMISSIONS, MEMBER_PERMISSIONS } from '../access-control-v2/access-control-v2.constants';
 import { TeamsService } from '../teams/teams.service';
 
 @Injectable()
@@ -589,13 +589,9 @@ export class MemberService {
     tx: Prisma.TransactionClient = this.prisma
   ): Promise<Member> {
     try {
-      const createdMember = await tx.member.create({
+      return await tx.member.create({
         data: member,
       });
-      await this.notificationSettingsService.createForumNotificationSetting(createdMember.uid).catch((error) => {
-        this.logger.error(`Error creating forum notification setting for member ${createdMember.uid}: ${error}`);
-      });
-      return createdMember;
     } catch (error) {
       return this.handleErrors(error);
     }
@@ -1755,6 +1751,7 @@ export class MemberService {
 
   async createMemberByAdmin(memberData: CreateMemberDto): Promise<Member> {
     let createdMember: any;
+    let hasForumAccess = false;
     await this.prisma.$transaction(async (tx) => {
       const aclPayload = memberData as CreateMemberDto & {
         roleCodes?: string[];
@@ -1844,6 +1841,8 @@ export class MemberService {
         actorUid: null,
       });
 
+      hasForumAccess = await this.memberHasPermissionCode(tx, createdMember.uid, FORUM_PERMISSIONS.READ);
+
       if ((memberData.memberState ?? MemberState.PENDING) === MemberState.APPROVED) {
         // Check if member has onboarding permission for targeted onboarding flow
         const hasOnboardingPermission = await this.memberHasOnboardingPermission(tx, createdMember.uid);
@@ -1860,6 +1859,17 @@ export class MemberService {
 
       await this.membersHooksService.postCreateActions(createdMember, memberData.email);
     });
+
+    // The digest is opt-in for members without forum access (LAB-2107,
+    // Option A): only members granted forum.read are auto-subscribed. Runs
+    // after the transaction so the access grants are committed and the HTTP
+    // call to the notification service can't roll back with the member.
+    if (hasForumAccess) {
+      await this.notificationSettingsService.createForumNotificationSetting(createdMember.uid).catch((error) => {
+        this.logger.error(`Error creating forum notification setting for member ${createdMember.uid}: ${error}`);
+      });
+    }
+
     return this.findMemberByUid(createdMember.uid);
   }
 

--- a/libs/contracts/src/schema/notification-settings.ts
+++ b/libs/contracts/src/schema/notification-settings.ts
@@ -45,6 +45,7 @@ export const UpdateParticipationSchema = z.object({
 export const UpdateForumSettingsSchema = z.object({
   forumDigestEnabled: z.boolean(),
   forumDigestFrequency: z.number(),
+  forumDigestForumEnabled: z.boolean().optional(),
   forumDigestNewsEnabled: z.boolean().optional(),
 });
 


### PR DESCRIPTION
### Ticket
[LAB-2107](https://linear.app/plrs-labos/issue/LAB-2107/team-news-digest-content-toggles-digest-for-users-without-forum-access)

### Summary
- Extends the forum digest settings contract with an optional **Forum activity** preference so members can choose whether forum content is included in their digest email.
- The new preference flows through the existing settings endpoint to the notification service, which stores it and applies it at send time.

### Related PRs
- UI: memser-spaceport/pln-directory-portal-v2#2633
- Notification service: memser-spaceport/pl-notification-service#117
