### PR TITLE
feat: add teams list to completed demo day response

### DIFF
--- a/apps/web-api/src/demo-days/DEMO_DAYS_API.md
+++ b/apps/web-api/src/demo-days/DEMO_DAYS_API.md
@@ -87,6 +87,51 @@ curl -X GET https://api.example.com/v1/demo-days
 
 ---
 
+### Get Demo Day by UID or Slug
+
+**Endpoint:** `GET /v1/demo-days/:demoDayUidOrSlug`
+
+**Access:** Public (optional auth via Bearer token)
+
+**Description:** Get demo day information and the caller's access level. For **COMPLETED** demo days, also returns a public `teams` list of participating teams (L0 / non-public teams excluded). For non-completed demo days, `teams` is an empty array.
+
+**Example:**
+```bash
+curl -X GET https://api.example.com/v1/demo-days/demo-day-2025 \
+  -H "Authorization: Bearer <token>"
+```
+
+**Response (Completed, guest or authenticated):**
+```json
+{
+  "access": "none",
+  "status": "COMPLETED",
+  "uid": "dd_123456",
+  "slugURL": "demo-day-2025",
+  "date": "2025-03-15T10:00:00Z",
+  "title": "Demo Day 2025",
+  "description": "Annual startup showcase",
+  "teamsCount": 2,
+  "investorsCount": 150,
+  "teams": [
+    {
+      "uid": "team_abc",
+      "name": "Example Team",
+      "shortDescription": "Building the future",
+      "logoUrl": "https://example.com/logo.png",
+      "isFollowing": false,
+      "newsCount": 3
+    }
+  ]
+}
+```
+
+- `isFollowing` is `true` only when the request is authenticated and the member follows that team; otherwise `false`.
+- `newsCount` is the number of `TeamNewsItem` rows for the team.
+- `teamsCount` matches `teams.length` for completed demo days.
+
+---
+
 ### Get Current Demo Day
 
 **Endpoint:** `GET /v1/demo-days/current`

--- a/apps/web-api/src/demo-days/demo-days.module.ts
+++ b/apps/web-api/src/demo-days/demo-days.module.ts
@@ -17,6 +17,7 @@ import { DemoDayNotificationsJob } from './demo-day-notifications.job';
 import { TeamEnrichmentModule } from '../team-enrichment/team-enrichment.module';
 import { MemberApprovalsModule } from '../member-approvals/member-approvals.module';
 import { InvestorsModule } from '../investors/investors.module';
+import { FollowsModule } from '../follows/follows.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { InvestorsModule } from '../investors/investors.module';
     forwardRef(() => PushNotificationsModule),
     TeamEnrichmentModule,
     InvestorsModule,
