### PR TITLE
LAB-2114 [AI Apps] Pass logged-in user context into AI apps

### DIFF
--- a/apps/web-api/prisma/migrations/20260714120000_ai_apps_kit_version/migration.sql
+++ b/apps/web-api/prisma/migrations/20260714120000_ai_apps_kit_version/migration.sql
@@ -1,0 +1,5 @@
+-- AI Apps: track which starter-kit version produced each app's last agent
+-- upload (deploy or draft registration), as reported by the kit itself.
+-- NULL = pre-1.4 kit (the field didn't exist yet) or a non-kit upload.
+
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "kitVersion" TEXT;

--- a/apps/web-api/prisma/migrations/20260714120000_ai_apps_kit_version/migration.sql
+++ b/apps/web-api/prisma/migrations/20260714120000_ai_apps_kit_version/migration.sql
@@ -1,5 +1,0 @@
--- AI Apps: track which starter-kit version produced each app's last agent
--- upload (deploy or draft registration), as reported by the kit itself.
--- NULL = pre-1.4 kit (the field didn't exist yet) or a non-kit upload.
-
-ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "kitVersion" TEXT;

--- a/apps/web-api/prisma/migrations/20260714120000_ai_apps_upload_meta/migration.sql
+++ b/apps/web-api/prisma/migrations/20260714120000_ai_apps_upload_meta/migration.sql
@@ -1,0 +1,10 @@
+-- AI Apps: debugging metadata about each app's last agent upload (deploy or
+-- draft registration). All values are self-reported by the agent/kit and NULL
+-- for uploads from older kits that didn't send them.
+--   kitVersion  — starter-kit version (from the kit's pln-app.config.json)
+--   agentClient — AI tool name from the connect session's clientName (e.g. "Claude Code")
+--   agentModel  — model the agent reports running on (e.g. "claude-sonnet-4-5")
+
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "kitVersion" TEXT;
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "agentClient" TEXT;
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "agentModel" TEXT;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -3012,6 +3012,12 @@ model AiApp {
   /// registration), as reported by the kit itself. Null = pre-1.4 kit (the
   /// field didn't exist yet) or a non-kit upload.
   kitVersion   String?
+  /// AI tool behind the last agent upload, copied server-side from the connect
+  /// session's self-reported `clientName` (e.g. "Claude Code").
+  agentClient  String?
+  /// Model the agent reported running on for the last upload (optional
+  /// self-reported multipart field, kits ≥1.4).
+  agentModel   String?
   createdAt    DateTime    @default(now())
   updatedAt    DateTime    @updatedAt
 

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -3008,6 +3008,10 @@ model AiApp {
   /// Env var NAMES the member has provided values for. Values are never stored
   /// here — they go straight to the sandbox runner's secret store.
   providedEnvVars String[]  @default([])
+  /// Starter-kit version that produced the last agent upload (deploy or draft
+  /// registration), as reported by the kit itself. Null = pre-1.4 kit (the
+  /// field didn't exist yet) or a non-kit upload.
+  kitVersion   String?
   createdAt    DateTime    @default(now())
   updatedAt    DateTime    @updatedAt
 

--- a/apps/web-api/src/ai-apps/ai-apps-draft.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-draft.spec.ts
@@ -151,20 +151,35 @@ describe('AiAppsService.registerDraft', () => {
     expect(result.missingEnvVars).toEqual(['SUPABASE_URL']);
   });
 
-  it('stores the reported kit version, and clears it when the kit sends none', async () => {
+  it('stores the upload metadata (kit version, agent client + model), clearing what is not sent', async () => {
     const { service, prisma } = buildService();
-    await service.registerDraft('creator-1', { ...DTO, kitVersion: '1.4' }, FILE);
+    await service.registerDraft(
+      'creator-1',
+      { ...DTO, kitVersion: '1.4', agentModel: 'claude-sonnet-4-5' },
+      FILE,
+      'Claude Code'
+    );
     expect(prisma.aiApp.upsert).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        create: expect.objectContaining({ kitVersion: '1.4' }),
-        update: expect.objectContaining({ kitVersion: '1.4' }),
+        create: expect.objectContaining({
+          kitVersion: '1.4',
+          agentClient: 'Claude Code',
+          agentModel: 'claude-sonnet-4-5',
+        }),
+        update: expect.objectContaining({
+          kitVersion: '1.4',
+          agentClient: 'Claude Code',
+          agentModel: 'claude-sonnet-4-5',
+        }),
       })
     );
+    // An older kit / anonymous session sends none of it — stored values are
+    // cleared rather than left stale.
     await service.registerDraft('creator-1', DTO, FILE);
     expect(prisma.aiApp.upsert).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        create: expect.objectContaining({ kitVersion: null }),
-        update: expect.objectContaining({ kitVersion: null }),
+        create: expect.objectContaining({ kitVersion: null, agentClient: null, agentModel: null }),
+        update: expect.objectContaining({ kitVersion: null, agentClient: null, agentModel: null }),
       })
     );
   });

--- a/apps/web-api/src/ai-apps/ai-apps-draft.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-draft.spec.ts
@@ -96,6 +96,13 @@ describe('RegisterDraftSchema.requiredEnvVars', () => {
   it('rejects an empty list', () => {
     expect(() => RegisterDraftSchema.parse({ ...base, requiredEnvVars: '' })).toThrow();
   });
+
+  it('accepts an optional kitVersion and rejects a malformed one', () => {
+    const withVars = { ...base, requiredEnvVars: 'OPENAI_API_KEY' };
+    expect(RegisterDraftSchema.parse({ ...withVars, kitVersion: '1.4' }).kitVersion).toBe('1.4');
+    expect(RegisterDraftSchema.parse(withVars).kitVersion).toBeUndefined();
+    expect(() => RegisterDraftSchema.parse({ ...withVars, kitVersion: 'latest' })).toThrow();
+  });
 });
 
 describe('AiAppsService.registerDraft', () => {
@@ -142,6 +149,24 @@ describe('AiAppsService.registerDraft', () => {
     prisma.aiApp.upsert.mockResolvedValue({ ...APP, providedEnvVars: ['OPENAI_API_KEY'] });
     const result = await service.registerDraft('creator-1', DTO, FILE);
     expect(result.missingEnvVars).toEqual(['SUPABASE_URL']);
+  });
+
+  it('stores the reported kit version, and clears it when the kit sends none', async () => {
+    const { service, prisma } = buildService();
+    await service.registerDraft('creator-1', { ...DTO, kitVersion: '1.4' }, FILE);
+    expect(prisma.aiApp.upsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ kitVersion: '1.4' }),
+        update: expect.objectContaining({ kitVersion: '1.4' }),
+      })
+    );
+    await service.registerDraft('creator-1', DTO, FILE);
+    expect(prisma.aiApp.upsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ kitVersion: null }),
+        update: expect.objectContaining({ kitVersion: null }),
+      })
+    );
   });
 });
 

