### PR TITLE
LAB-2145 [AI Apps] Starter kit skill: propose name/description, confirm with member, optionally generate and upload PRD

### DIFF
--- a/apps/web-api/src/ai-apps/ai-apps-feedback.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-feedback.spec.ts
@@ -47,9 +47,9 @@ describe('AiAppsService feedback', () => {
 
     it('returns the submitter as `member` instead of raw memberUid', async () => {
       const { service, prisma } = buildService();
-      prisma.member.findMany.mockResolvedValue([{ uid: 'member-1', name: 'Ada' }]);
+      prisma.member.findMany.mockResolvedValue([{ uid: 'member-1', name: 'Ada', image: { url: 'https://…/ada.png' } }]);
       const result = await service.submitFeedback('member-1', 'app-1', 'hi');
-      expect(result.member).toEqual({ uid: 'member-1', name: 'Ada' });
+      expect(result.member).toEqual({ uid: 'member-1', name: 'Ada', image: 'https://…/ada.png' });
       expect(result).not.toHaveProperty('memberUid');
     });
   });
@@ -86,7 +86,7 @@ describe('AiAppsService feedback', () => {
         { uid: 'fb-2', appUid: 'app-1', memberUid: 'member-2', text: 'later', createdAt: new Date(2) },
         { uid: 'fb-1', appUid: 'app-1', memberUid: 'member-1', text: 'earlier', createdAt: new Date(1) },
       ]);
-      prisma.member.findMany.mockResolvedValue([{ uid: 'member-2', name: 'Bea' }]);
+      prisma.member.findMany.mockResolvedValue([{ uid: 'member-2', name: 'Bea', image: null }]);
 
       const result = await service.listFeedback('creator-1', 'app-1');
       expect(prisma.aiAppFeedback.findMany).toHaveBeenCalledWith({
@@ -94,7 +94,8 @@ describe('AiAppsService feedback', () => {
         orderBy: { createdAt: 'desc' },
       });
       expect(result.map((f) => f.text)).toEqual(['later', 'earlier']);
-      expect(result[0].member).toEqual({ uid: 'member-2', name: 'Bea' });
+      // A member without a profile image resolves to image: null.
+      expect(result[0].member).toEqual({ uid: 'member-2', name: 'Bea', image: null });
       // Unknown submitter resolves to null rather than leaking the uid.
       expect(result[1].member).toBeNull();
     });