+    FollowsModule,
   ],
   controllers: [DemoDaysController, DemoDaySubscriptionsController],
   providers: [

--- a/apps/web-api/src/demo-days/demo-days.service.ts
+++ b/apps/web-api/src/demo-days/demo-days.service.ts
@@ -30,6 +30,16 @@ import {
 import { MemberWithRoles } from '../utils/constants';
 import { NotificationServiceClient } from '../notifications/notification-service.client';
 import { MemberApprovalsService } from '../member-approvals/member-approvals.service';
+import { FollowsService } from '../follows/follows.service';
+
+type ParticipatingTeam = {
+  uid: string;
+  name: string;
+  shortDescription: string | null;
+  logoUrl: string | null;
+  isFollowing: boolean;
+  newsCount: number;
+};
 
 type ExpressInterestStats = {
   saved: number;
@@ -97,7 +107,8 @@ export class DemoDaysService {
     private readonly membersService: MembersService,
     private readonly pushNotificationsService: PushNotificationsService,
     private readonly notificationServiceClient: NotificationServiceClient,
-    private readonly memberApprovalsService: MemberApprovalsService
+    private readonly memberApprovalsService: MemberApprovalsService,
+    private readonly followsService: FollowsService
   ) {}
 
   /** Resolve member with effectivePermissionCodes from admin JWT (email or memberUid on token). */
@@ -191,6 +202,7 @@ export class DemoDaysService {
     supportEmail?: string | null;
     teamsCount?: number;
     investorsCount?: number;
+    teams: ParticipatingTeam[];
     isDemoDayAdmin?: boolean;
     isDemoDayReadOnlyAdmin?: boolean;
     isEarlyAccess?: boolean;
@@ -211,15 +223,22 @@ export class DemoDaysService {
         status: 'NONE',
         teamsCount: 0,
         investorsCount: 0,
+        teams: [],
         confidentialityAccepted: false,
         isPending: false,
       };
     }
 
-    const [investorsCount, teamsCount] = await Promise.all([
+    const isCompleted = demoDay.status === DemoDayStatus.COMPLETED;
+    const [investorsCount, teamsCount, teams] = await Promise.all([
       this.getQualifiedInvestorsCount(),
-      this.getTeamsCountForDemoDay(demoDay.uid),
+      isCompleted ? Promise.resolve(0) : this.getTeamsCountForDemoDay(demoDay.uid),
+      isCompleted
+        ? this.getParticipatingTeamsForCompletedDemoDay(demoDay.uid, memberEmail)
+        : Promise.resolve([] as ParticipatingTeam[]),
     ]);
+
+    const resolvedTeamsCount = isCompleted ? teams.length : teamsCount;
 
     // Handle unauthorized users
     if (!memberEmail) {
@@ -235,8 +254,9 @@ export class DemoDaysService {
         shortDescription: demoDay.shortDescription,
         approximateStartDate: demoDay.approximateStartDate,
         supportEmail: demoDay.supportEmail,
-        teamsCount: teamsCount,
+        teamsCount: resolvedTeamsCount,
         investorsCount: investorsCount,
+        teams,
         confidentialityAccepted: false,
         isPending: false,
         logoUrl: demoDay.logoUrl ?? null,
@@ -258,6 +278,9 @@ export class DemoDaysService {
         slugURL: demoDay.slugURL,
         status: this.getExternalDemoDayStatus(demoDay.status),
         host: demoDay.host,
+        teamsCount: resolvedTeamsCount,
+        investorsCount,
+        teams,
         isPending: false,
         logoUrl: demoDay.logoUrl ?? null,
         primaryColor: demoDay.primaryColor ?? '#1a45e6',
@@ -303,8 +326,9 @@ export class DemoDaysService {
           isDemoDayReadOnlyAdmin: false,
           confidentialityAccepted: p?.confidentialityAccepted ?? false,
           isPending: p?.status === DemoDayParticipantStatus.PENDING,
-          teamsCount,
+          teamsCount: resolvedTeamsCount,
           investorsCount,
+          teams,
           logoUrl: demoDay.logoUrl ?? null,
           primaryColor: demoDay.primaryColor ?? '#1a45e6',
           landingLogosEnabled: demoDay.landingLogosEnabled ?? true,
@@ -327,8 +351,9 @@ export class DemoDaysService {
         shortDescription: demoDay.shortDescription,
         approximateStartDate: demoDay.approximateStartDate,
         supportEmail: demoDay.supportEmail,
-        teamsCount,
+        teamsCount: resolvedTeamsCount,
         investorsCount,
+        teams,
         confidentialityAccepted: participant?.confidentialityAccepted ?? false,
         isPending: participant?.status === DemoDayParticipantStatus.PENDING,
         logoUrl: demoDay.logoUrl ?? null,
@@ -362,8 +387,9 @@ export class DemoDaysService {
       isDemoDayAdmin: participant.isDemoDayAdmin || hasMemberLevelAdminAccess,
       isDemoDayReadOnlyAdmin: participant.isDemoDayReadOnlyAdmin || false,
       confidentialityAccepted: participant.confidentialityAccepted,
-      teamsCount,
+      teamsCount: resolvedTeamsCount,
       investorsCount,
+      teams,
       isPending: false,
       logoUrl: demoDay.logoUrl ?? null,
       primaryColor: demoDay.primaryColor ?? '#1a45e6',
@@ -1956,6 +1982,7 @@ export class DemoDaysService {
         onePagerUploadUid: { not: null },
         videoUploadUid: { not: null },
         team: {
+          accessLevel: { not: 'L0' },
           demoDayParticipants: {
             some: {
               demoDayUid,
@@ -1967,6 +1994,60 @@ export class DemoDaysService {
         },
       },
     });
+  }
+
+  private async getParticipatingTeamsForCompletedDemoDay(
+    demoDayUid: string,
+    memberEmail: string | null
+  ): Promise<ParticipatingTeam[]> {
+    const profiles = await this.prisma.teamFundraisingProfile.findMany({
+      where: {
+        demoDayUid,
+        status: 'PUBLISHED',
+        onePagerUploadUid: { not: null },
+        videoUploadUid: { not: null },
+        team: {
+          accessLevel: { not: 'L0' },
+          demoDayParticipants: {
+            some: {
+              demoDayUid,
+              isDeleted: false,
+              status: 'ENABLED',
+              type: 'FOUNDER',
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        team: {
+          select: {
+            uid: true,
+            name: true,
+            shortDescription: true,
+            logo: { select: { url: true } },
+            _count: { select: { newsItems: true } },
+          },
+        },
+      },
+    });
+
+    let followedTeamUids = new Set<string>();
+    if (memberEmail) {
+      const member = await this.membersService.findMemberByEmail(memberEmail);
+      if (member) {
+        followedTeamUids = await this.followsService.getFollowedTeamUids(member.uid);
+      }
+    }
+
+    return profiles.map(({ team }) => ({
+      uid: team.uid,
+      name: team.name,
+      shortDescription: team.shortDescription ?? null,
+      logoUrl: team.logo?.url ?? null,
+      isFollowing: followedTeamUids.has(team.uid),
+      newsCount: team._count.newsItems,
+    }));
   }
 
   private async getMemberWithDemoDayParticipants(memberEmail: string, demoDayUid?: string) {


### PR DESCRIPTION
### Endpoint
`GET /v1/demo-days/:demoDayUidOrSlug` (existing; optional auth)

### New field
`teams: Array<{ uid; name; shortDescription; logoUrl; isFollowing; newsCount }>`

- `COMPLETED` → populated list
- otherwise → `teams: []`

### FE notes
1. Extend `DemoDayState` with `teams` (default `[]`)
2. Completed page: use `teams` instead of static JSON; hide if empty
3. Follow via existing APIs + `isFollowing`; signed-out → sign-in (same as home news)
4. No `stage` / `website` on this payload
5. List `GET /v1/demo-days` does not include `teams`