--- a/apps/web-api/src/ai-apps/ai-apps-member-context-routes.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-member-context-routes.spec.ts
@@ -1,0 +1,44 @@
+/// <reference types="multer" />
+// axios ships ESM (not in the jest transform allowlist); the metadata checks
+// here never call it.
+jest.mock('axios', () => ({ isAxiosError: jest.fn(() => false) }));
+
+import 'reflect-metadata';
+import { PATH_METADATA, METHOD_METADATA, GUARDS_METADATA } from '@nestjs/common/constants';
+import { RequestMethod } from '@nestjs/common';
+import { AiAppsController } from './ai-apps.controller';
+import { UserAccessTokenValidateGuard } from '../guards/user-access-token-validate.guard';
+import { RbacGuard } from '../rbac/rbac.guard';
+import { RBAC_PERMISSIONS_KEY } from '../rbac/rbac.decorator';
+import { AI_APPS_PERMISSIONS } from '../access-control-v2/access-control-v2.constants';
+
+/**
+ * Wiring checks for `GET /v1/ai-apps/me` (the member-context endpoint deployed
+ * apps call). The full-app e2e path is not runnable in this repo's jest setup
+ * (@nestjs/testing lags @nestjs/core), so this pins the routing/guard metadata
+ * that matters instead.
+ */
+describe('AiAppsController GET /me wiring', () => {
+  const handler = AiAppsController.prototype.getMemberContext;
+
+  it('registers as GET "me"', () => {
+    expect(Reflect.getMetadata(PATH_METADATA, handler)).toBe('me');
+    expect(Reflect.getMetadata(METHOD_METADATA, handler)).toBe(RequestMethod.GET);
+  });
+
+  it('is declared before the :uid route so the literal path wins', () => {
+    const methods = Object.getOwnPropertyNames(AiAppsController.prototype);
+    expect(methods.indexOf('getMemberContext')).toBeGreaterThan(-1);
+    expect(methods.indexOf('getMemberContext')).toBeLessThan(methods.indexOf('getApp'));
+  });
+
+  it('uses the cookie-or-bearer token guard plus RBAC', () => {
+    expect(Reflect.getMetadata(GUARDS_METADATA, handler)).toEqual([UserAccessTokenValidateGuard, RbacGuard]);
+  });
+
+  it('requires AI Apps read (or write) permission', () => {
+    expect(Reflect.getMetadata(RBAC_PERMISSIONS_KEY, handler)).toEqual({
+      anyOf: [AI_APPS_PERMISSIONS.READ, AI_APPS_PERMISSIONS.WRITE],
+    });
+  });
+});

--- a/apps/web-api/src/ai-apps/ai-apps-member-context.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-member-context.spec.ts
@@ -1,0 +1,103 @@
+import { NotFoundException } from '@nestjs/common';
+
+// axios ships ESM (not in the jest transform allowlist) and the member-context
+// path under test never calls it.
+jest.mock('axios', () => ({ isAxiosError: jest.fn(() => false) }));
+
+import { AiAppsService } from './ai-apps.service';
+
+const MEMBER = {
+  uid: 'member-1',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  officeHours: null,
+  image: { url: 'https://cdn.example.com/ada.png' },
+  location: { city: 'London', country: 'United Kingdom', continent: 'Europe' },
+  skills: [{ title: 'Engineering' }, { title: 'Research' }],
+  teamMemberRoles: [
+    {
+      role: 'Engineer',
+      mainTeam: true,
+      teamLead: false,
+      team: { uid: 'team-1', name: 'Protocol Labs' },
+    },
+    {
+      role: null,
+      mainTeam: false,
+      teamLead: true,
+      team: { uid: 'team-2', name: 'Side Project' },
+    },
+  ],
+};
+
+function buildService(overrides: Record<string, any> = {}) {
+  const prisma = {
+    member: { findUnique: jest.fn().mockResolvedValue(MEMBER) },
+    ...overrides,
+  };
+  return { service: new AiAppsService(prisma as any, {} as any), prisma };
+}
+
+describe('AiAppsService getMemberContext', () => {
+  it('throws 404 when the member does not exist', async () => {
+    const { service, prisma } = buildService();
+    prisma.member.findUnique.mockResolvedValue(null);
+    await expect(service.getMemberContext('missing')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('returns the curated public identity under `member`', async () => {
+    const { service } = buildService();
+    const result = await service.getMemberContext('member-1');
+    expect(result).toEqual({
+      member: {
+        uid: 'member-1',
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        officeHours: null,
+        image: 'https://cdn.example.com/ada.png',
+        location: { city: 'London', country: 'United Kingdom', continent: 'Europe' },
+        skills: ['Engineering', 'Research'],
+        teams: [
+          { uid: 'team-1', name: 'Protocol Labs', role: 'Engineer', mainTeam: true, teamLead: false },
+          { uid: 'team-2', name: 'Side Project', role: null, mainTeam: false, teamLead: true },
+        ],
+      },
+    });
+  });
+
+  it('tolerates a member without image, location, skills, or teams', async () => {
+    const { service, prisma } = buildService();
+    prisma.member.findUnique.mockResolvedValue({
+      uid: 'member-2',
+      name: 'No Frills',
+      email: null,
+      officeHours: null,
+      image: null,
+      location: null,
+      skills: [],
+      teamMemberRoles: [],
+    });
+    const result = await service.getMemberContext('member-2');
+    expect(result.member).toEqual({
+      uid: 'member-2',
+      name: 'No Frills',
+      email: null,
+      officeHours: null,
+      image: null,
+      location: null,
+      skills: [],
+      teams: [],
+    });
+  });
+
+  it('selects only curated public fields (no raw relations leak through)', async () => {
+    const { service, prisma } = buildService();
+    await service.getMemberContext('member-1');
+    const select = prisma.member.findUnique.mock.calls[0][0].select;
+    expect(Object.keys(select).sort()).toEqual(
+      ['email', 'image', 'location', 'name', 'officeHours', 'skills', 'teamMemberRoles', 'uid'].sort()
+    );
+    const result = await service.getMemberContext('member-1');
+    expect(result.member).not.toHaveProperty('teamMemberRoles');
+  });
+});

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
@@ -173,6 +173,12 @@ its own). Each new deploy session just asks you to approve again.
 You are helping a Protocol Labs Network member build and deploy a small web app
 to the PLN sandbox. Follow these rules.
 
+**Skills note (non-Claude tools):** detailed how-to guides live as plain
+markdown under \`.claude/skills/<name>/SKILL.md\`. Claude Code discovers them
+automatically; if you are a different agent (Codex, Cursor, etc.), just READ
+the referenced file whenever these instructions say to "load a skill" — they
+are ordinary docs, not Claude-specific magic.
+
 ## Building the app
 - All application code lives in the \`app/\` directory.
 - \`app/\` must stay independently runnable: \`npm install && npm start\` serves it
@@ -522,12 +528,14 @@ the chat.
 2. **Get a deploy token via LabOS.** The kit has no token; obtain a short-lived one
    through the connect flow:
 
-   a. Start a session (no auth needed):
+   a. Start a session (no auth needed). Set \`clientName\` to YOUR actual tool
+      name (e.g. "Claude Code", "Cursor", "Codex CLI") — it is shown to the
+      member on the approval page and recorded with the deployed app:
 
    \`\`\`bash
    curl -sX POST "<connectEndpoint>" \\
      -H "Content-Type: application/json" \\
-     -d '{"clientName":"Claude Code"}'
+     -d '{"clientName":"<your tool name>"}'
    # → { "sessionId", "userCode", "connectUrl", "pollToken", "pollIntervalSec", "expiresAt" }
    \`\`\`
 
@@ -576,6 +584,7 @@ the chat.
      -F "description=<one line about the app>" \\
      -F "deploymentId=<unique id per deploy, e.g. a timestamp>" \\
      -F "kitVersion=<the kitVersion from pln-app.config.json>" \\
+     -F "agentModel=<the model you are running on, e.g. claude-sonnet-4-5; omit the field if unknown>" \\
      -F "file=@app.zip;type=application/zip"
    \`\`\`
 
@@ -621,6 +630,7 @@ curl -X POST "<draftEndpoint>" \\
   -F "description=<one line about the app>" \\
   -F "deploymentId=<unique id per upload, e.g. a timestamp>" \\
   -F "kitVersion=<the kitVersion from pln-app.config.json>" \\
+  -F "agentModel=<the model you are running on; omit the field if unknown>" \\
   -F 'requiredEnvVars=["OPENAI_API_KEY","SUPABASE_URL"]' \\
   -F "file=@app.zip;type=application/zip"
 # → { "status": "DRAFT", "appPageUrl": "https://…/pl-infra/ai-apps/<uid>", "missingEnvVars": [ … ] }

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
@@ -8,6 +8,7 @@ import {
   AI_APPS_CONNECT_ENDPOINT,
   AI_APPS_DEPLOY_ENDPOINT,
   AI_APPS_DRAFT_ENDPOINT,
+  AI_APPS_ME_ENDPOINT,
   AI_APPS_STARTER_KIT_VERSION,
 } from './ai-apps.constants';
 
@@ -35,6 +36,7 @@ export class AiAppsStarterKitService {
     add('AGENTS.md', this.agentInstructions());
     add('.claude/skills/deploy-to-labs/SKILL.md', this.deploySkill());
     add('.claude/skills/pl-design-system/SKILL.md', this.designSystemSkill());
+    add('.claude/skills/pln-member-context/SKILL.md', this.memberContextSkill());
     add('pln-app.config.json', this.configJson());
     add('styles/pln-theme.css', this.themeCss());
     add('styles/FONTS.md', this.fontsDoc());
@@ -98,6 +100,7 @@ to the Protocol Labs Network sandbox with a single instruction.
 - \`CLAUDE.md\` / \`AGENTS.md\` — instructions your AI agent reads automatically.
 - \`.claude/skills/deploy-to-labs/\` — the deploy skill your agent uses.
 - \`.claude/skills/pl-design-system/\` — how to build on-brand UI with the PL Design System.
+- \`.claude/skills/pln-member-context/\` — how your app can know which PLN member is using it.
 - \`pln-app.config.json\` — the LabOS connect + deploy endpoints (no secrets).
 - \`pl-design-system/\` — the **PL Design System**: ready-made React components
   (Button, MemberCard, TeamCard, Table, Tabs, Badge, PageHeader, SearchInput,
@@ -140,6 +143,14 @@ for you:
 
 Secrets never go into the code, the chat, or the uploaded ZIP — they are stored
 securely on the sandbox and injected into your app when it runs.
+
+## Personalized apps (who's using it)
+Your app can know which PLN member opened it. When a signed-in member with AI
+Apps access uses your app, it can fetch their public directory profile — name,
+photo, teams, role, skills — to greet them, tag their feedback, or tailor what
+it shows. Just ask your agent, e.g. *"greet me by name and show my team when I
+open the app"*. Visitors who aren't signed in (or lack access) simply get the
+non-personalized version — your app keeps working for them.
 
 ## Embedding in the dashboard
 Your app is shown inside the AI Apps dashboard. Apps built with this kit display
@@ -201,6 +212,21 @@ folder. Before any UI work, load the **pl-design-system** skill
     \`frame-ancestors 'none'\`.
   - The default scaffold sends neither header, so it already embeds fine — this
     only matters once you add \`helmet\`, a CSP, or other security headers.
+
+## Signed-in member context (personalization)
+The app can identify the PLN member using it. Load the **pln-member-context**
+skill (\`.claude/skills/pln-member-context/SKILL.md\`) before writing any code
+that needs the current user. In short: browser code calls the
+\`memberContextEndpoint\` from \`pln-app.config.json\` with
+\`fetch(url, { credentials: 'include' })\` — the LabOS session cookie (shared
+across the PLN parent domain) authenticates the request, and the response
+carries the member's public profile (uid, name, email, image, teams + roles,
+skills). Bake the endpoint URL into the app's frontend as a constant — the
+config file itself is not shipped inside \`app/\`.
+- Handle the signed-out case gracefully (401/403/local dev): show a friendly
+  note and keep the app usable without identity. Never hard-fail on it.
+- Personalization only: never gate sensitive/destructive actions on it, never
+  store or log tokens, and never forward member data to third parties.
 
 ## Migrating an existing app
 When the member already has an app and wants it on LabOS, you are *adapting their
@@ -302,8 +328,8 @@ hour and is tied to the member who approved the connect link. Never print it in
 logs, write it to a file, or commit it; if a deploy returns 401 (expired), just
 run the connect flow again to get a fresh one.
 
-Do not ask for or use any internal PLN APIs — only the connect and deploy
-endpoints in the config are available to you.
+Do not ask for or use any internal PLN APIs — only the connect, deploy, and
+member-context endpoints in the config are available to you.
 `;
   }
 
@@ -380,6 +406,87 @@ primitive, stop and tell the member: \`Missing canonical component: [name]\`.
 `;
   }
 
