### PR TITLE
feat(ai-apps): order=desc for member log routes — newest-first with backward paging

### DIFF
--- a/apps/web-api/src/ai-apps/ai-apps-logs.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-logs.spec.ts
@@ -33,7 +33,7 @@ function buildService(app: Record<string, any> | null = APP) {
   const prisma = {
     aiApp: { findUnique: jest.fn().mockResolvedValue(app) },
     aiAppEvent: { create: jest.fn().mockResolvedValue({}) },
-    member: { findMany: jest.fn().mockResolvedValue([]) },
+    member: { findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn().mockResolvedValue(null) },
   };
   return new AiAppsService(prisma as any, {} as any);
 }
@@ -140,5 +140,143 @@ describe('AiAppsController log routes wiring', () => {
       BadRequestException
     );
     expect(service.getAgentLogs).not.toHaveBeenCalled();
+  });
+});
+
+describe('AiAppsService.getMemberLogsDesc', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("403s when the requester is neither the creator nor a directory admin", async () => {
+    await expect(
+      buildService().getMemberLogsDesc('someone-else', 'app-1', 'runtime', {})
+    ).rejects.toThrow(ForbiddenException);
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('assembles the newest-first tail across forward pages, normalizing string timestamps', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { events: [{ timestamp: '2026-07-23T07:00:00.000Z', message: 'old' }], nextToken: 'p2' },
+      })
+      // The runner echoes the sent token at end-of-stream (CloudWatch never nulls it).
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { events: [{ timestamp: '2026-07-23T08:00:00.000Z', message: 'new' }], nextToken: 'p2' },
+      });
+
+    const result = await buildService().getMemberLogsDesc('creator-1', 'app-1', 'runtime', {
+      limit: 10,
+      sinceMinutes: 60,
+    });
+
+    expect(result.events.map((e) => e.message)).toEqual(['new', 'old']);
+    expect(result.events.map((e) => e.timestamp)).toEqual([
+      Date.parse('2026-07-23T08:00:00.000Z'),
+      Date.parse('2026-07-23T07:00:00.000Z'),
+    ]);
+    expect(result.nextToken).toBeUndefined();
+  });
+
+  it('pages backward into history via the offset cursor, walking the runner only once (cache)', async () => {
+    const service = buildService();
+    mockedAxios.get.mockResolvedValue({
+      status: 200,
+      data: { events: [1, 2, 3, 4, 5].map((t) => ({ timestamp: t, message: `m${t}` })) },
+    });
+
+    const p1 = await service.getMemberLogsDesc('creator-1', 'app-1', 'build', { limit: 2 });
+    expect(p1.events.map((e) => e.message)).toEqual(['m5', 'm4']);
+    expect(p1.nextToken).toBeTruthy();
+
+    const p2 = await service.getMemberLogsDesc('creator-1', 'app-1', 'build', { limit: 2, nextToken: p1.nextToken });
+    expect(p2.events.map((e) => e.message)).toEqual(['m3', 'm2']);
+
+    const p3 = await service.getMemberLogsDesc('creator-1', 'app-1', 'build', { limit: 2, nextToken: p2.nextToken });
+    expect(p3.events.map((e) => e.message)).toEqual(['m1']);
+    expect(p3.nextToken).toBeUndefined();
+
+    // All three pages served from one cached walk.
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('400s on a malformed desc cursor', async () => {
+    await expect(
+      buildService().getMemberLogsDesc('creator-1', 'app-1', 'build', { nextToken: 'not-a-cursor' })
+    ).rejects.toThrow(BadRequestException);
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('narrows the window when a walk exhausts the call budget, then serves the narrowed tail', async () => {
+    mockedAxios.get.mockImplementation((_url: string, config: any) => {
+      if (config?.params?.sinceMinutes === 15) {
+        // 60 / 4 — the first narrowing completes in one page.
+        return Promise.resolve({ status: 200, data: { events: [{ timestamp: 99, message: 'tail' }] } });
+      }
+      // The full window never ends: every call advances the token.
+      const call = mockedAxios.get.mock.calls.length;
+      return Promise.resolve({
+        status: 200,
+        data: { events: [{ timestamp: call, message: `x${call}` }], nextToken: `t${call}` },
+      });
+    });
+
+    const result = await buildService().getMemberLogsDesc('creator-1', 'app-1', 'runtime', {
+      limit: 10,
+      sinceMinutes: 60,
+    });
+    expect(result.events.map((e) => e.message)).toEqual(['tail']);
+  });
+
+  it('502s when even narrowed walks cannot reach the end of the stream', async () => {
+    mockedAxios.get.mockImplementation(() => {
+      const call = mockedAxios.get.mock.calls.length;
+      return Promise.resolve({ status: 200, data: { events: [], nextToken: `t${call}` } });
+    });
+
+    await expect(
+      buildService().getMemberLogsDesc('creator-1', 'app-1', 'runtime', { sinceMinutes: 60 })
+    ).rejects.toThrow(BadGatewayException);
+  });
+});
+
+describe('AiAppsController member log routes — order param', () => {
+  function buildController() {
+    const service = {
+      getMemberLogs: jest.fn().mockResolvedValue({ events: [] }),
+      getMemberLogsDesc: jest.fn().mockResolvedValue({ events: [] }),
+    };
+    const controller = new AiAppsController(service as any, {} as any, {} as any, {} as any);
+    jest.spyOn(controller as any, 'resolveMemberUid').mockResolvedValue('member-9');
+    return { service, controller };
+  }
+
+  it('routes order=desc to the desc service and defaults to verbatim passthrough', async () => {
+    const { service, controller } = buildController();
+
+    await controller.getMemberBuildLogs('app-1', {}, '100', '60', undefined, 'desc');
+    expect(service.getMemberLogsDesc).toHaveBeenCalledWith('member-9', 'app-1', 'build', {
+      limit: 100,
+      sinceMinutes: 60,
+      nextToken: undefined,
+    });
+    expect(service.getMemberLogs).not.toHaveBeenCalled();
+
+    await controller.getMemberRuntimeLogs('app-1', {}, undefined, undefined, 'tok', undefined);
+    expect(service.getMemberLogs).toHaveBeenCalledWith('member-9', 'app-1', 'runtime', {
+      limit: undefined,
+      sinceMinutes: undefined,
+      nextToken: 'tok',
+    });
+  });
+
+  it('400s on an unknown order value', async () => {
+    const { service, controller } = buildController();
+
+    await expect(controller.getMemberRuntimeLogs('app-1', {}, undefined, undefined, undefined, 'sideways')).rejects.toThrow(
+      BadRequestException
+    );
+    expect(service.getMemberLogs).not.toHaveBeenCalled();
+    expect(service.getMemberLogsDesc).not.toHaveBeenCalled();
   });
 });

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -137,6 +137,31 @@ export type AiAppLogPhase = 'build' | 'runtime';
 export const buildRunnerLogsUrl = (appId: string, phase: AiAppLogPhase): string =>
   `${AI_APPS_RUNNER_URL}/v1/apps/${encodeURIComponent(appId)}/${phase}/logs`;
 
+/**
+ * `order=desc` member log reads. The runner (and CloudWatch behind it) pages
+ * FORWARD from the window start, so the newest-first view the dashboard wants
+ * is assembled here: walk the runner's pages server-side, retain only the
+ * newest lines, and serve descending slices with an offset cursor. These
+ * bounds cap one walk; if a window can't be walked within them the service
+ * narrows the window (the tail survives narrowing — it's the end of any
+ * window that reaches "now") before giving up.
+ */
+export const AI_APPS_LOGS_DESC_RETAIN = 5000;
+export const AI_APPS_LOGS_DESC_RUNNER_LIMIT = 2000;
+export const AI_APPS_LOGS_DESC_MAX_RUNNER_CALLS = 30;
+export const AI_APPS_LOGS_DESC_TIME_BUDGET_MS = 20_000;
+/** Divisors applied to the requested window when a walk blows the budget. */
+export const AI_APPS_LOGS_DESC_NARROWINGS = [4, 16];
+/** Fallback page size / hard cap for one desc response. */
+export const AI_APPS_LOGS_DESC_DEFAULT_LIMIT = 500;
+export const AI_APPS_LOGS_DESC_MAX_LIMIT = 2000;
+/**
+ * Completed walks are cached per instance so a reader scrolling through
+ * history doesn't re-walk the runner for every page. Short TTL — logs move.
+ */
+export const AI_APPS_LOGS_DESC_CACHE_TTL_MS = 15_000;
+export const AI_APPS_LOGS_DESC_CACHE_MAX_ENTRIES = 30;
+
 /** Build the S3 key for an app bundle: apps/<appId>/<deploymentId>/app.zip */
 export const buildAppS3Key = (appId: string, deploymentId: string): string => `apps/${appId}/${deploymentId}/app.zip`;
 

--- a/apps/web-api/src/ai-apps/ai-apps.controller.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.controller.ts
@@ -217,7 +217,11 @@ export class AiAppsController {
   /**
    * Build logs for a signed-in member from the LabOS dashboard (member JWT +
    * `ai_apps.read`), gated to the app's creator OR a directory admin — so an
-   * admin can debug any app's logs without a deploy token. Same query params
+   * admin can debug any app's logs without a deploy token.
+   *
+   * `order=desc` returns a newest-first view (assembled server-side — the
+   * runner only pages forward) with an allowlisted `{events, nextToken}` body
+   * whose nextToken walks EARLIER into history. Without it, same query params
    * and verbatim runner envelope as the agent route.
    */
   @NoCache()
@@ -229,20 +233,24 @@ export class AiAppsController {
     @Req() req: any,
     @Query('limit') limit?: string,
     @Query('sinceMinutes') sinceMinutes?: string,
-    @Query('nextToken') nextToken?: string
+    @Query('nextToken') nextToken?: string,
+    @Query('order') order?: string
   ) {
     const memberUid = await this.resolveMemberUid(req);
-    return this.aiAppsService.getMemberLogs(memberUid, uid, 'build', {
+    const query = {
       limit: this.parsePositiveInt('limit', limit),
       sinceMinutes: this.parsePositiveInt('sinceMinutes', sinceMinutes),
       nextToken,
-    });
+    };
+    return this.parseLogOrder(order) === 'desc'
+      ? this.aiAppsService.getMemberLogsDesc(memberUid, uid, 'build', query)
+      : this.aiAppsService.getMemberLogs(memberUid, uid, 'build', query);
   }
 
   /**
    * Runtime logs for a signed-in member from the LabOS dashboard (member JWT +
    * `ai_apps.read`), gated to the app's creator OR a directory admin. Same
-   * query params and verbatim runner envelope as the agent route.
+   * `order=desc` behavior as the build route.
    */
   @NoCache()
   @Get(':uid/runtime-logs')
@@ -253,14 +261,25 @@ export class AiAppsController {
     @Req() req: any,
     @Query('limit') limit?: string,
     @Query('sinceMinutes') sinceMinutes?: string,
-    @Query('nextToken') nextToken?: string
+    @Query('nextToken') nextToken?: string,
+    @Query('order') order?: string
   ) {
     const memberUid = await this.resolveMemberUid(req);
-    return this.aiAppsService.getMemberLogs(memberUid, uid, 'runtime', {
+    const query = {
       limit: this.parsePositiveInt('limit', limit),
       sinceMinutes: this.parsePositiveInt('sinceMinutes', sinceMinutes),
       nextToken,
-    });
+    };
+    return this.parseLogOrder(order) === 'desc'
+      ? this.aiAppsService.getMemberLogsDesc(memberUid, uid, 'runtime', query)
+      : this.aiAppsService.getMemberLogs(memberUid, uid, 'runtime', query);
+  }
+
+  /** 'asc' (default) = verbatim runner passthrough; 'desc' = server-assembled newest-first view. */
+  private parseLogOrder(order: string | undefined): 'asc' | 'desc' {
+    if (order === undefined || order === 'asc') return 'asc';
+    if (order === 'desc') return 'desc';
+    throw new BadRequestException(`order must be 'asc' or 'desc', got: ${order}`);
   }
 
   /** Same metadata edit path for a connected member agent. */

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -23,6 +23,15 @@ import {
   AI_APPS_DEPLOY_STUCK_MS,
   AI_APPS_HELM_LOCK_RETRIES,
   AI_APPS_HELM_LOCK_RETRY_INTERVAL_MS,
+  AI_APPS_LOGS_DESC_CACHE_MAX_ENTRIES,
+  AI_APPS_LOGS_DESC_CACHE_TTL_MS,
+  AI_APPS_LOGS_DESC_DEFAULT_LIMIT,
+  AI_APPS_LOGS_DESC_MAX_LIMIT,
+  AI_APPS_LOGS_DESC_MAX_RUNNER_CALLS,
+  AI_APPS_LOGS_DESC_NARROWINGS,
+  AI_APPS_LOGS_DESC_RETAIN,
+  AI_APPS_LOGS_DESC_RUNNER_LIMIT,
+  AI_APPS_LOGS_DESC_TIME_BUDGET_MS,
   AI_APPS_RUNNER_ENVIRONMENT,
   AI_APPS_RUNNER_TOKEN,
   AI_APPS_RUNNER_URL,
@@ -356,6 +365,183 @@ export class AiAppsService {
       throw new ForbiddenException('Only the app creator or a directory admin can view logs');
     }
     return this.fetchRunnerLogs(app, phase, query);
+  }
+
+  /**
+   * Newest-first member log reads (`order=desc`) — what the dashboard's
+   * deployment-logs modal shows. The runner (CloudWatch behind it) only pages
+   * FORWARD from the window start, so the tail is assembled here: walk every
+   * runner page server-side keeping the newest AI_APPS_LOGS_DESC_RETAIN lines,
+   * then serve descending slices. The opaque nextToken encodes an offset from
+   * the newest line plus the window the walk used, so "load earlier" pages
+   * read a consistent slice of history. Unlike the forward routes, the
+   * response here is allowlisted to `{ events, nextToken }` with numeric
+   * epoch-ms timestamps (the runner has been seen sending strings).
+   */
+  async getMemberLogsDesc(
+    requesterUid: string,
+    uid: string,
+    phase: AiAppLogPhase,
+    query: { limit?: number; sinceMinutes?: number; nextToken?: string }
+  ): Promise<{ events: { timestamp: number; message: string }[]; nextToken?: string }> {
+    const app = await this.prisma.aiApp.findUnique({ where: { uid } });
+    if (!app || app.status === 'DELETED') {
+      throw new NotFoundException(`AI App not found: ${uid}`);
+    }
+    if (!(await this.isCreatorOrDirectoryAdmin(requesterUid, app))) {
+      throw new ForbiddenException('Only the app creator or a directory admin can view logs');
+    }
+
+    const limit = Math.min(Math.max(query.limit ?? AI_APPS_LOGS_DESC_DEFAULT_LIMIT, 1), AI_APPS_LOGS_DESC_MAX_LIMIT);
+    const cursor = this.decodeDescCursor(query.nextToken);
+    // A cursor pins the window its first page walked; later pages must read
+    // the same slice of history (and hit the same cache entry).
+    let windowMinutes = cursor ? cursor.w : query.sinceMinutes;
+
+    let walk = await this.walkRunnerLogsTail(app, phase, windowMinutes);
+    if (!walk.complete && !cursor && query.sinceMinutes !== undefined) {
+      // The window is too chatty to walk in one budget. Narrowing keeps the
+      // tail — it's the end of any window that reaches "now" — so retry with
+      // progressively smaller windows before giving up.
+      for (const divisor of AI_APPS_LOGS_DESC_NARROWINGS) {
+        windowMinutes = Math.max(1, Math.floor(query.sinceMinutes / divisor));
+        walk = await this.walkRunnerLogsTail(app, phase, windowMinutes);
+        if (walk.complete) break;
+      }
+    }
+    if (!walk.complete) {
+      throw new BadGatewayException(
+        'Log volume is too large to assemble a newest-first view — retry with a narrower sinceMinutes window'
+      );
+    }
+
+    const all = walk.events; // ascending, at most AI_APPS_LOGS_DESC_RETAIN newest lines
+    const offset = cursor?.o ?? 0;
+    const end = Math.max(0, all.length - offset);
+    const start = Math.max(0, end - limit);
+    const events = all.slice(start, end).reverse(); // newest-first within the page
+    const hasEarlier = start > 0;
+
+    return {
+      events,
+      nextToken: hasEarlier ? this.encodeDescCursor({ o: offset + events.length, w: windowMinutes }) : undefined,
+    };
+  }
+
+  /**
+   * Walk the runner's forward pages to the end of the stream, keeping only the
+   * newest lines (ascending). `complete: false` means a bound tripped before
+   * the end — the buffer then holds the OLDEST part of the window and must
+   * never be served as "newest", so the caller narrows or fails.
+   */
+  private async walkRunnerLogsTail(
+    app: Pick<AiApp, 'appId'>,
+    phase: AiAppLogPhase,
+    sinceMinutes: number | undefined
+  ): Promise<{ events: { timestamp: number; message: string }[]; complete: boolean }> {
+    const cacheKey = `${app.appId}:${phase}:${sinceMinutes ?? 'all'}`;
+    const cached = this.readLogsTailCache(cacheKey);
+    if (cached) {
+      return { events: cached, complete: true };
+    }
+
+    const startedAt = Date.now();
+    let token: string | undefined;
+    let buffer: { timestamp: number; message: string }[] = [];
+
+    for (let call = 0; call < AI_APPS_LOGS_DESC_MAX_RUNNER_CALLS; call++) {
+      const body = (await this.fetchRunnerLogs(app, phase, {
+        limit: AI_APPS_LOGS_DESC_RUNNER_LIMIT,
+        sinceMinutes,
+        nextToken: token,
+      })) as { events?: unknown; nextToken?: unknown } | null;
+
+      const pageEvents = Array.isArray(body?.events) ? body!.events : [];
+      for (const raw of pageEvents) {
+        const entry = raw as { timestamp?: unknown; message?: unknown };
+        if (typeof entry?.message !== 'string') continue;
+        buffer.push({ timestamp: this.toEpochMs(entry.timestamp), message: entry.message });
+      }
+      // The walk is chronological, so trimming the front keeps the newest.
+      if (buffer.length > AI_APPS_LOGS_DESC_RETAIN * 2) {
+        buffer.sort((a, b) => a.timestamp - b.timestamp);
+        buffer = buffer.slice(-AI_APPS_LOGS_DESC_RETAIN);
+      }
+
+      const next = typeof body?.nextToken === 'string' ? body.nextToken : undefined;
+      // CloudWatch never nulls the token at end-of-stream; the real end is no
+      // token or the token we just sent echoed back.
+      if (!next || next === token) {
+        buffer.sort((a, b) => a.timestamp - b.timestamp);
+        const events = buffer.slice(-AI_APPS_LOGS_DESC_RETAIN);
+        this.writeLogsTailCache(cacheKey, events);
+        return { events, complete: true };
+      }
+      token = next;
+
+      if (Date.now() - startedAt > AI_APPS_LOGS_DESC_TIME_BUDGET_MS) {
+        return { events: [], complete: false };
+      }
+    }
+
+    return { events: [], complete: false };
+  }
+
+  /** Runner timestamps arrive as numbers, ISO strings, or numeric strings; anything else sorts as 0. */
+  private toEpochMs(value: unknown): number {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && value !== '') {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) return parsed;
+      const numeric = Number(value);
+      if (Number.isFinite(numeric)) return numeric;
+    }
+    return 0;
+  }
+
+  private encodeDescCursor(cursor: { o: number; w?: number }): string {
+    return Buffer.from(JSON.stringify(cursor)).toString('base64url');
+  }
+
+  private decodeDescCursor(token: string | undefined): { o: number; w?: number } | undefined {
+    if (token === undefined) return undefined;
+    try {
+      const parsed = JSON.parse(Buffer.from(token, 'base64url').toString('utf8'));
+      const offset = parsed?.o;
+      const window = parsed?.w;
+      if (typeof offset !== 'number' || !Number.isInteger(offset) || offset < 0) throw new Error('bad offset');
+      if (window !== undefined && (typeof window !== 'number' || !Number.isInteger(window) || window < 1)) {
+        throw new Error('bad window');
+      }
+      return { o: offset, w: window };
+    } catch {
+      throw new BadRequestException('Invalid nextToken for order=desc — use the token from a previous desc response');
+    }
+  }
+
+  /** Per-instance cache of completed tail walks, so scrolling history doesn't re-walk the runner per page. */
+  private readonly logsTailCache = new Map<
+    string,
+    { expiresAt: number; events: { timestamp: number; message: string }[] }
+  >();
+
+  private readLogsTailCache(key: string): { timestamp: number; message: string }[] | null {
+    const entry = this.logsTailCache.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt < Date.now()) {
+      this.logsTailCache.delete(key);
+      return null;
+    }
+    return entry.events;
+  }
+
+  private writeLogsTailCache(key: string, events: { timestamp: number; message: string }[]): void {
+    if (this.logsTailCache.size >= AI_APPS_LOGS_DESC_CACHE_MAX_ENTRIES) {
+      // Maps iterate in insertion order — dropping the first key is a cheap FIFO.
+      const oldest = this.logsTailCache.keys().next().value;
+      if (oldest !== undefined) this.logsTailCache.delete(oldest);
+    }
+    this.logsTailCache.set(key, { expiresAt: Date.now() + AI_APPS_LOGS_DESC_CACHE_TTL_MS, events });
   }
 
   /**

--- a/apps/web-api/tsconfig.spec.json
+++ b/apps/web-api/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "multer"]
   },
   "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary

Adds `order=desc` to the member log routes (`GET /v1/ai-apps/:uid/build-logs` and `/runtime-logs`) so the dashboard's deployment-logs modal can show the **latest lines first** and page **backward into history** — the UX the frontend needs (frontend PR: memser-spaceport/pln-directory-portal-v2#2685).

The runner (CloudWatch behind it) only pages forward from the window start, so the newest-first view is assembled here:

- **Tail walk**: walk the runner's forward pages server-side, retaining only the newest 5,000 lines (bounded: 30 runner calls / 20s per walk; forward trimming is safe because the walk is chronological).
- **Window narrowing**: if a window is too chatty to walk within budget, retry with the window ÷4 then ÷16 — the tail survives narrowing since it's the end of any window that reaches "now". Only after that: 502 with a narrow-your-window message.
- **Backward paging**: an opaque base64url cursor `{offset-from-newest, window}` — each "earlier" page slices deeper into the retained tail; the pinned window keeps pages consistent (and cache-hitting).
- **Per-instance cache** (15s TTL, 30 entries) so a reader scrolling through history doesn't re-walk the runner per page.
- **Allowlisted response**: desc responses are `{events, nextToken}` only, with timestamps normalized to numeric epoch-ms (the runner has been observed sending strings — the FE currently works around this; worth fixing at the runner too).

`order` defaults to `asc` (verbatim runner passthrough, unchanged); unknown values 400. Agent routes untouched.

Also: adds `multer` to `apps/web-api/tsconfig.spec.json` types — specs importing the controller failed to compile locally without it (`Express.Multer` augmentation never loaded).

## Testing

- 8 new spec cases: newest-first assembly across forward pages with string-timestamp normalization, backward cursor paging served from one cached walk, malformed-cursor 400, window narrowing, 502 when even narrowed walks can't finish, non-owner 403, and controller `order` routing/validation.
- Full ai-apps suite: 80 tests pass.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)