--- a/apps/web-api/src/ai-apps/ai-apps-member-context.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-member-context.spec.ts
@@ -9,8 +9,6 @@ import { AiAppsService } from './ai-apps.service';
 const MEMBER = {
   uid: 'member-1',
   name: 'Ada Lovelace',
-  email: 'ada@example.com',
-  officeHours: null,
   image: { url: 'https://cdn.example.com/ada.png' },
   location: { city: 'London', country: 'United Kingdom', continent: 'Europe' },
   skills: [{ title: 'Engineering' }, { title: 'Research' }],
@@ -52,8 +50,6 @@ describe('AiAppsService getMemberContext', () => {
       member: {
         uid: 'member-1',
         name: 'Ada Lovelace',
-        email: 'ada@example.com',
-        officeHours: null,
         image: 'https://cdn.example.com/ada.png',
         location: { city: 'London', country: 'United Kingdom', continent: 'Europe' },
         skills: ['Engineering', 'Research'],
@@ -70,8 +66,6 @@ describe('AiAppsService getMemberContext', () => {
     prisma.member.findUnique.mockResolvedValue({
       uid: 'member-2',
       name: 'No Frills',
-      email: null,
-      officeHours: null,
       image: null,
       location: null,
       skills: [],
@@ -81,8 +75,6 @@ describe('AiAppsService getMemberContext', () => {
     expect(result.member).toEqual({
       uid: 'member-2',
       name: 'No Frills',
-      email: null,
-      officeHours: null,
       image: null,
       location: null,
       skills: [],
@@ -95,9 +87,19 @@ describe('AiAppsService getMemberContext', () => {
     await service.getMemberContext('member-1');
     const select = prisma.member.findUnique.mock.calls[0][0].select;
     expect(Object.keys(select).sort()).toEqual(
-      ['email', 'image', 'location', 'name', 'officeHours', 'skills', 'teamMemberRoles', 'uid'].sort()
+      ['image', 'location', 'name', 'skills', 'teamMemberRoles', 'uid'].sort()
     );
     const result = await service.getMemberContext('member-1');
     expect(result.member).not.toHaveProperty('teamMemberRoles');
+  });
+
+  it('never exposes contact info (email, office-hours link)', async () => {
+    const { service, prisma } = buildService();
+    const result = await service.getMemberContext('member-1');
+    const select = prisma.member.findUnique.mock.calls[0][0].select;
+    expect(select).not.toHaveProperty('email');
+    expect(select).not.toHaveProperty('officeHours');
+    expect(result.member).not.toHaveProperty('email');
+    expect(result.member).not.toHaveProperty('officeHours');
   });
 });

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
@@ -238,9 +238,10 @@ code reads it from \`document.cookie\` (URL-decode + strip quotes) and calls the
 \`memberContextEndpoint\` from \`pln-app.config.json\` with
 \`Authorization: Bearer <token>\` — use the exact snippet from the skill, and do
 NOT rely on \`credentials: 'include'\` alone (the cookie may not reach the API
-host). The response carries the member's public profile (uid, name, email,
-image, teams + roles, skills). Bake the endpoint URL into the app's frontend as
-a constant — the config file itself is not shipped inside \`app/\`.
+host). The response carries the member's public profile (uid, name, image,
+teams + roles, skills — deliberately no email or other contact info). Bake the
+endpoint URL into the app's frontend as a constant — the config file itself is
+not shipped inside \`app/\`.
 - Handle the signed-out case gracefully (401/403/local dev): show a friendly
   note and keep the app usable without identity. Never hard-fail on it.
 - Personalization only: never gate sensitive/destructive actions on it, never
@@ -628,9 +629,7 @@ Response shape (\`member\`):
 {
   "uid": "…",
   "name": "Ada Lovelace",
-  "email": "ada@example.com",
   "image": "https://…/profile.png",
-  "officeHours": null,
   "location": { "city": "London", "country": "United Kingdom", "continent": "Europe" },
   "skills": ["Engineering", "Research"],
   "teams": [
@@ -640,7 +639,10 @@ Response shape (\`member\`):
 \`\`\`
 
 Fields may be \`null\`/empty, and new fields may be added over time — ignore
-anything you don't recognize.
+anything you don't recognize. The response deliberately contains **no contact
+info** (no email, no office-hours link) — don't build features that assume a
+way to reach the member, and don't ask them to type contact details in to
+compensate.
 
 ## Rules
 

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
@@ -9,6 +9,7 @@ import {
   AI_APPS_DEPLOY_ENDPOINT,
   AI_APPS_DRAFT_ENDPOINT,
   AI_APPS_ME_ENDPOINT,
+  AI_APPS_METADATA_ENDPOINT,
   AI_APPS_STARTER_KIT_VERSION,
 } from './ai-apps.constants';
 
@@ -35,6 +36,7 @@ export class AiAppsStarterKitService {
     add('CLAUDE.md', this.agentInstructions());
     add('AGENTS.md', this.agentInstructions());
     add('.claude/skills/deploy-to-labs/SKILL.md', this.deploySkill());
+    add('.claude/skills/app-metadata/SKILL.md', this.metadataSkill());
     add('.claude/skills/pl-design-system/SKILL.md', this.designSystemSkill());
     add('.claude/skills/pln-member-context/SKILL.md', this.memberContextSkill());
     add('pln-app.config.json', this.configJson());
@@ -99,6 +101,8 @@ to the Protocol Labs Network sandbox with a single instruction.
 ## What's inside
 - \`CLAUDE.md\` / \`AGENTS.md\` — instructions your AI agent reads automatically.
 - \`.claude/skills/deploy-to-labs/\` — the deploy skill your agent uses.
+- \`.claude/skills/app-metadata/\` — how your agent names/describes your app and
+  adds an optional one-pager PRD (always with your approval).
 - \`.claude/skills/pl-design-system/\` — how to build on-brand UI with the PL Design System.
 - \`.claude/skills/pln-member-context/\` — how your app can know which PLN member is using it.
 - \`pln-app.config.json\` — the LabOS connect + deploy endpoints (no secrets).
@@ -119,11 +123,17 @@ to the Protocol Labs Network sandbox with a single instruction.
    - **Existing app:** copy your project's files into \`app/\`, then say "migrate this
      existing app and deploy it to LabOS". Your agent takes care of whatever setup is
      needed to run it there.
-3. When you're happy, say "deploy this app". The first time you deploy, your agent
-   will give you a LabOS link to open and approve — sign in and click **Approve**
-   to authorize the deploy. Your agent then ships the app to the PLN sandbox; the
-   first deploy can take a minute or two.
+3. When you're happy, say "deploy this app". Before the first deploy your agent
+   suggests a name and short description for your app — approve them or ask for
+   changes. The first time you deploy, your agent will also give you a LabOS
+   link to open and approve — sign in and click **Approve** to authorize the
+   deploy. Your agent then ships the app to the PLN sandbox; the first deploy
+   can take a minute or two.
 4. Your app appears on the PL Infra → AI Apps dashboard, where you can open it.
+   After the first deploy your agent offers an optional **one-pager PRD** — a
+   short product page shown with your app; say yes and approve the draft, or
+   skip it. You can rename your app, edit its description, or change the PRD
+   anytime — just ask your agent; no redeploy needed.
 
 ## Apps that need an API key or password (secrets)
 Some apps need a secret to work — for example an app that talks to ChatGPT/OpenAI,
@@ -308,26 +318,53 @@ The flow (full steps in the deploy skill):
 Never ask the member for secret values in the chat, and never write them to any
 file — LabOS is the only place they should be entered.
 
+## App name, description & one-pager PRD (display metadata)
+Every app has member-facing display metadata on the AI Apps dashboard: a
+**name**, a short **description**, and an optional **one-pager PRD**. The rules
+live in the **app-metadata** skill (\`.claude/skills/app-metadata/SKILL.md\`) —
+load it whenever metadata comes up. In short:
+- **Before the first deploy**: propose a human-friendly name + 1–2 sentence
+  description drawn from what the app does, present them to the member, and
+  **wait for explicit approval** (revise until they approve). Save the approved
+  values to \`appName\`/\`appDescription\` in \`pln-app.config.json\` and use them in
+  the deploy form.
+- **After the first successful deploy**: ask once whether the member wants a
+  one-pager PRD. If yes, generate a concise self-contained HTML one-pager, get
+  their approval, and save it via the \`metadataEndpoint\` — **no new ZIP and no
+  redeploy**. If they decline, carry on without one.
+- **On redeploys**: reuse the saved \`appName\`/\`appDescription\` verbatim and do
+  NOT re-run the propose-and-approve flow (the deploy form overwrites stored
+  metadata, so fresh drafts would revert what the member approved). Only
+  re-propose when the member explicitly asks to change something.
+- **When the member asks to rename / edit the description / change the PRD** of
+  an existing app: same propose → approve → save flow, via \`metadataEndpoint\` —
+  metadata changes never require a redeploy.
+
 ## Deploying the app
 When the member asks you to deploy, use the **deploy-to-labs** skill in
 \`.claude/skills/deploy-to-labs/SKILL.md\`. If the app needs runtime secrets,
 follow "Apps that need secrets" above instead of deploying directly. In short:
-1. Read \`pln-app.config.json\` for the \`connectEndpoint\`, \`deployEndpoint\`, and
-   (if present) a saved \`appId\`.
-2. **Get a deploy token via LabOS (the connect flow).** There is no token in the
+1. Read \`pln-app.config.json\` for the \`connectEndpoint\`, \`deployEndpoint\`,
+   \`metadataEndpoint\`, and (if present) saved \`appId\`, \`appUid\`, \`appName\`, and
+   \`appDescription\`.
+2. **Settle the display metadata** ("App name, description & one-pager PRD"
+   above): first deploy → propose name/description and get the member's
+   approval; redeploy → reuse the saved values without re-asking.
+3. **Get a deploy token via LabOS (the connect flow).** There is no token in the
    kit. POST to \`connectEndpoint\` to start a connect session, give the member the
    returned \`connectUrl\` + confirmation \`userCode\` to open and approve in LabOS,
    then poll until you receive a short-lived \`deployToken\`. Full steps are in the
    deploy skill. Keep the token **in memory only** — never write it to
    \`pln-app.config.json\` or any file.
-3. Choose a stable, lowercase \`appId\` (e.g. \`my-leaderboard\`) and a fresh
+4. Choose a stable, lowercase \`appId\` (e.g. \`my-leaderboard\`) and a fresh
    \`deploymentId\` for each deploy.
-4. Zip the **contents** of \`app/\` (so the \`Dockerfile\` sits at the root of the ZIP),
+5. Zip the **contents** of \`app/\` (so the \`Dockerfile\` sits at the root of the ZIP),
    excluding \`node_modules\`, build output, and any secrets/\`.env\`/data dirs, then
    upload that ZIP to \`deployEndpoint\` as multipart/form-data with the
    \`deployToken\` in the \`${AI_APP_TOKEN_HEADER}\` header. The PLN backend stores it
    and runs the build — you do not need any cloud credentials.
-5. Tell the member the deploy succeeded and that they can open their app from the
+6. Save the \`uid\` from the response as \`appUid\` in \`pln-app.config.json\`, then
+   tell the member the deploy succeeded and that they can open their app from the
    PL Infra → AI Apps dashboard. **Do NOT reveal the deployment URL, host, or port**
    (see "Keep the deployment URL private" in the deploy skill). That privacy rule
    covers only the app's own \`<appId>\` address — LabOS links (\`connectUrl\`,
@@ -343,6 +380,115 @@ run the connect flow again to get a fresh one.
 
 Do not ask for or use any internal PLN APIs — only the connect, deploy, and
 member-context endpoints in the config are available to you.
+`;
+  }
+
+  private metadataSkill(): string {
+    return `---
+name: app-metadata
+description: Set or change the app's display name, short description, and optional one-pager PRD shown on the AI Apps dashboard. Use before the FIRST deploy (no approved name saved yet) and whenever the member asks to rename the app, edit its description, or add/update/remove its PRD. Metadata saves go through their own endpoint — no ZIP upload and no redeploy.
+---
+
+# App name, description & one-pager PRD
+
+The AI Apps dashboard shows each app's **name**, a short **description**, and —
+optionally — a **one-pager PRD** (a small product page). These are member-facing:
+YOU draft them, the MEMBER approves them, and only then do you save them.
+Saving metadata never rebuilds or redeploys the app.
+
+## When to run this flow
+
+- **Before the first deploy** (no \`appName\` saved in \`pln-app.config.json\` yet):
+  do "Propose & approve" below, use the approved values in the deploy form, and
+  offer the one-pager PRD once the deploy succeeds.
+- **The member asks to change** the name, description, or PRD of an existing
+  app: same propose → approve → save flow, via the metadata endpoint.
+- **NOT on ordinary redeploys.** Reuse the approved \`appName\` /
+  \`appDescription\` from \`pln-app.config.json\` **verbatim** in the deploy form
+  and don't re-ask. A deploy overwrites the stored name/description with
+  whatever the form sends, so sending fresh drafts silently reverts metadata the
+  member already approved. The PRD is never touched by deploys — nothing to
+  re-send.
+
+## Propose & approve (name + description)
+
+1. Draft from what the app actually does (its code + the conversation):
+   - **Name** — 2–4 plain, human-friendly words (e.g. "Team Availability
+     Board"), max 200 chars. Not the \`appId\` slug, no version numbers.
+   - **Description** — 1–2 sentences: what it does and who it's for. Keep it
+     well under 2000 chars.
+2. Show both to the member and ask them to approve or revise.
+3. **Wait for explicit approval.** If they want changes, revise and re-present —
+   as many rounds as needed. Never upload a name or description the member has
+   not confirmed.
+4. After approval, write the values into \`pln-app.config.json\` (\`appName\`,
+   \`appDescription\`) so later redeploys reuse them without re-asking.
+
+## Offer the one-pager PRD (optional)
+
+Ask once, in plain words — e.g. *"Want me to add a one-pager PRD? It's a short
+product page (what the app does, who it's for, key features) shown alongside
+your app on the dashboard."* If the member declines, you're done — deploys and
+updates work fine without a PRD.
+
+If they want one:
+
+1. Generate a concise one-pager as a **single self-contained HTML document**:
+   inline CSS only, no external scripts/fonts/images, comfortably under 100,000
+   characters. Suggested sections: what it is, the problem it solves, who it's
+   for, key features, how to use it.
+2. Save it locally (e.g. \`prd.html\`) so the member can open and read it, and
+   give them a faithful summary in chat.
+3. Get explicit approval — revise and re-present on feedback — then upload it
+   (below). Never upload an unapproved PRD.
+
+## Saving via the metadata endpoint
+
+\`metadataEndpoint\` in \`pln-app.config.json\` is a URL **template** — replace the
+literal \`{appUid}\` with the app's \`uid\` (the \`uid\` field of the deploy/draft
+response, saved as \`appUid\` in the config after the first upload). Auth is the
+same short-lived deploy token used for deploys, in the \`${AI_APP_TOKEN_HEADER}\`
+header — for a metadata-only session (no deploy planned), run the connect flow
+from the deploy-to-labs skill to get one.
+
+Name/description only:
+
+\`\`\`bash
+curl -sX PATCH "<metadataEndpoint with {appUid} replaced>" \\
+  -H "${AI_APP_TOKEN_HEADER}: <deployToken>" \\
+  -H "Content-Type: application/json" \\
+  -d '{"name":"Team Availability Board","description":"See at a glance who on your team is free this week."}'
+\`\`\`
+
+With a PRD, build the JSON body in a file — the \`prd\` value is the whole HTML
+document as one JSON string, so don't hand-escape it in the shell:
+
+\`\`\`bash
+node -e 'const fs=require("fs");fs.writeFileSync("body.json",JSON.stringify({prd:fs.readFileSync("prd.html","utf8")}))'
+curl -sX PATCH "<metadataEndpoint with {appUid} replaced>" \\
+  -H "${AI_APP_TOKEN_HEADER}: <deployToken>" \\
+  -H "Content-Type: application/json" \\
+  --data @body.json
+\`\`\`
+
+All three fields are optional — send only what changed. \`"prd": null\` removes
+the PRD, \`"description": null\` clears the description. The response is the
+updated app record; the dashboard reflects it immediately.
+
+## Rules
+
+- **Approval first, always.** Name, description, and PRD are what other PLN
+  members see — never save a draft the member hasn't explicitly approved.
+- **Metadata saves are instant and deploy-free**: no ZIP, no build, no downtime.
+  Never redeploy "to apply" a name/description/PRD change.
+- The endpoint edits only apps owned by the member who approved the token, and
+  404s before the first deploy/draft upload (the app record is created by the
+  first upload) — a brand-new app gets its approved name/description through
+  the deploy form, and its PRD right after via this endpoint.
+- Keep \`pln-app.config.json\` in sync: after any approved rename or description
+  change, update \`appName\`/\`appDescription\` there too.
+- The deploy token stays in memory only — never write it to the config or any
+  file (same rule as the deploy skill).
 `;
   }
 
@@ -540,19 +686,30 @@ key (OpenAI/Anthropic, email/SMS, a database, a paid API)? A quick check:
 grep -rniE 'process\\.env\\.|os\\.environ|getenv' app --include='*.js' --include='*.ts' --include='*.py' | grep -viE 'PORT|NODE_ENV'
 \`\`\`
 
-If anything secret shows up (or you wrote code that needs a key), do steps 1–4 as
+If anything secret shows up (or you wrote code that needs a key), do steps 1–5 as
 written but then follow "**Apps that need secrets (draft flow)**" below instead of
-step 5 — you register a draft and the member deploys from LabOS after entering the
+step 6 — you register a draft and the member deploys from LabOS after entering the
 values there. Never deploy a secrets app directly and never accept key values in
 the chat.
 
 ## Steps
 1. Read \`pln-app.config.json\` to get \`connectEndpoint\`, \`deployEndpoint\`,
-   \`draftEndpoint\`, the \`kitVersion\` (sent with every upload so PLN knows which
-   kit built the app), and (if present) a saved \`appId\`. If no \`appId\` exists
-   yet, pick a short, stable, lowercase slug (e.g. \`hello-board\`) and save it
-   back to the config. Never edit \`kitVersion\` by hand.
-2. **Get a deploy token via LabOS.** The kit has no token; obtain a short-lived one
+   \`draftEndpoint\`, \`metadataEndpoint\`, the \`kitVersion\` (sent with every upload
+   so PLN knows which kit built the app), and (if present) saved \`appId\`,
+   \`appUid\`, \`appName\`, and \`appDescription\`. If no \`appId\` exists yet, pick a
+   short, stable, lowercase slug (e.g. \`hello-board\`) and save it back to the
+   config. Never edit \`kitVersion\` by hand.
+2. **Settle the display name & description.** If \`appName\` in the config is
+   empty (first deploy), load the **app-metadata** skill
+   (\`.claude/skills/app-metadata/SKILL.md\`): propose a human-friendly name and
+   a 1–2 sentence description, get the member's **explicit approval** (revise
+   until they approve), and save the approved values to \`appName\`/
+   \`appDescription\` in the config. If \`appName\` is already set, **reuse the
+   saved values verbatim and don't re-ask** — the deploy form overwrites the
+   stored metadata, so anything else would revert what the member approved.
+   Only re-run the propose flow when the member explicitly asks to change the
+   name or description.
+3. **Get a deploy token via LabOS.** The kit has no token; obtain a short-lived one
    through the connect flow:
 
    a. Start a session (no auth needed). Set \`clientName\` to YOUR actual tool
@@ -578,16 +735,16 @@ the chat.
    # pending  → keep polling
    # approved → { "status":"approved", "deployToken":"plndeploy_…", "deployTokenExpiresAt" }
    # denied   → the member lacks ai_apps.write; stop and tell them
-   # expired  → the link timed out; start a new session (step 2a)
+   # expired  → the link timed out; start a new session (step 3a)
    \`\`\`
 
    Hold \`deployToken\` **in memory only** — never write it to \`pln-app.config.json\`
    or any other file, and never print it.
-3. Make sure \`app/\` runs locally first (\`npm install && npm start\`, hit
+4. Make sure \`app/\` runs locally first (\`npm install && npm start\`, hit
    \`/health\`). For a migrated existing app, also confirm the migration checklist
    in \`AGENTS.md\` is satisfied (self-contained \`app/\`, fitting Dockerfile, binds
    \`0.0.0.0\`, no reliance on injected secrets).
-4. Zip the **contents** of \`app/\` so the \`Dockerfile\` sits at the ZIP root.
+5. Zip the **contents** of \`app/\` so the \`Dockerfile\` sits at the ZIP root.
    Exclude \`node_modules\`, build output, and — importantly — any secrets: real
    \`.env\` files, tokens/keys, and data dirs must never enter the ZIP (the backend
    stores it server-side).
@@ -599,34 +756,44 @@ the chat.
    unzip -l ../app.zip | grep -iE '\\.env|secret|credential|\\.pem|\\.key' && echo 'STOP: secret in zip' || echo 'ok'
    \`\`\`
 
-5. Upload the ZIP to the deploy endpoint as multipart/form-data, sending the
-   \`deployToken\` from step 2 in the \`${AI_APP_TOKEN_HEADER}\` header. The PLN backend
-   stores the ZIP and triggers the build — no cloud credentials are needed:
+6. Upload the ZIP to the deploy endpoint as multipart/form-data, sending the
+   \`deployToken\` from step 3 in the \`${AI_APP_TOKEN_HEADER}\` header. \`name\` and
+   \`description\` are the member-approved \`appName\`/\`appDescription\` from
+   \`pln-app.config.json\` (step 2) — send them verbatim. The PLN backend stores
+   the ZIP and triggers the build — no cloud credentials are needed:
 
    \`\`\`bash
    curl -X POST "<deployEndpoint>" \\
      -H "${AI_APP_TOKEN_HEADER}: <deployToken>" \\
      -F "appId=<your-app-id>" \\
-     -F "name=<human-friendly app name>" \\
-     -F "description=<one line about the app>" \\
+     -F "name=<the approved appName from pln-app.config.json>" \\
+     -F "description=<the approved appDescription from pln-app.config.json>" \\
      -F "deploymentId=<unique id per deploy, e.g. a timestamp>" \\
      -F "kitVersion=<the kitVersion from pln-app.config.json>" \\
      -F "agentModel=<the model you are running on, e.g. claude-sonnet-4-5; omit the field if unknown>" \\
      -F "file=@app.zip;type=application/zip"
    \`\`\`
 
-6. On success the response contains the deployment URL and status:
+7. On success the response contains the app record with its deployment URL and
+   status:
 
    \`\`\`json
-   { "status": "READY", "url": "https://<appId>.${AI_APPS_APP_DOMAIN}", "host": "...", "port": 31001 }
+   { "uid": "cl…", "status": "READY", "url": "https://<appId>.${AI_APPS_APP_DOMAIN}", "host": "...", "port": 31001 }
    \`\`\`
 
-   Use this URL only for the internal checks below — **do not reveal it to the
-   member** (see "Keep the deployment URL private"). On \`READY\`, tell the member the
-   app is live and can be opened from the PL Infra → AI Apps dashboard. If \`status\`
-   is \`ERROR\`, surface \`notes\` (never the URL).
+   Save the response's \`uid\` as \`appUid\` in \`pln-app.config.json\` (it addresses
+   the metadata endpoint later). Use the URL only for the internal checks below —
+   **do not reveal it to the member** (see "Keep the deployment URL private").
+   On \`READY\`, tell the member the app is live and can be opened from the
+   PL Infra → AI Apps dashboard. If \`status\` is \`ERROR\`, surface \`notes\`
+   (never the URL).
 
-7. **Verify the app is iframe-embeddable** (internal check — do not surface the URL
+   **After the FIRST successful deploy**, offer the optional one-pager PRD —
+   see "Offer the one-pager PRD" in the app-metadata skill. If the member wants
+   one, generate it, get approval, and save it via \`metadataEndpoint\` — no
+   redeploy involved. Don't re-offer it on later redeploys.
+
+8. **Verify the app is iframe-embeddable** (internal check — do not surface the URL
    to the member). The dashboard shows it in an \`<iframe>\` from a sibling
    \`*.plnetwork.io\` subdomain; check the live response headers:
 
@@ -644,8 +811,9 @@ the chat.
    (see the framing rule in \`AGENTS.md\`) and redeploy before reporting success.
 
 ## Apps that need secrets (draft flow)
-When the app needs runtime secrets, replace the upload in step 5 with a **draft
-registration** — same multipart shape, posted to \`draftEndpoint\`, plus
+When the app needs runtime secrets, replace the upload in step 6 with a **draft
+registration** — same multipart shape (including the approved \`appName\`/
+\`appDescription\` from the config), posted to \`draftEndpoint\`, plus
 \`requiredEnvVars\` (the env var NAMES the app reads; JSON array or
 comma-separated). Nothing is deployed yet:
 
@@ -653,15 +821,18 @@ comma-separated). Nothing is deployed yet:
 curl -X POST "<draftEndpoint>" \\
   -H "${AI_APP_TOKEN_HEADER}: <deployToken>" \\
   -F "appId=<your-app-id>" \\
-  -F "name=<human-friendly app name>" \\
-  -F "description=<one line about the app>" \\
+  -F "name=<the approved appName from pln-app.config.json>" \\
+  -F "description=<the approved appDescription from pln-app.config.json>" \\
   -F "deploymentId=<unique id per upload, e.g. a timestamp>" \\
   -F "kitVersion=<the kitVersion from pln-app.config.json>" \\
   -F "agentModel=<the model you are running on; omit the field if unknown>" \\
   -F 'requiredEnvVars=["OPENAI_API_KEY","SUPABASE_URL"]' \\
   -F "file=@app.zip;type=application/zip"
-# → { "status": "DRAFT", "appPageUrl": "https://…/pl-infra/ai-apps/<uid>", "missingEnvVars": [ … ] }
+# → { "uid": "cl…", "status": "DRAFT", "appPageUrl": "https://…/pl-infra/ai-apps/<uid>", "missingEnvVars": [ … ] }
 \`\`\`
+
+Save the response's \`uid\` as \`appUid\` in \`pln-app.config.json\`, same as a
+regular deploy.
 
 **IMMEDIATELY give the member the \`appPageUrl\` link — this is the very next
 thing you do after the registration call returns, before anything else.** A
@@ -716,6 +887,10 @@ verification steps. Only re-deploy if it stays unreachable.
 - Reuse the same \`appId\` to redeploy an existing app; use a new \`deploymentId\`
   each time. Derive the URL from the \`appId\` for your own checks, but treat it as
   sensitive (see "Keep the deployment URL private").
+- Redeploys resend the saved \`appName\`/\`appDescription\` verbatim and never
+  re-run the propose-and-approve flow. Renames, description edits, and PRD
+  changes go through the **app-metadata** skill (\`metadataEndpoint\`) — they
+  never require a redeploy, and a redeploy never touches the PRD.
 - The deploy token is short-lived (≈1 hour) and tied to the member who approved the
   connect link. Keep it in memory only — never save it to a file or print it. Within
   the window you can redeploy without reconnecting; once it expires (deploy returns
@@ -732,12 +907,16 @@ verification steps. Only re-deploy if it stays unreachable.
         connectEndpoint: AI_APPS_CONNECT_ENDPOINT,
         deployEndpoint: AI_APPS_DEPLOY_ENDPOINT,
         draftEndpoint: AI_APPS_DRAFT_ENDPOINT,
+        metadataEndpoint: AI_APPS_METADATA_ENDPOINT,
         memberContextEndpoint: AI_APPS_ME_ENDPOINT,
         deployTokenHeader: AI_APP_TOKEN_HEADER,
         kitVersion: AI_APPS_STARTER_KIT_VERSION,
         appId: '',
+        appUid: '',
+        appName: '',
+        appDescription: '',
         notes:
-          'No token is stored here. At deploy time the agent runs the LabOS connect flow (see .claude/skills/deploy-to-labs) to get a short-lived deploy token. Set appId to a stable lowercase slug on first deploy and reuse it. If the app needs runtime secrets, register it via draftEndpoint instead of deploying (see the deploy skill).',
+          'No token is stored here. At deploy time the agent runs the LabOS connect flow (see .claude/skills/deploy-to-labs) to get a short-lived deploy token. Set appId to a stable lowercase slug on first deploy and reuse it. appName/appDescription hold the member-APPROVED display metadata (see .claude/skills/app-metadata) — redeploys resend them verbatim. After the first deploy, save the response uid as appUid; metadataEndpoint is a template where {appUid} is replaced with it. If the app needs runtime secrets, register it via draftEndpoint instead of deploying (see the deploy skill).',
       },
       null,
       2

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.spec.ts
@@ -22,6 +22,7 @@ describe('AiAppsStarterKitService buildZip', () => {
       'CLAUDE.md',
       'AGENTS.md',
       '.claude/skills/deploy-to-labs/SKILL.md',
+      '.claude/skills/app-metadata/SKILL.md',
       '.claude/skills/pl-design-system/SKILL.md',
       '.claude/skills/pln-member-context/SKILL.md',
       'pln-app.config.json',
@@ -65,6 +66,47 @@ describe('AiAppsStarterKitService buildZip', () => {
     expect(deploySkill).toContain('It does NOT cover the LabOS links');
     for (const path of ['CLAUDE.md', 'AGENTS.md']) {
       expect(entries.get(path) as string).toContain('LabOS links');
+    }
+  });
+
+  it('writes the metadata endpoint template and display-metadata fields into the config', () => {
+    const config = JSON.parse(entries.get('pln-app.config.json') as string);
+    expect(config.metadataEndpoint).toContain('/v1/ai-apps/{appUid}/agent');
+    // Persisted so redeploys reuse the member-approved values and can address
+    // the metadata endpoint without re-running the propose flow.
+    expect(config.appUid).toBe('');
+    expect(config.appName).toBe('');
+    expect(config.appDescription).toBe('');
+  });
+
+  it('teaches the propose → approve → optional-PRD metadata flow', () => {
+    const metadataSkill = entries.get('.claude/skills/app-metadata/SKILL.md') as string;
+    // Nothing member-facing is saved without explicit approval…
+    expect(metadataSkill).toContain('Wait for explicit approval');
+    // …the PRD is offered, not imposed, and declining is a valid outcome…
+    expect(metadataSkill).toContain('If the member declines');
+    // …and saving goes through the deploy-free metadata endpoint.
+    expect(metadataSkill).toContain('PATCH');
+    expect(metadataSkill).toContain('{appUid}');
+    expect(metadataSkill).toContain('"prd": null');
+    expect(metadataSkill).toContain('no ZIP, no build');
+    for (const path of ['CLAUDE.md', 'AGENTS.md']) {
+      const content = entries.get(path) as string;
+      expect(content).toContain('app-metadata');
+      expect(content).toContain('wait for explicit approval');
+      expect(content).toContain('one-pager PRD');
+    }
+  });
+
+  it('makes redeploys reuse approved metadata instead of re-proposing', () => {
+    const deploySkill = entries.get('.claude/skills/deploy-to-labs/SKILL.md') as string;
+    // The deploy form overwrites stored name/description, so redeploys must
+    // resend the saved values verbatim — not fresh drafts.
+    expect(deploySkill).toContain("saved values verbatim and don't re-ask");
+    expect(deploySkill).toContain('the approved appName from pln-app.config.json');
+    expect(deploySkill).toContain("Save the response's `uid` as `appUid`");
+    for (const path of ['CLAUDE.md', 'AGENTS.md']) {
+      expect(entries.get(path) as string).toContain('NOT re-run the propose-and-approve flow');
     }
   });
 

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -11,7 +11,7 @@
  */
 
 /** Starter kit version shown in the README, ZIP filename, and LabOS UI. Bump when the kit contents or flow change. */
-export const AI_APPS_STARTER_KIT_VERSION = '1.4';
+export const AI_APPS_STARTER_KIT_VERSION = '1.5';
 
 /** Header the AI agent sends with its short-lived deploy token. */
 export const AI_APP_TOKEN_HEADER = 'x-app-token';
@@ -76,8 +76,7 @@ export const AI_APPS_S3_BUCKET = process.env.AI_APPS_S3_BUCKET || '';
  * already used for member images, so no new bucket policy/IAM permission is
  * required. AI_APPS_PRD_S3_BUCKET remains an optional override.
  */
-export const AI_APPS_PRD_S3_BUCKET =
-  process.env.AI_APPS_PRD_S3_BUCKET || AI_APPS_S3_BUCKET;
+export const AI_APPS_PRD_S3_BUCKET = process.env.AI_APPS_PRD_S3_BUCKET || AI_APPS_S3_BUCKET;
 
 /** Optional CDN/public base URL for PRDs, without a trailing slash. */
 export const AI_APPS_PRD_PUBLIC_BASE_URL = process.env.AI_APPS_PRD_PUBLIC_BASE_URL || '';
@@ -158,6 +157,15 @@ export const AI_APPS_DRAFT_ENDPOINT = process.env.AI_APPS_DRAFT_ENDPOINT || `${A
  * signed-in member's identity from.
  */
 export const AI_APPS_ME_ENDPOINT = process.env.AI_APPS_ME_ENDPOINT || `${AI_APPS_BASE_URL}/v1/ai-apps/me`;
+
+/**
+ * Public URL TEMPLATE of THIS API's agent metadata endpoint
+ * (`PATCH /v1/ai-apps/:uid/agent`), written into the starter kit. The agent
+ * replaces the literal `{appUid}` placeholder with the app's `uid` (returned by
+ * the deploy/draft response and saved in `pln-app.config.json`).
+ */
+export const AI_APPS_METADATA_ENDPOINT =
+  process.env.AI_APPS_METADATA_ENDPOINT || `${AI_APPS_BASE_URL}/v1/ai-apps/{appUid}/agent`;
 
 /**
  * Base URL of the LabOS portal that hosts the connect page the member opens to

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -11,7 +11,7 @@
  */
 
 /** Starter kit version shown in the README, ZIP filename, and LabOS UI. Bump when the kit contents or flow change. */
-export const AI_APPS_STARTER_KIT_VERSION = '1.5';
+export const AI_APPS_STARTER_KIT_VERSION = '1.4';
 
 /** Header the AI agent sends with its short-lived deploy token. */
 export const AI_APP_TOKEN_HEADER = 'x-app-token';

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -227,9 +227,7 @@ export class AiAppsService {
   ): Promise<WithMember<AiApp>> {
     const extension = this.validatePrdFile(file);
     if (!AI_APPS_PRD_S3_BUCKET) {
-      throw new InternalServerErrorException(
-        'No PRD bucket configured (AI_APPS_PRD_S3_BUCKET or AI_APPS_S3_BUCKET)'
-      );
+      throw new InternalServerErrorException('No PRD bucket configured (AI_APPS_PRD_S3_BUCKET or AI_APPS_S3_BUCKET)');
     }
 
     const app = await this.prisma.aiApp.findUnique({ where: { uid } });
@@ -239,10 +237,7 @@ export class AiAppsService {
 
     const key = buildPrdS3Key(app.appId, extension, randomUUID());
     try {
-      const contentType =
-        extension === '.md'
-          ? 'text/markdown; charset=utf-8'
-          : 'text/html; charset=utf-8';
+      const contentType = extension === '.md' ? 'text/markdown; charset=utf-8' : 'text/html; charset=utf-8';
 
       await this.awsService.uploadFileToS3(
         {
@@ -267,9 +262,7 @@ export class AiAppsService {
     }
 
     const filename = file.originalname || '';
-    const rawExtension = filename.includes('.')
-      ? filename.slice(filename.lastIndexOf('.')).toLowerCase()
-      : '';
+    const rawExtension = filename.includes('.') ? filename.slice(filename.lastIndexOf('.')).toLowerCase() : '';
 
     let extension: '.md' | '.html';
 
@@ -278,9 +271,7 @@ export class AiAppsService {
     } else if (rawExtension === '.html' || rawExtension === '.htm') {
       extension = '.html';
     } else {
-      throw new BadRequestException(
-        'Unsupported PRD file type. Only .md, .markdown, .html, and .htm are allowed'
-      );
+      throw new BadRequestException('Unsupported PRD file type. Only .md, .markdown, .html, and .htm are allowed');
     }
 
     if (file.buffer.includes(0)) {

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -98,6 +98,8 @@ export class AiAppsService {
    * personalization ("member context"). Returns curated public directory
    * fields only — this is the extension point if apps may read more PLN data
    * later (add fields/sections here rather than exposing internal endpoints).
+   * Deliberately NO contact info (email, office-hours link, …): apps
+   * personalize with the identity, they never get a channel to the member.
    */
   async getMemberContext(memberUid: string) {
     const member = await this.prisma.member.findUnique({
@@ -105,8 +107,6 @@ export class AiAppsService {
       select: {
         uid: true,
         name: true,
-        email: true,
-        officeHours: true,
         image: { select: { url: true } },
         location: { select: { city: true, country: true, continent: true } },
         skills: { select: { title: true }, orderBy: { title: 'asc' } },

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -229,14 +229,15 @@ feedback, adapt behavior). `GET /v1/ai-apps/me` returns the signed-in member's
 ```json
 {
   "member": {
-    "uid": "…", "name": "Ada Lovelace", "email": "ada@example.com",
-    "image": "https://…/ada.png", "officeHours": null,
+    "uid": "…", "name": "Ada Lovelace", "image": "https://…/ada.png",
     "location": { "city": "London", "country": "United Kingdom", "continent": "Europe" },
     "skills": ["Engineering"],
     "teams": [{ "uid": "…", "name": "Protocol Labs", "role": "Engineer", "mainTeam": true, "teamLead": false }]
   }
 }
 ```
+
+The payload deliberately carries **no contact info** — no `email` and no `officeHours` link. Apps get an identity to personalize with, never a channel to reach the member.
 
 How it works — no app-side login and no new token flow:
 

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -8,8 +8,8 @@ PLN members "vibe-code" a small web app locally with an AI assistant (Claude Cod
 
 1. A member with `ai_apps.write` opens the AI Apps dashboard and downloads the **starter kit** ZIP. The kit carries **no token**.
 2. They unzip it into their AI coding tool and describe what to build. The agent edits files under `app/`, reusing the bundled **PL Design System** (`pl-design-system/`) for on-brand UI instead of hand-rolling components.
-3. When ready, the member says "deploy". The agent has no stored token, so it **starts a LabOS connect session**, gives the member a link + confirmation code to open and approve, then polls until it receives a **short-lived deploy token**.
-4. The agent packages `app/` and POSTs to our deploy endpoint with that short-lived token. The backend proxies the deploy to the sandbox runner, stores the result, and the app shows up on the dashboard with its live URL.
+3. When ready, the member says "deploy". Before the **first** deploy the agent proposes a human-friendly **name** and short **description** for the app and waits for the member to approve (or revise) them — kits ≥1.5, see "Editable metadata & one-pager PRD" below. The agent has no stored token, so it **starts a LabOS connect session**, gives the member a link + confirmation code to open and approve, then polls until it receives a **short-lived deploy token**.
+4. The agent packages `app/` and POSTs to our deploy endpoint with that short-lived token. The backend proxies the deploy to the sandbox runner, stores the result, and the app shows up on the dashboard with its live URL. After the first successful deploy the agent offers an optional **one-pager PRD**; if the member wants one, the agent drafts it, gets approval, and saves it through the metadata endpoint — no redeploy.
 5. **Apps that need runtime secrets** (API keys etc.) take a detour: instead of deploying, the agent registers a **draft** (same upload + the required env var *names*), then hands the member a LabOS link. The member enters the secret *values* there and clicks **Deploy** — see "Draft apps & runtime secrets" below.
 
 ## Architecture
@@ -93,6 +93,9 @@ The `deployToken` is held in agent memory only and never written into the kit, s
 | GET    | `/v1/ai-apps/:uid`               | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Single app detail |
 | GET    | `/v1/ai-apps/:uid/events`        | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Full event/status history for one app (404 if app missing) |
 | GET    | `/v1/ai-apps/:uid/live`          | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Liveness probe: one server-side reachability check of the app URL → `{ live }`; gateway timeouts AND 404 count as down (the ingress 404s until a first deploy's route is ready). The LabOS detail page polls it so the iframe never shows a raw gateway/404 error |
+| PATCH  | `/v1/ai-apps/:uid`               | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.write`   | Edit display metadata (`name`/`description`/`prd`) without redeploying; JSON **or** multipart (`file` = Markdown/HTML PRD, stored in S3) |
+| POST   | `/v1/ai-apps/:uid/prd`           | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.write`   | File-only PRD upload from the LabOS dashboard (multipart `file`, `.md`/`.html`) — no redeploy |
+| PATCH  | `/v1/ai-apps/:uid/agent`         | `AiAppTokenGuard` (`x-app-token`) | — (token = member, **owner only**) | Agent metadata edit: JSON `{ name?, description?, prd? }`; how the starter kit saves approved names/descriptions and one-pager PRDs |
 | POST   | `/v1/ai-apps/:uid/feedback`      | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` | Submit free-text feedback on an app (multiple entries per member allowed) |
 | GET    | `/v1/ai-apps/:uid/feedback`      | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.read`/`write` + creator/directory-admin (checked in service) | All feedback for one app, newest first, with submitter info |
 | GET    | `/v1/ai-apps/starter-kit/download` | `UserTokenCheckGuard`+`RbacGuard` | `ai_apps.write`   | Stream the starter-kit ZIP (no token inside) |
@@ -116,9 +119,11 @@ curl -X POST "$AI_APPS_DEPLOY_ENDPOINT" \
   -F "name=My Leaderboard" \
   -F "description=A small leaderboard demo" \
   -F "deploymentId=deploy-1718900000" \
-  -F "kitVersion=1.4" \
+  -F "kitVersion=1.5" \
   -F "file=@app.zip;type=application/zip"
 ```
+
+`name`/`description` are member-facing: kits ≥1.5 send values the member explicitly approved (and resend the same values on redeploys — see "Editable metadata & one-pager PRD").
 
 `kitVersion` is optional (kits ≥1.4 send the value from their `pln-app.config.json`) and is stored on the app so we know which kit produced the last upload — older kits send nothing and the column goes/stays null. The same field exists on `POST /v1/ai-apps/draft`, and the `KIT_DOWNLOADED` audit event records the downloaded version in `message`.
 
@@ -174,6 +179,46 @@ Header: x-runner-token: <server secret>
 ```
 
 Flow: set status `DELETING` + log `DELETE_STARTED` → call the runner → on success clear hosting fields, set status `DELETED`, log `DELETE_SUCCEEDED`; on failure set status `ERROR` (with `notes`), log `DELETE_FAILED`, and return `502`. The `AiApp` row is **kept** (status flips to `DELETED`) so the audit trail and event history survive. Response is the updated `AiApp` record.
+
+## Editable metadata & one-pager PRD
+
+An app's display metadata — `name`, `description`, and an optional **one-pager PRD** (`prd`) — is editable **independently of deploys**: none of these endpoints upload a ZIP, invoke the sandbox runner, or change the app's status. Three routes (migration `20260715120000_ai_apps_editable_metadata` added the `prd` column):
+
+- **`PATCH /v1/ai-apps/:uid`** (member JWT, `ai_apps.write`) — accepts `application/json` (`{ name?, description?, prd? }`) **or** `multipart/form-data` where an optional `file` carries a Markdown/HTML PRD (then `prd` must not also be sent in the body). Used by the LabOS edit UI.
+- **`POST /v1/ai-apps/:uid/prd`** (member JWT, `ai_apps.write`) — file-only PRD upload for the dashboard.
+- **`PATCH /v1/ai-apps/:uid/agent`** (`AiAppTokenGuard`, `x-app-token` deploy token) — JSON-only agent variant used by starter kits ≥1.5; unlike the member routes it is restricted to apps **owned by the connected member** (403 otherwise).
+
+Validation: at least one field must be present; `name` 1–200 chars, `description` ≤4000 (nullable — `null` clears), `prd` ≤100,000 chars (nullable). PRD **files** must be `.md`/`.markdown`/`.html`/`.htm`, UTF-8 text (a NUL byte rejects), ≤1 MB (`AI_APPS_MAX_PRD_BYTES`). Both multipart routes are excluded from `ContentTypeMiddleware` in `app.module.ts`.
+
+**PRD storage:** an uploaded PRD *file* goes to S3 under `ai-app-prds/<appId>/<uuid><.md|.html>` in `AI_APPS_PRD_S3_BUCKET` (defaults to `AI_APPS_S3_BUCKET`), and only the S3 key is stored in `AiApp.prd`. On every read, `withMember` maps a `prd` value starting with `ai-app-prds/` to its public URL (`AI_APPS_PRD_PUBLIC_BASE_URL` if set, else the standard S3 URL) — so the API contract is simply "`prd` holds a URL or inline content". Inline `prd` *text* (the agent route, or JSON PATCH without a file) is stored verbatim in the DB and returned as-is.
+
+Agent example (name/description + inline HTML one-pager):
+
+```bash
+curl -X PATCH "https://api.plnetwork.io/v1/ai-apps/<uid>/agent" \
+  -H "x-app-token: $DEPLOY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Team Availability Board","description":"See who on your team is free this week.","prd":"<!doctype html>…"}'
+```
+
+Dashboard PRD file upload:
+
+```bash
+curl -X POST "https://api.plnetwork.io/v1/ai-apps/<uid>/prd" \
+  -H "Authorization: Bearer $MEMBER_JWT" \
+  -F "file=@one-pager.html;type=text/html"
+```
+
+**Interplay with deploys:** every deploy/draft upload **overwrites** `name`/`description` with the multipart form values (the upsert has no "keep existing" path) — which is why kits ≥1.5 persist the member-approved values in `pln-app.config.json` and resend them verbatim on redeploys. Deploys never touch `prd`, so a one-pager survives any number of redeploys. Metadata edits are not audited (no `AiAppEvent` rows).
+
+### Starter kit flow (kits ≥1.5)
+
+The kit's `app-metadata` skill drives a propose → confirm → save workflow so the agent never publishes member-facing copy without approval:
+
+1. **First deploy** (no `appName` saved in `pln-app.config.json`): the agent drafts a human-friendly name + 1–2 sentence description from what the app does, presents them, and waits for **explicit approval** (revising as asked). Approved values are saved to `appName`/`appDescription` in the config and sent as the deploy form's `name`/`description`.
+2. **After the first successful deploy**: the agent asks once whether the member wants a one-pager PRD. If declined, nothing happens; if wanted, it generates a concise self-contained HTML one-pager, gets approval, and saves it via `PATCH …/:uid/agent` — no new ZIP, no redeploy.
+3. **Redeploys**: the saved `appName`/`appDescription` are resent verbatim and the propose flow is **not** re-run (it would otherwise revert approved metadata, since deploys overwrite it).
+4. **Metadata changes on an existing app** (rename, description edit, PRD add/update/remove): same propose → confirm → save flow through the metadata endpoint, using the `appUid` the kit saved from the deploy/draft response (`metadataEndpoint` in the config is a template with a `{appUid}` placeholder). A metadata-only session still gets its short-lived token through the normal connect flow.
 
 ## Member context (signed-in user → deployed app)
 
@@ -234,6 +279,7 @@ model AiApp {
   appId        String          // business key, unique per owner
   name         String
   description  String?
+  prd          String?         // one-pager PRD: inline Markdown/HTML, or an S3 key (ai-app-prds/…) returned as a public URL
   status       AiAppStatus @default(IN_DEVELOPMENT)
   notes        String?         // error detail on failed deploys
   url / httpUrl / host / port  // hosting details from the runner
@@ -292,7 +338,7 @@ model AiAppEvent {            // append-only audit log — one row per event, ne
 
 Apps are **lazy-created on first deploy** — there is no registration form. (A draft registration counts: it upserts the same record with status `DRAFT`.)
 
-**Response shape:** every AI Apps endpoint (`list`, detail, `events`, and the `deploy` result) returns the owner as `member: { uid, name }` and omits the raw `memberUid` (the uid lives in `member.uid`, so it isn't duplicated). `memberUid` remains a column on the DB models above. The detail endpoint additionally returns `canManage` — whether the requesting member is the creator or a directory admin — computed server-side so the UI never compares member uids from a possibly stale login cookie.
+**Response shape:** every AI Apps endpoint (`list`, detail, `events`, and the `deploy` result) returns the owner as `member: { uid, name, image }` and omits the raw `memberUid` (the uid lives in `member.uid`, so it isn't duplicated). `memberUid` remains a column on the DB models above. The detail endpoint additionally returns `canManage` — whether the requesting member is the creator or a directory admin — computed server-side so the UI never compares member uids from a possibly stale login cookie.
 
 `AiApp.status` is the current-state snapshot for the dashboard; `AiAppEvent` is the immutable event flow. A row is appended on kit download (`KIT_DOWNLOADED`), on each connect approval/denial (`CONNECT_APPROVED` / `CONNECT_DENIED` — the `userCode` is recorded in `message`), at the start of every deploy (`DEPLOY_STARTED`) and its outcome (`DEPLOY_SUCCEEDED` / `DEPLOY_FAILED`), and likewise for deletes (`DELETE_STARTED` → `DELETE_SUCCEEDED` / `DELETE_FAILED`). Event logging never throws — a logging failure won't break a download, connect, deploy, or delete.
 
@@ -316,16 +362,18 @@ Design System is embedded as a curated folder (see below):
 README.md                                      human quick-start
 CLAUDE.md / AGENTS.md                          agent build + deploy instructions
 .claude/skills/deploy-to-labs/SKILL.md         deploy skill (incl. connect flow)
+.claude/skills/app-metadata/SKILL.md           propose → approve name/description + optional one-pager PRD (kits ≥1.5)
 .claude/skills/pl-design-system/SKILL.md       single UI skill (components + tokens)
 .claude/skills/pln-member-context/SKILL.md     how the app gets the signed-in member's identity
-pln-app.config.json                            connect + deploy + member-context endpoints (+ appId) — NO token
+pln-app.config.json                            connect/deploy/draft/metadata/member-context endpoints
+                                               (+ appId, appUid, approved appName/appDescription) — NO token
 pl-design-system/                              curated PL Design System (files, not a nested zip)
 styles/pln-theme.css                           minimal CSS-variable fallback (plain-HTML apps)
 styles/FONTS.md                                Inter font guidance
 app/                                           minimal runnable Node/Express scaffold
 ```
 
-The kit deliberately exposes **no internal PLN APIs** — only the connect, deploy, and member-context endpoints — and **no token**.
+The kit deliberately exposes **no internal PLN APIs** — only the connect, deploy, draft, metadata, and member-context endpoints — and **no token**.
 
 ### Bundled PL Design System
 
@@ -367,7 +415,9 @@ The agent loads `.claude/skills/pl-design-system` for UI work and follows
 | `AI_APPS_S3_BUCKET` | _(empty)_ | **Required** for real deploys; bucket the runner reads app bundles from (e.g. `sandbox-apps-pln-dev-013228333448`) |
 | `AI_APPS_APP_DOMAIN` | `prod.plnetwork.io` | Base domain deployed apps are served under (app URL = `https://<appId>.<domain>`); set `dev.plnetwork.io` on Dev, `prod.plnetwork.io` on Prod |
 | `AI_APPS_BASE_URL` | `https://api.plnetwork.io` | Public base URL of this API; the agent-facing endpoint URLs written into the kit (deploy/connect/draft/member context) are derived from it as `<base>/v1/ai-apps/<endpoint>` |
-| `AI_APPS_DEPLOY_ENDPOINT` / `AI_APPS_CONNECT_ENDPOINT` / `AI_APPS_DRAFT_ENDPOINT` / `AI_APPS_ME_ENDPOINT` | _derived from `AI_APPS_BASE_URL`_ | Optional per-endpoint overrides; rarely needed |
+| `AI_APPS_DEPLOY_ENDPOINT` / `AI_APPS_CONNECT_ENDPOINT` / `AI_APPS_DRAFT_ENDPOINT` / `AI_APPS_ME_ENDPOINT` / `AI_APPS_METADATA_ENDPOINT` | _derived from `AI_APPS_BASE_URL`_ | Optional per-endpoint overrides; rarely needed. The metadata endpoint is a template with a literal `{appUid}` placeholder the agent substitutes |
+| `AI_APPS_PRD_S3_BUCKET` | _`AI_APPS_S3_BUCKET`_ | Bucket for uploaded PRD files (`ai-app-prds/<appId>/<uuid>.<ext>`); defaults to the app-bundle bucket so no extra IAM is needed |
+| `AI_APPS_PRD_PUBLIC_BASE_URL` | _(empty)_ | Optional CDN/public base URL used when turning a stored PRD key into the URL returned in `prd`; falls back to the standard S3 URL |
 | `AI_APPS_PORTAL_URL` | `https://directory.plnetwork.io` | Base URL of the LabOS portal hosting the connect/approval page (used to build `connectUrl` and `appPageUrl`) |
 | `AI_APPS_RUNNER_PROJECT` | `default` | Project scope of the runner's secrets API (`/v1/projects/<project>/secrets`) |
 | `AI_APPS_RUNNER_ENVIRONMENT` | `prod` | Environment label for the runner secrets/deployments API. **Must match the environment the runner's `/deploy` build registers under** (its helm release is `<environment>-<appId>`; the legacy-compat build path registers as `sandbox`) — a mismatch makes the secrets-injection deploy collide with the build's release |
@@ -384,6 +434,7 @@ S3 uploads reuse the shared `AwsService`, so the standard `AWS_REGION` / `AWS_AC
 - `apps/web-api/prisma/migrations/20260630120000_ai_apps_connect/` — connect session table + connect event values; drops `AiAppToken`.
 - `apps/web-api/prisma/migrations/20260707120000_ai_apps_draft_secrets/` — `DRAFT` status, `s3Key`/`requiredEnvVars`/`providedEnvVars`, draft/secrets event values.
 - `apps/web-api/prisma/migrations/20260714120000_ai_apps_upload_meta/` — `kitVersion`/`agentClient`/`agentModel` columns (self-reported metadata about the last agent upload).
+- `apps/web-api/prisma/migrations/20260715120000_ai_apps_editable_metadata/` — `prd` column (one-pager PRD).
 - LabOS UI (`pln-directory-portal-v2`): `app/pl-infra/ai-apps/connect/page.tsx` + `components/page/ai-apps/AiAppsConnectPage/` — the approval page; connect calls in `services/ai-apps/ai-apps.service.ts`.
 - `.claude/skills/ai-apps/SKILL.md` — agent guidance for working on this feature.
 


### PR DESCRIPTION
## Ticket

[LAB-2145](https://linear.app/plrs-labos/issue/LAB-2145/ai-apps-starter-kit-skill-propose-namedescription-confirm-with-member)

## What was done

### Starter kit: guided name / description / one-pager PRD flow

The kit now walks the member's agent through display metadata instead of letting it silently invent `name`/`description` at upload time. Builds on the metadata API added in #3252 / #3257 — everything works without redeploying the app bundle.

- **New `app-metadata` skill** shipped in the kit ZIP (`.claude/skills/app-metadata/SKILL.md`):
  - **First deploy** — the agent drafts a human-friendly name + 1–2 sentence description from what the app does, presents them, and waits for the member's **explicit approval** (revise-and-re-present loop) before anything is uploaded.
  - **One-pager PRD** — after the first successful deploy the agent asks once whether the member wants one; if yes it generates a concise self-contained HTML one-pager, saves it locally for preview, gets approval, and uploads it via `PATCH /v1/ai-apps/:uid/agent` — no new ZIP, no redeploy. Declining is a first-class outcome.
  - **Editing an existing app** (rename / description / PRD add-update-remove) — same propose → confirm → save flow through the metadata endpoint.
- **Redeploys reuse approved metadata**: the deploy upsert overwrites `name`/`description` with whatever the form sends, so the kit now persists the approved values in `pln-app.config.json` (`appName`, `appDescription`) and the deploy skill resends them **verbatim** — the propose flow is never re-run unless the member asks. `prd` is untouched by deploys, so the one-pager survives redeploys.
- **`pln-app.config.json`** gains `metadataEndpoint` (a `{appUid}` URL template, new `AI_APPS_METADATA_ENDPOINT` constant derived from `AI_APPS_BASE_URL`) plus `appUid` (saved from the deploy/draft response), `appName`, `appDescription`.
- `AGENTS.md`/`CLAUDE.md`, the `deploy-to-labs` skill, and the member-facing README updated to wire the flow in (deploy steps renumbered; draft flow included).

### `GET /v1/ai-apps/me`: contact info removed

- `email` and `officeHours` dropped from the member-context response — deployed apps get an identity to personalize with (`uid`, `name`, `image`, `location`, `skills`, `teams`), never a channel to reach the member.
- Kit's `pln-member-context` skill + agent instructions updated to the reduced shape, with a note not to assume (or collect) contact details.

### Tests & docs

- Starter-kit spec: new assertions for the config fields, the approval-first flow, and reuse-on-redeploy; member-context spec updated + regression test that neither `email` nor `officeHours` is selected or returned.
- Fixed 2 pre-existing `ai-apps-feedback.spec.ts` failures from #3252's `member.image` addition (+ prettier fixes the earlier merge left behind in `ai-apps.service.ts` / `ai-apps.constants.ts`).
- `docs/AI_APPS.md` caught up with everything since #3252 (previously undocumented): the three metadata endpoints, validation + PRD S3 storage/URL mapping, `prd` in the data model, `member.image` response shape, new env vars (`AI_APPS_PRD_S3_BUCKET`, `AI_APPS_PRD_PUBLIC_BASE_URL`), the editable-metadata migration, and the new kit flow.

> Companion change in `pln-directory-portal-v2`: bump the duplicated `AI_APPS_STARTER_KIT_VERSION` to `1.5` when this ships.

## How to verify

1. Download a fresh starter kit, open it in Claude Code, build a small app, and say "deploy": the agent must propose a name/description and wait for approval before uploading, then offer the PRD after the deploy succeeds.
2. Redeploy after a code change: no re-asking; the approved name/description stay intact on the dashboard.
3. Ask to rename the app / refresh the PRD: saved via the metadata endpoint with the app never leaving `READY`.
4. `GET /v1/ai-apps/me` returns no `email`/`officeHours`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