+  private memberContextSkill(): string {
+    return `---
+name: pln-member-context
+description: Get the signed-in PLN member's identity (name, teams, role, skills) inside a deployed AI App, for personalization and feedback. Use whenever the app should greet the user, tag content with who created it, or adapt to the member using it. Load before writing any code that needs to know who is using the app.
+---
+
+# PLN Member Context — who is using the app
+
+Deployed apps are opened by signed-in PLN members from the PL Infra → AI Apps
+dashboard. The LabOS login cookie is scoped to the parent PLN domain, so it
+automatically rides along on requests from the deployed app to the PLN API —
+the app can ask "who is using me?" without any login UI of its own.
+
+## The endpoint
+
+\`memberContextEndpoint\` in \`pln-app.config.json\`:
+
+\`\`\`
+GET ${AI_APPS_ME_ENDPOINT}
+\`\`\`
+
+Call it from **browser code** with cookies included. The config file is not
+shipped inside \`app/\`, so bake the URL into the frontend as a constant:
+
+\`\`\`js
+const MEMBER_CONTEXT_URL = '${AI_APPS_ME_ENDPOINT}';
+
+async function getMemberContext() {
+  try {
+    const res = await fetch(MEMBER_CONTEXT_URL, { credentials: 'include' });
+    if (!res.ok) return null; // 401 = not signed in, 403 = no AI Apps access
+    const { member } = await res.json();
+    return member;
+  } catch {
+    return null; // network/CORS error — treat as signed out
+  }
+}
+\`\`\`
+
+Response shape (\`member\`):
+
+\`\`\`json
+{
+  "uid": "…",
+  "name": "Ada Lovelace",
+  "email": "ada@example.com",
+  "image": "https://…/profile.png",
+  "officeHours": null,
+  "location": { "city": "London", "country": "United Kingdom", "continent": "Europe" },
+  "skills": ["Engineering", "Research"],
+  "teams": [
+    { "uid": "…", "name": "Protocol Labs", "role": "Engineer", "mainTeam": true, "teamLead": false }
+  ]
+}
+\`\`\`
+
+Fields may be \`null\`/empty, and new fields may be added over time — ignore
+anything you don't recognize.
+
+## Rules
+
+- **Always handle the signed-out case.** \`getMemberContext()\` returns \`null\`
+  when the visitor is not signed in, lacks AI Apps access, or when the app runs
+  locally (\`npm start\` — no PLN cookie on localhost). Show a friendly note like
+  *"Open this app from the LabOS → AI Apps dashboard to personalize it"* and keep
+  the rest of the app working. Never crash or block on missing identity.
+- **Personalization only, not authentication.** Use the identity to greet the
+  member, tag feedback/content with who wrote it, or tailor behavior. Do not
+  gate sensitive or destructive actions on it, and don't build your own
+  session/auth system on top.
+- Call it client-side. If you must know the member on your server, forward the
+  incoming request's \`authToken\` cookie value to the endpoint as an
+  \`Authorization: Bearer <token>\` header (strip any surrounding double quotes).
+  Never store or log the token, and never send it — or the member's data — to
+  any third-party service.
+- This is the only PLN member API available to apps. Don't call other internal
+  PLN endpoints; if the app needs more PLN data than this provides, tell the
+  member it isn't available yet.
+`;
+  }
+
   private deploySkill(): string {
     return `---
 name: deploy-to-labs
@@ -408,9 +515,10 @@ the chat.
 
 ## Steps
 1. Read \`pln-app.config.json\` to get \`connectEndpoint\`, \`deployEndpoint\`,
-   \`draftEndpoint\`, and (if present) a saved \`appId\`. If no \`appId\` exists yet,
-   pick a short, stable, lowercase slug (e.g. \`hello-board\`) and save it back to
-   the config.
+   \`draftEndpoint\`, the \`kitVersion\` (sent with every upload so PLN knows which
+   kit built the app), and (if present) a saved \`appId\`. If no \`appId\` exists
+   yet, pick a short, stable, lowercase slug (e.g. \`hello-board\`) and save it
+   back to the config. Never edit \`kitVersion\` by hand.
 2. **Get a deploy token via LabOS.** The kit has no token; obtain a short-lived one
    through the connect flow:
 
@@ -467,6 +575,7 @@ the chat.
      -F "name=<human-friendly app name>" \\
      -F "description=<one line about the app>" \\
      -F "deploymentId=<unique id per deploy, e.g. a timestamp>" \\
+     -F "kitVersion=<the kitVersion from pln-app.config.json>" \\
      -F "file=@app.zip;type=application/zip"
    \`\`\`
 
@@ -511,6 +620,7 @@ curl -X POST "<draftEndpoint>" \\
   -F "name=<human-friendly app name>" \\
   -F "description=<one line about the app>" \\
   -F "deploymentId=<unique id per upload, e.g. a timestamp>" \\
+  -F "kitVersion=<the kitVersion from pln-app.config.json>" \\
   -F 'requiredEnvVars=["OPENAI_API_KEY","SUPABASE_URL"]' \\
   -F "file=@app.zip;type=application/zip"
 # → { "status": "DRAFT", "appPageUrl": "https://…/pl-infra/ai-apps/<uid>", "missingEnvVars": [ … ] }
@@ -574,7 +684,9 @@ verification steps. Only re-deploy if it stays unreachable.
         connectEndpoint: AI_APPS_CONNECT_ENDPOINT,
         deployEndpoint: AI_APPS_DEPLOY_ENDPOINT,
         draftEndpoint: AI_APPS_DRAFT_ENDPOINT,
+        memberContextEndpoint: AI_APPS_ME_ENDPOINT,
         deployTokenHeader: AI_APP_TOKEN_HEADER,
+        kitVersion: AI_APPS_STARTER_KIT_VERSION,
         appId: '',
         notes:
           'No token is stored here. At deploy time the agent runs the LabOS connect flow (see .claude/skills/deploy-to-labs) to get a short-lived deploy token. Set appId to a stable lowercase slug on first deploy and reuse it. If the app needs runtime secrets, register it via draftEndpoint instead of deploying (see the deploy skill).',

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.spec.ts
@@ -1,0 +1,61 @@
+import AdmZip from 'adm-zip';
+
+import { AiAppsStarterKitService } from './ai-apps-starter-kit.service';
+import { AI_APPS_STARTER_KIT_VERSION } from './ai-apps.constants';
+
+describe('AiAppsStarterKitService buildZip', () => {
+  let entries: Map<string, string>;
+
+  beforeAll(() => {
+    const zip = new AdmZip(new AiAppsStarterKitService().buildZip());
+    entries = new Map(
+      zip
+        .getEntries()
+        .filter((e) => !e.isDirectory)
+        .map((e) => [e.entryName, e.getData().toString('utf8')])
+    );
+  });
+
+  it('ships the agent-facing instruction files and skills', () => {
+    for (const path of [
+      'README.md',
+      'CLAUDE.md',
+      'AGENTS.md',
+      '.claude/skills/deploy-to-labs/SKILL.md',
+      '.claude/skills/pl-design-system/SKILL.md',
+      '.claude/skills/pln-member-context/SKILL.md',
+      'pln-app.config.json',
+    ]) {
+      expect(entries.has(path)).toBe(true);
+    }
+  });
+
+  it('writes the member-context endpoint into the config (and still no token)', () => {
+    const config = JSON.parse(entries.get('pln-app.config.json') as string);
+    expect(config.memberContextEndpoint).toContain('/v1/ai-apps/me');
+    expect(JSON.stringify(config)).not.toContain('plndeploy_');
+  });
+
+  it('stamps the kit version into the config and tells the agent to send it on uploads', () => {
+    const config = JSON.parse(entries.get('pln-app.config.json') as string);
+    expect(config.kitVersion).toBe(AI_APPS_STARTER_KIT_VERSION);
+    const deploySkill = entries.get('.claude/skills/deploy-to-labs/SKILL.md') as string;
+    expect(deploySkill).toContain('kitVersion=');
+  });
+
+  it('points the agent at the member-context skill from CLAUDE.md/AGENTS.md', () => {
+    for (const path of ['CLAUDE.md', 'AGENTS.md']) {
+      const content = entries.get(path) as string;
+      expect(content).toContain('pln-member-context');
+      expect(content).toContain("credentials: 'include'");
+    }
+  });
+
+  it('documents the response shape and signed-out handling in the skill', () => {
+    const skill = entries.get('.claude/skills/pln-member-context/SKILL.md') as string;
+    expect(skill).toContain('/v1/ai-apps/me');
+    expect(skill).toContain("credentials: 'include'");
+    expect(skill).toContain('signed-out');
+    expect(skill).toContain('"teams"');
+  });
+});

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.spec.ts
@@ -36,11 +36,13 @@ describe('AiAppsStarterKitService buildZip', () => {
     expect(JSON.stringify(config)).not.toContain('plndeploy_');
   });
 
-  it('stamps the kit version into the config and tells the agent to send it on uploads', () => {
+  it('stamps the kit version into the config and tells the agent to send upload metadata', () => {
     const config = JSON.parse(entries.get('pln-app.config.json') as string);
     expect(config.kitVersion).toBe(AI_APPS_STARTER_KIT_VERSION);
     const deploySkill = entries.get('.claude/skills/deploy-to-labs/SKILL.md') as string;
     expect(deploySkill).toContain('kitVersion=');
+    expect(deploySkill).toContain('agentModel=');
+    expect(deploySkill).toContain('clientName');
   });
 
   it('points the agent at the member-context skill from CLAUDE.md/AGENTS.md', () => {

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -11,7 +11,7 @@
  */
 
 /** Starter kit version shown in the README, ZIP filename, and LabOS UI. Bump when the kit contents or flow change. */
-export const AI_APPS_STARTER_KIT_VERSION = '1.3';
+export const AI_APPS_STARTER_KIT_VERSION = '1.4';
 
 /** Header the AI agent sends with its short-lived deploy token. */
 export const AI_APP_TOKEN_HEADER = 'x-app-token';
@@ -112,6 +112,13 @@ export const AI_APPS_CONNECT_ENDPOINT =
  * secrets), written into the starter kit.
  */
 export const AI_APPS_DRAFT_ENDPOINT = process.env.AI_APPS_DRAFT_ENDPOINT || `${AI_APPS_BASE_URL}/v1/ai-apps/draft`;
+
+/**
+ * Public URL of THIS API's member-context endpoint (`GET /v1/ai-apps/me`),
+ * written into the starter kit so deployed apps know where to fetch the
+ * signed-in member's identity from.
+ */
+export const AI_APPS_ME_ENDPOINT = process.env.AI_APPS_ME_ENDPOINT || `${AI_APPS_BASE_URL}/v1/ai-apps/me`;
 
 /**
  * Base URL of the LabOS portal that hosts the connect page the member opens to

--- a/apps/web-api/src/ai-apps/ai-apps.controller.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.controller.ts
@@ -20,6 +20,7 @@ import { ZodValidationPipe } from '@abitia/zod-dto';
 import { Response } from 'express';
 import { NoCache } from '../decorators/no-cache.decorator';
 import { UserTokenCheckGuard } from '../guards/user-token-check.guard';
+import { UserAccessTokenValidateGuard } from '../guards/user-access-token-validate.guard';
 import { RequirePermissions } from '../rbac/rbac.decorator';
 import { RbacGuard } from '../rbac/rbac.guard';
 import { RbacService } from '../rbac/rbac.service';
@@ -114,6 +115,24 @@ export class AiAppsController {
   @RequirePermissions(READ)
   async listEvents(@Query('appUid') appUid?: string, @Query('limit') limit?: string) {
     return this.aiAppsService.listEvents(appUid, limit ? Number(limit) : undefined);
+  }
+
+  /**
+   * Identity of the signed-in member ("member context"), consumed by deployed
+   * AI apps for personalization. Unlike the other dashboard reads, the guard
+   * here also accepts the LabOS `authToken` cookie — it is scoped to the parent
+   * domain, so it rides along on same-site requests from `<appId>.<domain>` and
+   * an app can simply `fetch(meEndpoint, { credentials: 'include' })`. Guests
+   * get 401 (no token), members without AI Apps access get 403. Declared before
+   * `:uid` so the literal path wins.
+   */
+  @NoCache()
+  @Get('me')
+  @UseGuards(UserAccessTokenValidateGuard, RbacGuard)
+  @RequirePermissions(READ)
+  async getMemberContext(@Req() req: any) {
+    const memberUid = await this.resolveMemberUid(req);
+    return this.aiAppsService.getMemberContext(memberUid);
   }
 
   /** Single AI App detail (includes `canManage` for the requesting member). */

--- a/apps/web-api/src/ai-apps/ai-apps.controller.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.controller.ts
@@ -238,7 +238,7 @@ export class AiAppsController {
   @UseInterceptors(FileInterceptor('file', { limits: { fileSize: AI_APPS_MAX_ZIP_BYTES } }))
   @UsePipes(ZodValidationPipe)
   async deploy(@Req() req: any, @Body() body: DeployAppDto, @UploadedFile() file: Express.Multer.File) {
-    return this.aiAppsService.deploy(req.aiAppMemberUid, body, file);
+    return this.aiAppsService.deploy(req.aiAppMemberUid, body, file, req.aiAppClientName);
   }
 
   /**
@@ -254,7 +254,7 @@ export class AiAppsController {
   @UseInterceptors(FileInterceptor('file', { limits: { fileSize: AI_APPS_MAX_ZIP_BYTES } }))
   @UsePipes(ZodValidationPipe)
   async registerDraft(@Req() req: any, @Body() body: RegisterDraftDto, @UploadedFile() file: Express.Multer.File) {
-    return this.aiAppsService.registerDraft(req.aiAppMemberUid, body, file);
+    return this.aiAppsService.registerDraft(req.aiAppMemberUid, body, file, req.aiAppClientName);
   }
 
   /**

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -302,7 +302,12 @@ export class AiAppsService {
    * the deploy to the sandbox runner (keeping AWS creds + the runner token
    * server-side) and stores the result.
    */
-  async deploy(memberUid: string, dto: DeployAppDto, file: Express.Multer.File): Promise<WithMember<AiApp>> {
+  async deploy(
+    memberUid: string,
+    dto: DeployAppDto,
+    file: Express.Multer.File,
+    agentClient?: string | null
+  ): Promise<WithMember<AiApp>> {
     if (!file?.buffer?.length) {
       throw new BadGatewayException('Missing app ZIP file');
     }
@@ -330,6 +335,8 @@ export class AiAppsService {
         httpUrl,
         host,
         kitVersion: dto.kitVersion ?? null,
+        agentClient: agentClient ?? null,
+        agentModel: dto.agentModel ?? null,
       },
       update: {
         name: dto.name,
@@ -340,9 +347,11 @@ export class AiAppsService {
         url,
         httpUrl,
         host,
-        // Reflects the kit behind the LAST upload — cleared when an older kit
-        // (which sends nothing) redeploys, so it never claims a newer version.
+        // Upload metadata reflects the LAST upload — cleared when a client
+        // that sends nothing (older kit) redeploys, so it never goes stale.
         kitVersion: dto.kitVersion ?? null,
+        agentClient: agentClient ?? null,
+        agentModel: dto.agentModel ?? null,
         notes: null,
       },
     });
@@ -376,7 +385,8 @@ export class AiAppsService {
   async registerDraft(
     memberUid: string,
     dto: RegisterDraftDto,
-    file: Express.Multer.File
+    file: Express.Multer.File,
+    agentClient?: string | null
   ): Promise<WithMember<AiApp> & { appPageUrl: string; missingEnvVars: string[] }> {
     if (!file?.buffer?.length) {
       throw new BadRequestException('Missing app ZIP file');
@@ -411,6 +421,8 @@ export class AiAppsService {
         s3Key,
         requiredEnvVars: dto.requiredEnvVars,
         kitVersion: dto.kitVersion ?? null,
+        agentClient: agentClient ?? null,
+        agentModel: dto.agentModel ?? null,
       },
       update: {
         name: dto.name,
@@ -420,6 +432,8 @@ export class AiAppsService {
         s3Key,
         requiredEnvVars: dto.requiredEnvVars,
         kitVersion: dto.kitVersion ?? null,
+        agentClient: agentClient ?? null,
+        agentModel: dto.agentModel ?? null,
         notes: null,
       },
     });

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -22,6 +22,7 @@ import {
   AI_APPS_RUNNER_TOKEN,
   AI_APPS_RUNNER_URL,
   AI_APPS_S3_BUCKET,
+  AI_APPS_STARTER_KIT_VERSION,
   buildAppHost,
   buildAppHttpUrl,
   buildAppPageUrl,
@@ -69,6 +70,55 @@ export class AiAppsService {
       ...(rest as Omit<T, 'memberUid'>),
       member: byUid.get(memberUid) ?? null,
     }));
+  }
+
+  /**
+   * Public identity of the signed-in member, served to deployed AI apps for
+   * personalization ("member context"). Returns curated public directory
+   * fields only — this is the extension point if apps may read more PLN data
+   * later (add fields/sections here rather than exposing internal endpoints).
+   */
+  async getMemberContext(memberUid: string) {
+    const member = await this.prisma.member.findUnique({
+      where: { uid: memberUid },
+      select: {
+        uid: true,
+        name: true,
+        email: true,
+        officeHours: true,
+        image: { select: { url: true } },
+        location: { select: { city: true, country: true, continent: true } },
+        skills: { select: { title: true }, orderBy: { title: 'asc' } },
+        teamMemberRoles: {
+          select: {
+            role: true,
+            mainTeam: true,
+            teamLead: true,
+            team: { select: { uid: true, name: true } },
+          },
+          orderBy: { mainTeam: 'desc' },
+        },
+      },
+    });
+    if (!member) {
+      throw new NotFoundException(`Member not found: ${memberUid}`);
+    }
+    const { image, location, skills, teamMemberRoles, ...identity } = member;
+    return {
+      member: {
+        ...identity,
+        image: image?.url ?? null,
+        location: location ?? null,
+        skills: skills.map((skill) => skill.title),
+        teams: teamMemberRoles.map((tmr) => ({
+          uid: tmr.team.uid,
+          name: tmr.team.name,
+          role: tmr.role,
+          mainTeam: tmr.mainTeam,
+          teamLead: tmr.teamLead,
+        })),
+      },
+    };
   }
 
   /** Dashboard list — all non-deleted apps across PL Infra users, newest first, with owner info. */
@@ -157,7 +207,9 @@ export class AiAppsService {
       data: { status: 'ERROR', notes: message },
     });
     if (count > 0) {
-      this.logger.warn(`AI App deploy stuck for ${app.appId} (deploymentId=${app.deploymentId ?? 'n/a'}) — marked ERROR`);
+      this.logger.warn(
+        `AI App deploy stuck for ${app.appId} (deploymentId=${app.deploymentId ?? 'n/a'}) — marked ERROR`
+      );
       await this.recordEvent('DEPLOY_FAILED', app.memberUid, {
         appUid: app.uid,
         appId: app.appId,
@@ -184,9 +236,9 @@ export class AiAppsService {
     }
   }
 
-  /** Logs that a member downloaded the starter kit. */
+  /** Logs that a member downloaded the starter kit (and which version). */
   async logKitDownloaded(memberUid: string): Promise<void> {
-    await this.recordEvent('KIT_DOWNLOADED', memberUid);
+    await this.recordEvent('KIT_DOWNLOADED', memberUid, { message: `Starter kit v${AI_APPS_STARTER_KIT_VERSION}` });
   }
 
   /** Event log (audit feed) — newest first, optionally scoped to one app. */
@@ -277,6 +329,7 @@ export class AiAppsService {
         url,
         httpUrl,
         host,
+        kitVersion: dto.kitVersion ?? null,
       },
       update: {
         name: dto.name,
@@ -287,6 +340,9 @@ export class AiAppsService {
         url,
         httpUrl,
         host,
+        // Reflects the kit behind the LAST upload — cleared when an older kit
+        // (which sends nothing) redeploys, so it never claims a newer version.
+        kitVersion: dto.kitVersion ?? null,
         notes: null,
       },
     });
@@ -354,6 +410,7 @@ export class AiAppsService {
         deploymentId: dto.deploymentId,
         s3Key,
         requiredEnvVars: dto.requiredEnvVars,
+        kitVersion: dto.kitVersion ?? null,
       },
       update: {
         name: dto.name,
@@ -362,6 +419,7 @@ export class AiAppsService {
         deploymentId: dto.deploymentId,
         s3Key,
         requiredEnvVars: dto.requiredEnvVars,
+        kitVersion: dto.kitVersion ?? null,
         notes: null,
       },
     });

--- a/apps/web-api/src/ai-apps/dto/deploy-app.dto.ts
+++ b/apps/web-api/src/ai-apps/dto/deploy-app.dto.ts
@@ -30,6 +30,12 @@ export const DeployAppSchema = z.object({
     .max(20)
     .regex(/^\d+(\.\d+){0,2}$/, 'kitVersion must look like 1.4 or 1.4.1')
     .optional(),
+  /**
+   * Model the agent reports running on (e.g. "claude-sonnet-4-5", "gpt-5").
+   * Free-form, self-reported, optional — stored for debugging. The agent's
+   * TOOL name isn't sent here; it comes from the connect session's clientName.
+   */
+  agentModel: z.string().trim().min(1).max(100).optional(),
 });
 
 export class DeployAppDto extends createZodDto(DeployAppSchema) {}

--- a/apps/web-api/src/ai-apps/dto/deploy-app.dto.ts
+++ b/apps/web-api/src/ai-apps/dto/deploy-app.dto.ts
@@ -20,6 +20,16 @@ export const DeployAppSchema = z.object({
     .min(1)
     .max(100)
     .regex(/^[a-zA-Z0-9][a-zA-Z0-9-]*$/, 'deploymentId must be alphanumeric and hyphens'),
+  /**
+   * Starter-kit version the agent deployed with (from `pln-app.config.json`,
+   * sent by kits ≥1.4). Optional so older kits keep working; stored on the app
+   * for debugging.
+   */
+  kitVersion: z
+    .string()
+    .max(20)
+    .regex(/^\d+(\.\d+){0,2}$/, 'kitVersion must look like 1.4 or 1.4.1')
+    .optional(),
 });
 
 export class DeployAppDto extends createZodDto(DeployAppSchema) {}

--- a/apps/web-api/src/ai-apps/guards/ai-app-token.guard.ts
+++ b/apps/web-api/src/ai-apps/guards/ai-app-token.guard.ts
@@ -7,7 +7,8 @@ import { AI_APP_TOKEN_HEADER } from '../ai-apps.constants';
  * the `x-app-token` header) that was minted when the member approved a connect
  * session. The token must belong to an APPROVED session and be unexpired. On
  * success it stamps the session's member uid onto the request as
- * `aiAppMemberUid`.
+ * `aiAppMemberUid`, plus the session's self-reported `clientName` as
+ * `aiAppClientName` (stored on the app for debugging).
  */
 @Injectable()
 export class AiAppTokenGuard implements CanActivate {
@@ -30,6 +31,7 @@ export class AiAppTokenGuard implements CanActivate {
     }
 
     req.aiAppMemberUid = session.memberUid;
+    req.aiAppClientName = session.clientName;
     await this.prisma.aiAppConnectSession.update({
       where: { uid: session.uid },
       data: { lastUsedAt: new Date() },

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -122,6 +122,8 @@ curl -X POST "$AI_APPS_DEPLOY_ENDPOINT" \
 
 `kitVersion` is optional (kits ≥1.4 send the value from their `pln-app.config.json`) and is stored on the app so we know which kit produced the last upload — older kits send nothing and the column goes/stays null. The same field exists on `POST /v1/ai-apps/draft`, and the `KIT_DOWNLOADED` audit event records the downloaded version in `message`.
 
+Two more debugging columns describe the agent behind the last upload, both self-reported: `agentClient` is copied **server-side** from the connect session's `clientName` (the deploy token is bound to the session, so no extra field is needed — the kit now tells agents to send their real tool name instead of a hardcoded "Claude Code"), and `agentModel` is an optional free-form multipart field (e.g. `claude-sonnet-4-5`) the kit tells the agent to include when it knows its model. Like `kitVersion`, they reflect the LAST upload and are cleared when a client sends nothing.
+
 The backend uploads the ZIP to `s3://<AI_APPS_S3_BUCKET>/apps/<appId>/<deploymentId>/app.zip`, then calls the runner with that `s3Key`. Response is the stored `AiApp` record (status `READY` with `url`/`host`/`port`, or `ERROR` with `notes`).
 
 **Deterministic URL:** the sandbox host is always `<appId>.<AI_APPS_APP_DOMAIN>` (env-configurable: `dev.plnetwork.io` on Dev, `prod.plnetwork.io` on Prod), so `url`/`httpUrl`/`host` are computed from `appId` and stored on the record **at deploy start** (status `DEPLOYING`) — the link exists before the runner finishes. For `appId` `test-hello-01` on Prod the URL is `https://test-hello-01.prod.plnetwork.io`.
@@ -233,6 +235,8 @@ model AiApp {
   requiredEnvVars String[]     // env var NAMES the agent declared (draft flow)
   providedEnvVars String[]     // NAMES the member gave values for — values live only on the runner
   kitVersion   String?         // starter-kit version behind the last agent upload (null = pre-1.4 kit)
+  agentClient  String?         // AI tool from the connect session's clientName (e.g. "Claude Code")
+  agentModel   String?         // model the agent reported for the last upload (self-reported)
   @@unique([memberUid, appId])
 }
 
@@ -372,7 +376,7 @@ S3 uploads reuse the shared `AwsService`, so the standard `AWS_REGION` / `AWS_AC
 - `apps/web-api/prisma/migrations/20260625120000_ai_apps_delete/` — `DELETING`/`DELETED` + delete event enum values.
 - `apps/web-api/prisma/migrations/20260630120000_ai_apps_connect/` — connect session table + connect event values; drops `AiAppToken`.
 - `apps/web-api/prisma/migrations/20260707120000_ai_apps_draft_secrets/` — `DRAFT` status, `s3Key`/`requiredEnvVars`/`providedEnvVars`, draft/secrets event values.
-- `apps/web-api/prisma/migrations/20260714120000_ai_apps_kit_version/` — `kitVersion` column (starter-kit version behind the last agent upload).
+- `apps/web-api/prisma/migrations/20260714120000_ai_apps_upload_meta/` — `kitVersion`/`agentClient`/`agentModel` columns (self-reported metadata about the last agent upload).
 - LabOS UI (`pln-directory-portal-v2`): `app/pl-infra/ai-apps/connect/page.tsx` + `components/page/ai-apps/AiAppsConnectPage/` — the approval page; connect calls in `services/ai-apps/ai-apps.service.ts`.
 - `.claude/skills/ai-apps/SKILL.md` — agent guidance for working on this feature.
 

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -89,6 +89,7 @@ The `deployToken` is held in agent memory only and never written into the kit, s
 |--------|-----------------------------------|------------------------------|-------------------|---------|
 | GET    | `/v1/ai-apps`                     | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | List apps with owner + status (excludes `DELETED`) |
 | GET    | `/v1/ai-apps/events`             | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Event log (audit feed); `?appUid=` to scope, `?limit=` (default 100, max 500) |
+| GET    | `/v1/ai-apps/me`                 | `UserAccessTokenValidateGuard`+`RbacGuard` (Bearer **or** `authToken` cookie) | `ai_apps.read`/`write` | Member context for deployed apps: the signed-in member's public identity (see below) |
 | GET    | `/v1/ai-apps/:uid`               | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Single app detail |
 | GET    | `/v1/ai-apps/:uid/events`        | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Full event/status history for one app (404 if app missing) |
 | GET    | `/v1/ai-apps/:uid/live`          | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Liveness probe: one server-side reachability check of the app URL → `{ live }`; gateway timeouts AND 404 count as down (the ingress 404s until a first deploy's route is ready). The LabOS detail page polls it so the iframe never shows a raw gateway/404 error |
@@ -115,8 +116,11 @@ curl -X POST "$AI_APPS_DEPLOY_ENDPOINT" \
   -F "name=My Leaderboard" \
   -F "description=A small leaderboard demo" \
   -F "deploymentId=deploy-1718900000" \
+  -F "kitVersion=1.4" \
   -F "file=@app.zip;type=application/zip"
 ```
+
+`kitVersion` is optional (kits ≥1.4 send the value from their `pln-app.config.json`) and is stored on the app so we know which kit produced the last upload — older kits send nothing and the column goes/stays null. The same field exists on `POST /v1/ai-apps/draft`, and the `KIT_DOWNLOADED` audit event records the downloaded version in `message`.
 
 The backend uploads the ZIP to `s3://<AI_APPS_S3_BUCKET>/apps/<appId>/<deploymentId>/app.zip`, then calls the runner with that `s3Key`. Response is the stored `AiApp` record (status `READY` with `url`/`host`/`port`, or `ERROR` with `notes`).
 
@@ -169,6 +173,47 @@ Header: x-runner-token: <server secret>
 
 Flow: set status `DELETING` + log `DELETE_STARTED` → call the runner → on success clear hosting fields, set status `DELETED`, log `DELETE_SUCCEEDED`; on failure set status `ERROR` (with `notes`), log `DELETE_FAILED`, and return `502`. The `AiApp` row is **kept** (status flips to `DELETED`) so the audit trail and event history survive. Response is the updated `AiApp` record.
 
+## Member context (signed-in user → deployed app)
+
+Deployed apps can personalize for the member using them (greet by name, tag
+feedback, adapt behavior). `GET /v1/ai-apps/me` returns the signed-in member's
+**public** directory identity:
+
+```json
+{
+  "member": {
+    "uid": "…", "name": "Ada Lovelace", "email": "ada@example.com",
+    "image": "https://…/ada.png", "officeHours": null,
+    "location": { "city": "London", "country": "United Kingdom", "continent": "Europe" },
+    "skills": ["Engineering"],
+    "teams": [{ "uid": "…", "name": "Protocol Labs", "role": "Engineer", "mainTeam": true, "teamLead": false }]
+  }
+}
+```
+
+How it works — no app-side login and no new token flow:
+
+- LabOS writes the login cookies (`authToken` etc.) with `domain=COOKIE_DOMAIN`,
+  a **parent** domain (e.g. `.plnetwork.io`), so they are sent on same-site
+  requests from a deployed app at `<appId>.<AI_APPS_APP_DOMAIN>` to this API.
+  The app's browser code just calls `fetch(meEndpoint, { credentials: 'include' })`.
+- Unlike the other dashboard endpoints, `/me` uses `UserAccessTokenValidateGuard`,
+  which accepts the token from the `Authorization: Bearer` header **or** the
+  `authToken` cookie (`extractTokenFromRequest`), then introspects it against the
+  auth service. `RbacGuard` enforces `ai_apps.read`.
+- Access outcomes: guest/signed-out → `401` (no token); signed-in member without
+  AI Apps access → `403`; otherwise the curated profile above. The kit instructs
+  apps to treat any non-200 as "not signed in" and keep working un-personalized.
+- CORS already covers app origins with credentials (the dev list matches
+  `*.dev.plnetwork.io`, the prod list `*.plnetwork.io`).
+- The response is assembled in `AiAppsService.getMemberContext` from curated
+  public fields only — extend **there** if apps may read more PLN data later
+  (the "light MCP" extension point); never point apps at internal endpoints.
+- The kit's `pln-app.config.json` carries the URL as `memberContextEndpoint`,
+  and `.claude/skills/pln-member-context/SKILL.md` tells the agent how to use it
+  (client-side fetch, handle 401/403/local-dev gracefully, personalization only —
+  never auth for sensitive actions, never store/log tokens).
+
 ## Data model
 
 ```prisma
@@ -187,6 +232,7 @@ model AiApp {
   s3Key        String?         // last uploaded bundle (lets a member redeploy a draft)
   requiredEnvVars String[]     // env var NAMES the agent declared (draft flow)
   providedEnvVars String[]     // NAMES the member gave values for — values live only on the runner
+  kitVersion   String?         // starter-kit version behind the last agent upload (null = pre-1.4 kit)
   @@unique([memberUid, appId])
 }
 
@@ -260,14 +306,15 @@ README.md                                      human quick-start
 CLAUDE.md / AGENTS.md                          agent build + deploy instructions
 .claude/skills/deploy-to-labs/SKILL.md         deploy skill (incl. connect flow)
 .claude/skills/pl-design-system/SKILL.md       single UI skill (components + tokens)
-pln-app.config.json                            connect + deploy endpoints (+ appId) — NO token
+.claude/skills/pln-member-context/SKILL.md     how the app gets the signed-in member's identity
+pln-app.config.json                            connect + deploy + member-context endpoints (+ appId) — NO token
 pl-design-system/                              curated PL Design System (files, not a nested zip)
 styles/pln-theme.css                           minimal CSS-variable fallback (plain-HTML apps)
 styles/FONTS.md                                Inter font guidance
 app/                                           minimal runnable Node/Express scaffold
 ```
 
-The kit deliberately exposes **no internal PLN APIs** — only the connect and deploy endpoints — and **no token**.
+The kit deliberately exposes **no internal PLN APIs** — only the connect, deploy, and member-context endpoints — and **no token**.
 
 ### Bundled PL Design System
 
@@ -308,8 +355,8 @@ The agent loads `.claude/skills/pl-design-system` for UI work and follows
 | `AI_APPS_RUNNER_TOKEN` | _(empty)_ | **Required** for real deploys; `x-runner-token` to the runner |
 | `AI_APPS_S3_BUCKET` | _(empty)_ | **Required** for real deploys; bucket the runner reads app bundles from (e.g. `sandbox-apps-pln-dev-013228333448`) |
 | `AI_APPS_APP_DOMAIN` | `prod.plnetwork.io` | Base domain deployed apps are served under (app URL = `https://<appId>.<domain>`); set `dev.plnetwork.io` on Dev, `prod.plnetwork.io` on Prod |
-| `AI_APPS_BASE_URL` | `https://api.plnetwork.io` | Public base URL of this API; the agent-facing endpoint URLs written into the kit (deploy/connect/draft) are derived from it as `<base>/v1/ai-apps/<endpoint>` |
-| `AI_APPS_DEPLOY_ENDPOINT` / `AI_APPS_CONNECT_ENDPOINT` / `AI_APPS_DRAFT_ENDPOINT` | _derived from `AI_APPS_BASE_URL`_ | Optional per-endpoint overrides; rarely needed |
+| `AI_APPS_BASE_URL` | `https://api.plnetwork.io` | Public base URL of this API; the agent-facing endpoint URLs written into the kit (deploy/connect/draft/member context) are derived from it as `<base>/v1/ai-apps/<endpoint>` |
+| `AI_APPS_DEPLOY_ENDPOINT` / `AI_APPS_CONNECT_ENDPOINT` / `AI_APPS_DRAFT_ENDPOINT` / `AI_APPS_ME_ENDPOINT` | _derived from `AI_APPS_BASE_URL`_ | Optional per-endpoint overrides; rarely needed |
 | `AI_APPS_PORTAL_URL` | `https://directory.plnetwork.io` | Base URL of the LabOS portal hosting the connect/approval page (used to build `connectUrl` and `appPageUrl`) |
 | `AI_APPS_RUNNER_PROJECT` | `default` | Project scope of the runner's secrets API (`/v1/projects/<project>/secrets`) |
 | `AI_APPS_RUNNER_ENVIRONMENT` | `prod` | Environment label for the runner secrets/deployments API. **Must match the environment the runner's `/deploy` build registers under** (its helm release is `<environment>-<appId>`; the legacy-compat build path registers as `sandbox`) — a mismatch makes the secrets-injection deploy collide with the build's release |
@@ -325,6 +372,7 @@ S3 uploads reuse the shared `AwsService`, so the standard `AWS_REGION` / `AWS_AC
 - `apps/web-api/prisma/migrations/20260625120000_ai_apps_delete/` — `DELETING`/`DELETED` + delete event enum values.
 - `apps/web-api/prisma/migrations/20260630120000_ai_apps_connect/` — connect session table + connect event values; drops `AiAppToken`.
 - `apps/web-api/prisma/migrations/20260707120000_ai_apps_draft_secrets/` — `DRAFT` status, `s3Key`/`requiredEnvVars`/`providedEnvVars`, draft/secrets event values.
+- `apps/web-api/prisma/migrations/20260714120000_ai_apps_kit_version/` — `kitVersion` column (starter-kit version behind the last agent upload).
 - LabOS UI (`pln-directory-portal-v2`): `app/pl-infra/ai-apps/connect/page.tsx` + `components/page/ai-apps/AiAppsConnectPage/` — the approval page; connect calls in `services/ai-apps/ai-apps.service.ts`.
 - `.claude/skills/ai-apps/SKILL.md` — agent guidance for working on this feature.
 


### PR DESCRIPTION
## Summary

Deployed AI apps can now identify the signed-in PLN member using them, so they can personalize behavior and tag feedback.
A new endpoint returns the current member's public directory identity: name, email, photo, teams with roles, skills, location, and office hours.
It accepts the LabOS session cookie or a Bearer token, so an app fetches it from browser code with credentials included — no app-side login is needed.
Guests get 401, signed-in members without AI Apps access get 403, and apps are instructed to keep working un-personalized in both cases.
The starter kit was bumped to v1.4: `pln-app.config.json` now carries the member-context endpoint, and a new `pln-member-context` skill plus README/CLAUDE.md/AGENTS.md sections explain how apps fetch and use the identity safely (personalization only, graceful signed-out handling, never store or forward tokens).
The LabOS UI (portal-v2 repo) version labels were bumped to v1.4 to match.
Upload metadata is now tracked for debugging: each app stores which kit version produced its last upload, which AI tool ran the connect session (copied server-side from the session's clientName), and which model the agent reported running on.
The kit sends the version and model automatically on deploy and draft registration, tells agents to report their real tool name at connect time, and the kit-download audit event records the downloaded version.
Apps uploaded by older kits show no metadata (null), since those kits don't send the fields.
The kit's agent instructions now explicitly tell non-Claude tools (Codex, Cursor, etc.) to read the skill markdown files directly, since only Claude Code auto-discovers .claude/skills.
Feature docs and the project skill were updated, and tests cover the identity shape, access wiring, kit contents, and version tracking.

## New endpoint

```bash
curl -s "https://<api-host>/v1/ai-apps/me" \
  -H "Authorization: Bearer <member-access-token>"
```

From a deployed app's browser code the same endpoint is called cookie-authenticated: `fetch('https://<api-host>/v1/ai-apps/me', { credentials: 'include' })`.

## Tickets

[LAB-2114](https://linear.app/plrs-labos/issue/LAB-2114/ai-apps-pass-logged-in-user-context-into-ai-apps)
