### PR TITLE
perf(ai-apps): coalesce and serve-stale the order=desc log walks

### DIFF
--- a/apps/web-api/src/ai-apps/ai-apps-logs.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-logs.spec.ts
@@ -200,6 +200,109 @@ describe('AiAppsService.getMemberLogsDesc', () => {
     expect(mockedAxios.get).toHaveBeenCalledTimes(1);
   });
 
+  it('coalesces concurrent cold reads into one runner walk', async () => {
+    const service = buildService();
+    let release!: (value: unknown) => void;
+    mockedAxios.get.mockReturnValue(new Promise((resolve) => (release = resolve)) as any);
+
+    const first = service.getMemberLogsDesc('creator-1', 'app-1', 'runtime', { limit: 5, sinceMinutes: 60 });
+    const second = service.getMemberLogsDesc('creator-1', 'app-1', 'runtime', { limit: 5, sinceMinutes: 60 });
+    // Let both requests get past the access checks and reach the walk.
+    await new Promise((resolve) => setImmediate(resolve));
+    release({ status: 200, data: { events: [{ timestamp: 1, message: 'only' }] } });
+
+    const [r1, r2] = await Promise.all([first, second]);
+    expect(r1.events.map((e) => e.message)).toEqual(['only']);
+    expect(r2.events.map((e) => e.message)).toEqual(['only']);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a stale walk instantly and revalidates in the background', async () => {
+    const service = buildService();
+    let now = 1_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      mockedAxios.get.mockResolvedValue({ status: 200, data: { events: [{ timestamp: 1, message: 'v1' }] } });
+      const p1 = await service.getMemberLogsDesc('creator-1', 'app-1', 'runtime', { limit: 5, sinceMinutes: 60 });
+      expect(p1.events.map((e) => e.message)).toEqual(['v1']);
+
+      // Past the 15s fresh TTL, inside the 2min stale bound.
+      now += 16_000;
+      mockedAxios.get.mockResolvedValue({ status: 200, data: { events: [{ timestamp: 2, message: 'v2' }] } });
+      const p2 = await service.getMemberLogsDesc('creator-1', 'app-1', 'runtime', { limit: 5, sinceMinutes: 60 });
+      // The stale copy answers instantly…
+      expect(p2.events.map((e) => e.message)).toEqual(['v1']);
+      // …while one background walk revalidates the cache.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+
+      const p3 = await service.getMemberLogsDesc('creator-1', 'app-1', 'runtime', { limit: 5, sinceMinutes: 60 });
+      expect(p3.events.map((e) => e.message)).toEqual(['v2']);
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('re-walks cold once the stale bound passes', async () => {
+    const service = buildService();
+    let now = 1_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      mockedAxios.get.mockResolvedValue({ status: 200, data: { events: [{ timestamp: 1, message: 'v1' }] } });
+      await service.getMemberLogsDesc('creator-1', 'app-1', 'runtime', { limit: 5, sinceMinutes: 60 });
+
+      now += 121_000;
+      mockedAxios.get.mockResolvedValue({ status: 200, data: { events: [{ timestamp: 2, message: 'v2' }] } });
+      const result = await service.getMemberLogsDesc('creator-1', 'app-1', 'runtime', { limit: 5, sinceMinutes: 60 });
+      // Evicted — the read blocks on a fresh walk instead of serving the old copy.
+      expect(result.events.map((e) => e.message)).toEqual(['v2']);
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('a deploy drops cached walks so serve-stale never spans deployments', async () => {
+    const service = buildService();
+    mockedAxios.get.mockResolvedValue({ status: 200, data: { events: [{ timestamp: 1, message: 'pre' }] } });
+    await service.getMemberLogsDesc('creator-1', 'app-1', 'build', { limit: 5 });
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+
+    (service as any).dropLogsTailCache('demo');
+
+    mockedAxios.get.mockResolvedValue({ status: 200, data: { events: [{ timestamp: 2, message: 'post' }] } });
+    const result = await service.getMemberLogsDesc('creator-1', 'app-1', 'build', { limit: 5 });
+    expect(result.events.map((e) => e.message)).toEqual(['post']);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('a walk that started before a deploy is served but never cached', async () => {
+    const service = buildService();
+    let now = 1_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      let release!: (value: unknown) => void;
+      mockedAxios.get.mockReturnValueOnce(new Promise((resolve) => (release = resolve)) as any);
+      const inFlight = service.getMemberLogsDesc('creator-1', 'app-1', 'build', { limit: 5 });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      now += 1_000;
+      (service as any).dropLogsTailCache('demo');
+      release({ status: 200, data: { events: [{ timestamp: 1, message: 'pre-deploy' }] } });
+      const result = await inFlight;
+      expect(result.events.map((e) => e.message)).toEqual(['pre-deploy']);
+
+      // The pre-deploy walk must not have been cached: the next read walks fresh.
+      mockedAxios.get.mockResolvedValue({ status: 200, data: { events: [{ timestamp: 2, message: 'post-deploy' }] } });
+      const next = await service.getMemberLogsDesc('creator-1', 'app-1', 'build', { limit: 5 });
+      expect(next.events.map((e) => e.message)).toEqual(['post-deploy']);
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it('400s on a malformed desc cursor', async () => {
     await expect(
       buildService().getMemberLogsDesc('creator-1', 'app-1', 'build', { nextToken: 'not-a-cursor' })

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -157,9 +157,15 @@ export const AI_APPS_LOGS_DESC_DEFAULT_LIMIT = 500;
 export const AI_APPS_LOGS_DESC_MAX_LIMIT = 2000;
 /**
  * Completed walks are cached per instance so a reader scrolling through
- * history doesn't re-walk the runner for every page. Short TTL — logs move.
+ * history doesn't re-walk the runner for every page. An entry is FRESH for the
+ * short TTL (logs move), then serve-stale up to the stale bound: a stale read
+ * answers instantly from the cached walk while ONE background walk revalidates
+ * — so the multi-second cold walk is paid once per window, not on every modal
+ * open. Deploys drop the app's entries (see dropLogsTailCache) so a stale copy
+ * never outlives the deployment it captured.
  */
 export const AI_APPS_LOGS_DESC_CACHE_TTL_MS = 15_000;
+export const AI_APPS_LOGS_DESC_CACHE_STALE_TTL_MS = 120_000;
 export const AI_APPS_LOGS_DESC_CACHE_MAX_ENTRIES = 30;
 
 /** Build the S3 key for an app bundle: apps/<appId>/<deploymentId>/app.zip */

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -24,6 +24,7 @@ import {
   AI_APPS_HELM_LOCK_RETRIES,
   AI_APPS_HELM_LOCK_RETRY_INTERVAL_MS,
   AI_APPS_LOGS_DESC_CACHE_MAX_ENTRIES,
+  AI_APPS_LOGS_DESC_CACHE_STALE_TTL_MS,
   AI_APPS_LOGS_DESC_CACHE_TTL_MS,
   AI_APPS_LOGS_DESC_DEFAULT_LIMIT,
   AI_APPS_LOGS_DESC_MAX_LIMIT,
@@ -433,18 +434,63 @@ export class AiAppsService {
    * newest lines (ascending). `complete: false` means a bound tripped before
    * the end — the buffer then holds the OLDEST part of the window and must
    * never be served as "newest", so the caller narrows or fails.
+   *
+   * The cold walk is sequential runner→CloudWatch paging and can take many
+   * seconds even over a sparse window (empty pages still carry tokens that
+   * must be chased to the true end), so reads are cached and coalesced:
+   * - FRESH cache entry → answered from cache.
+   * - STALE-but-recent entry → ALSO answered from cache instantly, while one
+   *   background walk revalidates it (stale-while-revalidate).
+   * - miss → concurrent identical requests share a single in-flight walk
+   *   instead of each paging the runner through the same chain.
    */
-  private async walkRunnerLogsTail(
+  private walkRunnerLogsTail(
     app: Pick<AiApp, 'appId'>,
     phase: AiAppLogPhase,
     sinceMinutes: number | undefined
   ): Promise<{ events: { timestamp: number; message: string }[]; complete: boolean }> {
     const cacheKey = `${app.appId}:${phase}:${sinceMinutes ?? 'all'}`;
-    const cached = this.readLogsTailCache(cacheKey);
-    if (cached) {
-      return { events: cached, complete: true };
+    const entry = this.logsTailCache.get(cacheKey);
+    const now = Date.now();
+    if (entry && entry.evictAt <= now) {
+      this.logsTailCache.delete(cacheKey);
+    } else if (entry) {
+      if (entry.staleAt <= now) {
+        // Revalidation failure only logs — the stale copy stays valid until
+        // evictAt, and the read after that pays the cold walk (and its error).
+        this.startLogsTailWalk(app, phase, sinceMinutes, cacheKey).catch((error) => {
+          this.logger.warn(
+            `Background ${phase}-logs revalidation failed for ${app.appId}: ${(error as Error).message}`
+          );
+        });
+      }
+      return Promise.resolve({ events: entry.events, complete: true });
     }
+    return this.startLogsTailWalk(app, phase, sinceMinutes, cacheKey);
+  }
 
+  /** One walk per key at a time: concurrent identical requests await the same promise. */
+  private startLogsTailWalk(
+    app: Pick<AiApp, 'appId'>,
+    phase: AiAppLogPhase,
+    sinceMinutes: number | undefined,
+    cacheKey: string
+  ): Promise<{ events: { timestamp: number; message: string }[]; complete: boolean }> {
+    const inFlight = this.logsTailWalks.get(cacheKey);
+    if (inFlight) return inFlight;
+    const walk = this.runLogsTailWalk(app, phase, sinceMinutes, cacheKey).finally(() => {
+      this.logsTailWalks.delete(cacheKey);
+    });
+    this.logsTailWalks.set(cacheKey, walk);
+    return walk;
+  }
+
+  private async runLogsTailWalk(
+    app: Pick<AiApp, 'appId'>,
+    phase: AiAppLogPhase,
+    sinceMinutes: number | undefined,
+    cacheKey: string
+  ): Promise<{ events: { timestamp: number; message: string }[]; complete: boolean }> {
     const startedAt = Date.now();
     let token: string | undefined;
     let buffer: { timestamp: number; message: string }[] = [];
@@ -474,7 +520,7 @@ export class AiAppsService {
       if (!next || next === token) {
         buffer.sort((a, b) => a.timestamp - b.timestamp);
         const events = buffer.slice(-AI_APPS_LOGS_DESC_RETAIN);
-        this.writeLogsTailCache(cacheKey, events);
+        this.writeLogsTailCache(cacheKey, app.appId, startedAt, events);
         return { events, complete: true };
       }
       token = next;
@@ -522,26 +568,51 @@ export class AiAppsService {
   /** Per-instance cache of completed tail walks, so scrolling history doesn't re-walk the runner per page. */
   private readonly logsTailCache = new Map<
     string,
-    { expiresAt: number; events: { timestamp: number; message: string }[] }
+    { staleAt: number; evictAt: number; events: { timestamp: number; message: string }[] }
   >();
 
-  private readLogsTailCache(key: string): { timestamp: number; message: string }[] | null {
-    const entry = this.logsTailCache.get(key);
-    if (!entry) return null;
-    if (entry.expiresAt < Date.now()) {
-      this.logsTailCache.delete(key);
-      return null;
-    }
-    return entry.events;
-  }
+  /** In-flight walks by cache key — concurrent identical requests share one runner walk. */
+  private readonly logsTailWalks = new Map<
+    string,
+    Promise<{ events: { timestamp: number; message: string }[]; complete: boolean }>
+  >();
 
-  private writeLogsTailCache(key: string, events: { timestamp: number; message: string }[]): void {
-    if (this.logsTailCache.size >= AI_APPS_LOGS_DESC_CACHE_MAX_ENTRIES) {
+  /** When each app's walks were last invalidated by a deploy — see writeLogsTailCache. */
+  private readonly logsTailDroppedAt = new Map<string, number>();
+
+  private writeLogsTailCache(
+    key: string,
+    appId: string,
+    walkStartedAt: number,
+    events: { timestamp: number; message: string }[]
+  ): void {
+    // A walk that began before the app's last deploy captured the PREVIOUS
+    // deployment's stream — never cache it (returning it once is fine; the
+    // next read re-walks fresh).
+    if ((this.logsTailDroppedAt.get(appId) ?? 0) > walkStartedAt) return;
+    if (!this.logsTailCache.has(key) && this.logsTailCache.size >= AI_APPS_LOGS_DESC_CACHE_MAX_ENTRIES) {
       // Maps iterate in insertion order — dropping the first key is a cheap FIFO.
       const oldest = this.logsTailCache.keys().next().value;
       if (oldest !== undefined) this.logsTailCache.delete(oldest);
     }
-    this.logsTailCache.set(key, { expiresAt: Date.now() + AI_APPS_LOGS_DESC_CACHE_TTL_MS, events });
+    const now = Date.now();
+    this.logsTailCache.set(key, {
+      staleAt: now + AI_APPS_LOGS_DESC_CACHE_TTL_MS,
+      evictAt: now + AI_APPS_LOGS_DESC_CACHE_STALE_TTL_MS,
+      events,
+    });
+  }
+
+  /**
+   * A new deploy invalidates every cached walk for the app — serve-stale must
+   * never show the previous deployment's lines to someone watching the new one.
+   */
+  private dropLogsTailCache(appId: string): void {
+    this.logsTailDroppedAt.set(appId, Date.now());
+    const prefix = `${appId}:`;
+    for (const key of this.logsTailCache.keys()) {
+      if (key.startsWith(prefix)) this.logsTailCache.delete(key);
+    }
   }
 
   /**
@@ -980,6 +1051,7 @@ export class AiAppsService {
       where: { uid: app.uid },
       data: { status: 'DEPLOYING', deploymentId, s3Key, url, httpUrl, host, notes: null },
     });
+    this.dropLogsTailCache(app.appId);
 
     const eventContext = { appUid: app.uid, appId: app.appId, deploymentId };
 


### PR DESCRIPTION
## Problem

`GET /v1/ai-apps/:uid/{build,runtime}-logs?order=desc` (shipped in #3284) is slow — the dashboard's logs modal routinely waits multiple seconds for page 1, even for an app with **zero** runtime lines.

The cost is structural: the runner (and CloudWatch behind it) only pages **forward**, so the newest-first view is assembled by walking the runner's pages to the true end of the stream before responding — sequential `web-api → runner → CloudWatch` round-trips, and CloudWatch returns empty pages that still carry `nextToken` over sparse windows, each costing a full hop. The walk cache was 15s per instance, so **every modal open after 15s paid the full cold walk again**, and concurrent identical requests each walked the same chain independently.

## Fix (web-api side)

1. **Coalesce concurrent walks** — identical in-flight reads (same app/phase/window) now share one runner walk instead of each paging through the same chain.
2. **Stale-while-revalidate** — a cache entry stays *fresh* for 15s as before; after that, a stale copy (bounded at 2 minutes) answers **instantly** while a single background walk refreshes the cache. The multi-second cold walk is paid once per window, not on every modal open.
3. **Deploy invalidation** — `proxyDeploy` drops the app's cached walks the moment an app flips to DEPLOYING, and walks that *started* before the deploy are served but never cached — serve-stale can never show the previous deployment's lines to someone watching a new deploy.

No API contract change: same routes, params, envelope, and cursor semantics.

## What this does NOT fix

The **first** (cold) walk is still bounded by the runner's forward-only paging. The real fix is upstream in the runner: CloudWatch `GetLogEvents` supports `startFromHead=false` (native newest-first reads from the tail), which would remove the walk entirely. Filed here as a follow-up ask for the runner team.

## Testing

- 5 new tests in `ai-apps-logs.spec.ts`: coalescing (one walk for concurrent reads), serve-stale + background revalidation, eviction after the stale bound, deploy drop, and the started-before-deploy cache guard
- Full ai-apps sweep green: 8 suites / 85 tests
- `typecheck:api` introduces no new errors (pre-existing failures in warm-intros-v2/prisma are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
