### PR TITLE
LAB-2175 [Team News] Support forum posts and feed-only comments in the newsfeed

### DIFF
--- a/apps/web-api/prisma/migrations/20260727120000_add_feed_comments_and_forum_likes/migration.sql
+++ b/apps/web-api/prisma/migrations/20260727120000_add_feed_comments_and_forum_likes/migration.sql
@@ -1,0 +1,54 @@
+-- CreateEnum
+CREATE TYPE "FeedItemType" AS ENUM ('NEWS', 'FORUM_POST');
+
+-- CreateTable
+CREATE TABLE "FeedComment" (
+    "id" SERIAL NOT NULL,
+    "uid" TEXT NOT NULL,
+    "itemType" "FeedItemType" NOT NULL,
+    "itemUid" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "authorUid" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FeedComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FeedForumPostLike" (
+    "id" SERIAL NOT NULL,
+    "uid" TEXT NOT NULL,
+    "forumPostUid" TEXT NOT NULL,
+    "memberUid" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FeedForumPostLike_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FeedComment_uid_key" ON "FeedComment"("uid");
+
+-- CreateIndex
+CREATE INDEX "FeedComment_itemType_itemUid_createdAt_idx" ON "FeedComment"("itemType", "itemUid", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "FeedComment_authorUid_idx" ON "FeedComment"("authorUid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FeedForumPostLike_uid_key" ON "FeedForumPostLike"("uid");
+
+-- CreateIndex
+CREATE INDEX "FeedForumPostLike_forumPostUid_idx" ON "FeedForumPostLike"("forumPostUid");
+
+-- CreateIndex
+CREATE INDEX "FeedForumPostLike_memberUid_idx" ON "FeedForumPostLike"("memberUid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FeedForumPostLike_forumPostUid_memberUid_key" ON "FeedForumPostLike"("forumPostUid", "memberUid");
+
+-- AddForeignKey
+ALTER TABLE "FeedComment" ADD CONSTRAINT "FeedComment_authorUid_fkey" FOREIGN KEY ("authorUid") REFERENCES "Member"("uid") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeedForumPostLike" ADD CONSTRAINT "FeedForumPostLike_memberUid_fkey" FOREIGN KEY ("memberUid") REFERENCES "Member"("uid") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -247,6 +247,8 @@ model Member {
   roadmapObjectivesCreated  RoadmapObjective[]      @relation("roadmapObjectiveCreatedBy")
   roadmapSubmissionDraft    RoadmapSubmissionDraft? @relation("roadmapSubmissionDraftOwner")
   teamNewsUpvotes           TeamNewsUpvote[]        @relation("MemberTeamNewsUpvotes")
+  feedComments              FeedComment[]           @relation("MemberFeedComments")
+  feedForumPostLikes        FeedForumPostLike[]     @relation("MemberFeedForumPostLikes")
 
   /// Read-only Affinity CRM sidecar (task 02). Optional 1:1 when linked.
   affinityPerson               AffinityPerson?
@@ -2338,6 +2340,50 @@ model TeamNewsForumLink {
 
   @@unique([newsItemUid, forumTopicId])
   @@index([newsItemUid])
+}
+
+enum FeedItemType {
+  NEWS
+  FORUM_POST
+}
+
+/// Feed-only comment on a TeamNewsItem or a NodeBB-backed forum-post feed
+/// item. Never synced to NodeBB even for FORUM_POST — these are unrelated
+/// to NodeBB's own reply system. itemUid is a soft reference (news uid or
+/// `fp_<tid>`), not a hard FK, since it can point at two different source
+/// types. itemType is redundant with the `fp_` prefix but kept explicit for
+/// query clarity/indexing, matching Follow.entityType. authorUid IS a hard
+/// FK since the author is always a real directory member.
+model FeedComment {
+  id        Int          @id @default(autoincrement())
+  uid       String       @unique @default(cuid())
+  itemType  FeedItemType
+  itemUid   String
+  text      String
+  authorUid String
+  author    Member       @relation("MemberFeedComments", fields: [authorUid], references: [uid], onDelete: Cascade)
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+
+  @@index([itemType, itemUid, createdAt])
+  @@index([authorUid])
+}
+
+/// Directory-portal-native like on a forum-post feed item — NOT a proxy for
+/// NodeBB's own upvote/downvote (NodeBB has no native "like"). forumPostUid
+/// is a soft reference (`fp_<tid>`, no local table for forum posts).
+/// memberUid IS a hard FK since the liker is always a real directory member.
+model FeedForumPostLike {
+  id           Int      @id @default(autoincrement())
+  uid          String   @unique @default(cuid())
+  forumPostUid String
+  memberUid    String
+  member       Member   @relation("MemberFeedForumPostLikes", fields: [memberUid], references: [uid], onDelete: Cascade)
+  createdAt    DateTime @default(now())
+
+  @@unique([forumPostUid, memberUid])
+  @@index([forumPostUid])
+  @@index([memberUid])
 }
 
 model TeamNewsEnrichment {

--- a/apps/web-api/src/app.module.ts
+++ b/apps/web-api/src/app.module.ts
@@ -71,6 +71,7 @@ import { ArticleRequestsModule } from './article-requests/article-requests.modul
 import { JobOpeningsModule } from './job-openings/job-openings.module';
 import { JobAlertsModule } from './job-alerts/job-alerts.module';
 import { TeamNewsModule } from './team-news/team-news.module';
+import { FeedModule } from './feed/feed.module';
 import { FollowsModule } from './follows/follows.module';
 import { InvestorOutreachModule } from './investor-outreach/investor-outreach.module';
 import { PathfinderModule } from './pathfinder/pathfinder.module';
@@ -172,6 +173,7 @@ import { AiAppsModule } from './ai-apps/ai-apps.module';
     JobOpeningsModule,
     JobAlertsModule,
     TeamNewsModule,
+    FeedModule,
     FollowsModule,
     InvestorOutreachModule,
     PathfinderModule,

--- a/apps/web-api/src/feed/feed-comments.service.spec.ts
+++ b/apps/web-api/src/feed/feed-comments.service.spec.ts
@@ -1,0 +1,155 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../shared/prisma.service';
+import { FeedCommentsService } from './feed-comments.service';
+
+describe('FeedCommentsService', () => {
+  let service: FeedCommentsService;
+
+  const teamNewsItemFindUnique = jest.fn();
+  const feedCommentFindMany = jest.fn();
+  const feedCommentFindUnique = jest.fn();
+  const feedCommentCreate = jest.fn();
+  const feedCommentDelete = jest.fn();
+  const feedCommentGroupBy = jest.fn();
+
+  const prismaMock = {
+    teamNewsItem: { findUnique: teamNewsItemFindUnique },
+    feedComment: {
+      findMany: feedCommentFindMany,
+      findUnique: feedCommentFindUnique,
+      create: feedCommentCreate,
+      delete: feedCommentDelete,
+      groupBy: feedCommentGroupBy,
+    },
+  } as unknown as PrismaService;
+
+  const authorInclude = { uid: 'author-1', name: 'Ada Lovelace', image: { url: 'https://img/ada.png' } };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    teamNewsItemFindUnique.mockResolvedValue({ uid: 'news-1' });
+    service = new FeedCommentsService(prismaMock);
+  });
+
+  describe('createComment', () => {
+    it('rejects a comment on a missing news item', async () => {
+      teamNewsItemFindUnique.mockResolvedValue(null);
+
+      await expect(service.createComment('author-1', { itemUid: 'news-missing', text: 'hi' })).rejects.toBeInstanceOf(
+        NotFoundException
+      );
+      expect(feedCommentCreate).not.toHaveBeenCalled();
+    });
+
+    it('creates a NEWS comment when itemUid does not start with fp_', async () => {
+      feedCommentCreate.mockResolvedValue({
+        uid: 'c1',
+        itemUid: 'news-1',
+        text: 'hi',
+        authorUid: 'author-1',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        author: authorInclude,
+      });
+
+      const result = await service.createComment('author-1', { itemUid: 'news-1', text: 'hi' });
+
+      expect(feedCommentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { itemType: 'NEWS', itemUid: 'news-1', text: 'hi', authorUid: 'author-1' } })
+      );
+      expect(result).toEqual({
+        uid: 'c1',
+        itemUid: 'news-1',
+        text: 'hi',
+        author: { uid: 'author-1', name: 'Ada Lovelace', avatarUrl: 'https://img/ada.png' },
+        createdAt: '2026-01-01T00:00:00.000Z',
+        isOwn: true,
+      });
+    });
+
+    it('creates a FORUM_POST comment without validating a local news item', async () => {
+      feedCommentCreate.mockResolvedValue({
+        uid: 'c2',
+        itemUid: 'fp_42',
+        text: 'nice post',
+        authorUid: 'author-1',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        author: authorInclude,
+      });
+
+      await service.createComment('author-1', { itemUid: 'fp_42', text: 'nice post' });
+
+      expect(teamNewsItemFindUnique).not.toHaveBeenCalled();
+      expect(feedCommentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { itemType: 'FORUM_POST', itemUid: 'fp_42', text: 'nice post', authorUid: 'author-1' },
+        })
+      );
+    });
+  });
+
+  describe('listComments', () => {
+    it('marks isOwn only for the viewer’s own comments', async () => {
+      feedCommentFindMany.mockResolvedValue([
+        {
+          uid: 'c1',
+          itemUid: 'fp_42',
+          text: 'mine',
+          authorUid: 'author-1',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          author: authorInclude,
+        },
+        {
+          uid: 'c2',
+          itemUid: 'fp_42',
+          text: 'someone else',
+          authorUid: 'author-2',
+          createdAt: new Date('2026-01-02T00:00:00.000Z'),
+          author: { uid: 'author-2', name: 'Bob', image: null },
+        },
+      ]);
+
+      const result = await service.listComments('fp_42', 'author-1');
+
+      expect(result.items[0].isOwn).toBe(true);
+      expect(result.items[1].isOwn).toBe(false);
+      expect(result.items[1].author.avatarUrl).toBeNull();
+    });
+  });
+
+  describe('deleteComment', () => {
+    it('throws NotFound when the comment does not exist', async () => {
+      feedCommentFindUnique.mockResolvedValue(null);
+
+      await expect(service.deleteComment('author-1', 'missing')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws Forbidden when a non-author tries to delete', async () => {
+      feedCommentFindUnique.mockResolvedValue({ uid: 'c1', authorUid: 'author-1' });
+
+      await expect(service.deleteComment('author-2', 'c1')).rejects.toBeInstanceOf(ForbiddenException);
+      expect(feedCommentDelete).not.toHaveBeenCalled();
+    });
+
+    it('deletes when the caller is the author', async () => {
+      feedCommentFindUnique.mockResolvedValue({ uid: 'c1', authorUid: 'author-1' });
+      feedCommentDelete.mockResolvedValue({});
+
+      const result = await service.deleteComment('author-1', 'c1');
+
+      expect(feedCommentDelete).toHaveBeenCalledWith({ where: { uid: 'c1' } });
+      expect(result).toEqual({ uid: 'c1', deleted: true });
+    });
+  });
+
+  describe('getCommentCounts / loadCommentCounts', () => {
+    it('returns 0 for uids with no comments and defaults empty input to an empty map', async () => {
+      expect(await service.loadCommentCounts([])).toEqual(new Map());
+      expect(feedCommentGroupBy).not.toHaveBeenCalled();
+
+      feedCommentGroupBy.mockResolvedValue([{ itemUid: 'fp_1', _count: { _all: 3 } }]);
+      const result = await service.getCommentCounts(['fp_1', 'fp_2']);
+
+      expect(result).toEqual({ counts: { fp_1: 3 } });
+    });
+  });
+});

--- a/apps/web-api/src/feed/feed-comments.service.ts
+++ b/apps/web-api/src/feed/feed-comments.service.ts
@@ -1,0 +1,113 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import type {
+  CreateFeedCommentRequest,
+  FeedComment,
+  FeedCommentCountsResponse,
+  FeedCommentsResponse,
+  DeleteFeedCommentResponse,
+} from 'libs/contracts/src/schema/feed';
+import { PrismaService } from '../shared/prisma.service';
+
+const FORUM_POST_PREFIX = 'fp_';
+
+@Injectable()
+export class FeedCommentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Batch comment counts for a list of feed item uids (news items or forum posts). */
+  async getCommentCounts(uids: string[]): Promise<FeedCommentCountsResponse> {
+    const counts = await this.loadCommentCounts(uids);
+    return { counts: Object.fromEntries(counts) };
+  }
+
+  async listComments(itemUid: string, viewerMemberUid?: string): Promise<FeedCommentsResponse> {
+    const comments = await this.prisma.feedComment.findMany({
+      where: { itemUid },
+      orderBy: { createdAt: 'asc' },
+      include: {
+        author: {
+          select: { uid: true, name: true, image: { select: { url: true } } },
+        },
+      },
+    });
+
+    return {
+      items: comments.map((comment) => this.toDto(comment, viewerMemberUid)),
+    };
+  }
+
+  async createComment(memberUid: string, request: CreateFeedCommentRequest): Promise<FeedComment> {
+    const { itemUid, text } = request;
+    const itemType = itemUid.startsWith(FORUM_POST_PREFIX) ? 'FORUM_POST' : 'NEWS';
+
+    if (itemType === 'NEWS') {
+      const newsItem = await this.prisma.teamNewsItem.findUnique({ where: { uid: itemUid }, select: { uid: true } });
+      if (!newsItem) {
+        throw new NotFoundException(`News item with uid ${itemUid} not found`);
+      }
+    }
+    // FORUM_POST uids are a soft reference to NodeBB-backed feed items with no
+    // local table, so there's nothing to validate against locally (mirrors
+    // FeedForumPostLike's soft-reference design).
+
+    const comment = await this.prisma.feedComment.create({
+      data: { itemType, itemUid, text, authorUid: memberUid },
+      include: {
+        author: {
+          select: { uid: true, name: true, image: { select: { url: true } } },
+        },
+      },
+    });
+
+    return this.toDto(comment, memberUid);
+  }
+
+  async deleteComment(memberUid: string, commentUid: string): Promise<DeleteFeedCommentResponse> {
+    const comment = await this.prisma.feedComment.findUnique({ where: { uid: commentUid } });
+    if (!comment) {
+      throw new NotFoundException(`Comment with uid ${commentUid} not found`);
+    }
+    if (comment.authorUid !== memberUid) {
+      throw new ForbiddenException('You can only delete your own comment');
+    }
+
+    await this.prisma.feedComment.delete({ where: { uid: commentUid } });
+    return { uid: commentUid, deleted: true };
+  }
+
+  /** Same groupBy-by-item-uid batching pattern as TeamNewsQueryService.loadUpvotes. */
+  async loadCommentCounts(uids: string[]): Promise<Map<string, number>> {
+    if (uids.length === 0) return new Map();
+    const grouped = await this.prisma.feedComment.groupBy({
+      by: ['itemUid'],
+      where: { itemUid: { in: uids } },
+      _count: { _all: true },
+    });
+    return new Map(grouped.map((g) => [g.itemUid, g._count._all]));
+  }
+
+  private toDto(
+    comment: {
+      uid: string;
+      itemUid: string;
+      text: string;
+      authorUid: string;
+      createdAt: Date;
+      author: { uid: string; name: string; image: { url: string } | null };
+    },
+    viewerMemberUid?: string
+  ): FeedComment {
+    return {
+      uid: comment.uid,
+      itemUid: comment.itemUid,
+      text: comment.text,
+      author: {
+        uid: comment.author.uid,
+        name: comment.author.name ?? null,
+        avatarUrl: comment.author.image?.url ?? null,
+      },
+      createdAt: comment.createdAt.toISOString(),
+      isOwn: comment.authorUid === viewerMemberUid,
+    };
+  }
+}

--- a/apps/web-api/src/feed/feed-forum-posts.service.spec.ts
+++ b/apps/web-api/src/feed/feed-forum-posts.service.spec.ts
@@ -52,7 +52,6 @@ describe('FeedForumPostsService', () => {
       title: 'Hello & welcome',
       body: 'Body one Body two',
       author: topic.author,
-      focusAreas: ['General'],
       category: 'General',
       createdAt: new Date(1700000000000).toISOString(),
       forumTopicUrl: topic.forumTopicUrl,

--- a/apps/web-api/src/feed/feed-forum-posts.service.spec.ts
+++ b/apps/web-api/src/feed/feed-forum-posts.service.spec.ts
@@ -1,0 +1,78 @@
+import { PrismaService } from '../shared/prisma.service';
+import type { ProtosphereApiClient } from '../forum/protosphere-api.client';
+import { FeedCommentsService } from './feed-comments.service';
+import { FeedForumPostsService } from './feed-forum-posts.service';
+
+// protosphere-api.client.ts imports axios, which ships an ESM build jest
+// can't transform — mock the whole module so it's never actually loaded,
+// same workaround used elsewhere in this repo (e.g. team-news.service.spec.ts).
+jest.mock('../forum/protosphere-api.client', () => ({}));
+
+describe('FeedForumPostsService', () => {
+  let service: FeedForumPostsService;
+
+  const getRecentTopics = jest.fn();
+  const feedForumPostLikeGroupBy = jest.fn();
+  const feedForumPostLikeFindMany = jest.fn();
+  const loadCommentCounts = jest.fn();
+
+  const protosphereApiClientMock = { getRecentTopics } as unknown as ProtosphereApiClient;
+  const prismaMock = {
+    feedForumPostLike: { groupBy: feedForumPostLikeGroupBy, findMany: feedForumPostLikeFindMany },
+  } as unknown as PrismaService;
+  const feedCommentsServiceMock = { loadCommentCounts } as unknown as FeedCommentsService;
+
+  const topic = {
+    tid: 42,
+    cid: 7,
+    categoryName: 'General',
+    title: '<b>Hello</b> &amp; welcome',
+    timestamp: 1700000000000,
+    postcount: 3,
+    bodyHtml: '<p>Body one</p><p>Body two</p>',
+    author: { memberUid: 'member-9', name: 'Ada', avatarUrl: null, role: 'Contributor' },
+    forumTopicUrl: 'https://plnetwork.io/forum/topics/7/42',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getRecentTopics.mockResolvedValue([topic]);
+    feedForumPostLikeGroupBy.mockResolvedValue([{ forumPostUid: 'fp_42', _count: { _all: 5 } }]);
+    feedForumPostLikeFindMany.mockResolvedValue([{ forumPostUid: 'fp_42' }]);
+    loadCommentCounts.mockResolvedValue(new Map([['fp_42', 2]]));
+    service = new FeedForumPostsService(protosphereApiClientMock, prismaMock, feedCommentsServiceMock);
+  });
+
+  it('maps a NodeBB topic to a feed forum post with fp_-prefixed uid and stripped html', async () => {
+    const result = await service.listForumPosts({ limit: 20, page: 0 }, 'member-viewer');
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual({
+      uid: 'fp_42',
+      title: 'Hello & welcome',
+      body: 'Body one Body two',
+      author: topic.author,
+      focusAreas: ['General'],
+      category: 'General',
+      createdAt: new Date(1700000000000).toISOString(),
+      forumTopicUrl: topic.forumTopicUrl,
+      commentCount: 2,
+      likeCount: 5,
+      viewerHasLiked: true,
+    });
+  });
+
+  it('slices results to the requested limit before enrichment', async () => {
+    getRecentTopics.mockResolvedValue([topic, { ...topic, tid: 43 }, { ...topic, tid: 44 }]);
+
+    const result = await service.listForumPosts({ limit: 2, page: 0 });
+
+    expect(result.items).toHaveLength(2);
+  });
+
+  it('returns viewerHasLiked false and skips the viewer query when there is no viewer', async () => {
+    await service.listForumPosts({ limit: 20, page: 0 });
+
+    expect(feedForumPostLikeFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-api/src/feed/feed-forum-posts.service.ts
+++ b/apps/web-api/src/feed/feed-forum-posts.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+import type { FeedForumPost, FeedForumPostsQuery, FeedForumPostsResponse } from 'libs/contracts/src/schema/feed';
+import { NodeBBRecentTopic, ProtosphereApiClient } from '../forum/protosphere-api.client';
+import { stripHtmlToPlainText } from '../utils/html-to-text';
+import { PrismaService } from '../shared/prisma.service';
+import { FeedCommentsService } from './feed-comments.service';
+
+const FORUM_POST_PREFIX = 'fp_';
+
+interface LikeStamp {
+  counts: Map<string, number>;
+  viewerLiked: Set<string>;
+}
+
+@Injectable()
+export class FeedForumPostsService {
+  constructor(
+    private readonly protosphereApiClient: ProtosphereApiClient,
+    private readonly prisma: PrismaService,
+    private readonly feedCommentsService: FeedCommentsService
+  ) {}
+
+  async listForumPosts(query: FeedForumPostsQuery, viewerMemberUid?: string): Promise<FeedForumPostsResponse> {
+    const topics = await this.protosphereApiClient.getRecentTopics({ page: query.page || undefined });
+    const limited = topics.slice(0, query.limit);
+    const uids = limited.map((topic) => `${FORUM_POST_PREFIX}${topic.tid}`);
+
+    const [commentCounts, likes] = await Promise.all([
+      this.feedCommentsService.loadCommentCounts(uids),
+      this.loadLikes(uids, viewerMemberUid),
+    ]);
+
+    return {
+      items: limited.map((topic) => this.toDto(topic, commentCounts, likes)),
+    };
+  }
+
+  private toDto(topic: NodeBBRecentTopic, commentCounts: Map<string, number>, likes: LikeStamp): FeedForumPost {
+    const uid = `${FORUM_POST_PREFIX}${topic.tid}`;
+    return {
+      uid,
+      title: stripHtmlToPlainText(topic.title),
+      body: stripHtmlToPlainText(topic.bodyHtml),
+      author: topic.author,
+      focusAreas: topic.categoryName ? [topic.categoryName] : [],
+      category: topic.categoryName,
+      createdAt: new Date(topic.timestamp).toISOString(),
+      forumTopicUrl: topic.forumTopicUrl,
+      commentCount: commentCounts.get(uid) ?? 0,
+      likeCount: likes.counts.get(uid) ?? 0,
+      viewerHasLiked: likes.viewerLiked.has(uid),
+    };
+  }
+
+  /** Same groupBy + viewer-scoped findMany batching pattern as TeamNewsQueryService.loadUpvotes. */
+  private async loadLikes(uids: string[], viewerMemberUid?: string): Promise<LikeStamp> {
+    if (uids.length === 0) {
+      return { counts: new Map(), viewerLiked: new Set() };
+    }
+
+    const [grouped, viewerRows] = await Promise.all([
+      this.prisma.feedForumPostLike.groupBy({
+        by: ['forumPostUid'],
+        where: { forumPostUid: { in: uids } },
+        _count: { _all: true },
+      }),
+      viewerMemberUid
+        ? this.prisma.feedForumPostLike.findMany({
+            where: { forumPostUid: { in: uids }, memberUid: viewerMemberUid },
+            select: { forumPostUid: true },
+          })
+        : Promise.resolve([] as Array<{ forumPostUid: string }>),
+    ]);
+
+    return {
+      counts: new Map(grouped.map((g) => [g.forumPostUid, g._count._all])),
+      viewerLiked: new Set(viewerRows.map((r) => r.forumPostUid)),
+    };
+  }
+}

--- a/apps/web-api/src/feed/feed-forum-posts.service.ts
+++ b/apps/web-api/src/feed/feed-forum-posts.service.ts
@@ -42,7 +42,6 @@ export class FeedForumPostsService {
       title: stripHtmlToPlainText(topic.title),
       body: stripHtmlToPlainText(topic.bodyHtml),
       author: topic.author,
-      focusAreas: topic.categoryName ? [topic.categoryName] : [],
       category: topic.categoryName,
       createdAt: new Date(topic.timestamp).toISOString(),
       forumTopicUrl: topic.forumTopicUrl,

--- a/apps/web-api/src/feed/feed-likes.service.spec.ts
+++ b/apps/web-api/src/feed/feed-likes.service.spec.ts
@@ -1,0 +1,48 @@
+import { PrismaService } from '../shared/prisma.service';
+import { FeedLikesService } from './feed-likes.service';
+
+describe('FeedLikesService', () => {
+  let service: FeedLikesService;
+
+  const feedForumPostLikeUpsert = jest.fn();
+  const feedForumPostLikeDeleteMany = jest.fn();
+  const feedForumPostLikeCount = jest.fn();
+
+  const prismaMock = {
+    feedForumPostLike: {
+      upsert: feedForumPostLikeUpsert,
+      deleteMany: feedForumPostLikeDeleteMany,
+      count: feedForumPostLikeCount,
+    },
+  } as unknown as PrismaService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    feedForumPostLikeUpsert.mockResolvedValue({});
+    feedForumPostLikeDeleteMany.mockResolvedValue({ count: 1 });
+    feedForumPostLikeCount.mockResolvedValue(2);
+    service = new FeedLikesService(prismaMock);
+  });
+
+  it('upserts a like and returns the updated count', async () => {
+    const result = await service.like('member-1', 'fp_123');
+
+    expect(feedForumPostLikeUpsert).toHaveBeenCalledWith({
+      where: { forumPostUid_memberUid: { forumPostUid: 'fp_123', memberUid: 'member-1' } },
+      create: { forumPostUid: 'fp_123', memberUid: 'member-1' },
+      update: {},
+    });
+    expect(result).toEqual({ likeCount: 2, viewerHasLiked: true });
+  });
+
+  it('removes a like idempotently and returns viewerHasLiked false', async () => {
+    feedForumPostLikeCount.mockResolvedValue(1);
+
+    const result = await service.unlike('member-1', 'fp_123');
+
+    expect(feedForumPostLikeDeleteMany).toHaveBeenCalledWith({
+      where: { forumPostUid: 'fp_123', memberUid: 'member-1' },
+    });
+    expect(result).toEqual({ likeCount: 1, viewerHasLiked: false });
+  });
+});

--- a/apps/web-api/src/feed/feed-likes.service.ts
+++ b/apps/web-api/src/feed/feed-likes.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import type { FeedForumPostLikeStatus } from 'libs/contracts/src/schema/feed';
+import { PrismaService } from '../shared/prisma.service';
+
+@Injectable()
+export class FeedLikesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Like a forum-post feed item. Idempotent: re-liking succeeds without double-counting. */
+  async like(memberUid: string, forumPostUid: string): Promise<FeedForumPostLikeStatus> {
+    await this.prisma.feedForumPostLike.upsert({
+      where: {
+        forumPostUid_memberUid: { forumPostUid, memberUid },
+      },
+      create: { forumPostUid, memberUid },
+      update: {},
+    });
+
+    return this.buildStatus(forumPostUid, true);
+  }
+
+  /** Remove a like. Idempotent: removing when not liked succeeds. */
+  async unlike(memberUid: string, forumPostUid: string): Promise<FeedForumPostLikeStatus> {
+    await this.prisma.feedForumPostLike.deleteMany({
+      where: { forumPostUid, memberUid },
+    });
+
+    return this.buildStatus(forumPostUid, false);
+  }
+
+  private async buildStatus(forumPostUid: string, viewerHasLiked: boolean): Promise<FeedForumPostLikeStatus> {
+    const likeCount = await this.prisma.feedForumPostLike.count({ where: { forumPostUid } });
+    return { likeCount, viewerHasLiked };
+  }
+}

--- a/apps/web-api/src/feed/feed.controller.ts
+++ b/apps/web-api/src/feed/feed.controller.ts
@@ -1,0 +1,118 @@
+import { Body, Controller, ForbiddenException, Logger, Param, Req, UseGuards } from '@nestjs/common';
+import { Api, initNestServer } from '@ts-rest/nest';
+import { Request } from 'express';
+import { apiFeed } from 'libs/contracts/src/lib/contract-feed';
+import {
+  CreateFeedCommentRequestSchema,
+  FeedCommentCountsRequestSchema,
+  FeedCommentsQueryParams,
+  FeedForumPostsQueryParams,
+} from 'libs/contracts/src/schema/feed';
+import { NoCache } from '../decorators/no-cache.decorator';
+import { UserTokenCheckGuard } from '../guards/user-token-check.guard';
+import { UserTokenValidation } from '../guards/user-token-validation.guard';
+import { MembersService } from '../members/members.service';
+import { AccessControlV2Service } from '../access-control-v2/services/access-control-v2.service';
+import { FORUM_PERMISSIONS } from '../access-control-v2/access-control-v2.constants';
+import { FeedForumPostsService } from './feed-forum-posts.service';
+import { FeedCommentsService } from './feed-comments.service';
+import { FeedLikesService } from './feed-likes.service';
+
+const server = initNestServer(apiFeed);
+
+@Controller()
+export class FeedController {
+  private readonly logger = new Logger(FeedController.name);
+
+  constructor(
+    private readonly feedForumPostsService: FeedForumPostsService,
+    private readonly feedCommentsService: FeedCommentsService,
+    private readonly feedLikesService: FeedLikesService,
+    private readonly membersService: MembersService,
+    private readonly accessControl: AccessControlV2Service
+  ) {}
+
+  @Api(server.route.getFeedForumPosts)
+  @NoCache()
+  @UseGuards(UserTokenCheckGuard)
+  async getFeedForumPosts(@Req() req: Request & { userEmail?: string }) {
+    const params = FeedForumPostsQueryParams.parse(req.query);
+
+    const canReadForum = await this.hasForumReadPermission(req.userEmail);
+    if (!canReadForum) {
+      // Degrade gracefully — omit forum posts entirely rather than 403,
+      // matching search.controller.ts's handling of gated forum content.
+      return { items: [] };
+    }
+
+    const member = req.userEmail ? await this.membersService.findMemberByEmail(req.userEmail) : null;
+    return this.feedForumPostsService.listForumPosts(params, member?.uid);
+  }
+
+  @Api(server.route.getFeedCommentCounts)
+  @NoCache()
+  async getFeedCommentCounts(@Body() body: unknown) {
+    const { uids } = FeedCommentCountsRequestSchema.parse(body);
+    return this.feedCommentsService.getCommentCounts(uids);
+  }
+
+  @Api(server.route.getFeedComments)
+  @NoCache()
+  @UseGuards(UserTokenCheckGuard)
+  async getFeedComments(@Req() req: Request & { userEmail?: string }) {
+    const { itemUid } = FeedCommentsQueryParams.parse(req.query);
+    const member = req.userEmail ? await this.membersService.findMemberByEmail(req.userEmail) : null;
+    return this.feedCommentsService.listComments(itemUid, member?.uid);
+  }
+
+  @Api(server.route.createFeedComment)
+  @UseGuards(UserTokenValidation)
+  async createFeedComment(@Req() req: Request & { userEmail?: string }, @Body() body: unknown) {
+    const validated = CreateFeedCommentRequestSchema.parse(body);
+    const member = await this.resolveMember(req);
+    return this.feedCommentsService.createComment(member.uid, validated);
+  }
+
+  @Api(server.route.deleteFeedComment)
+  @UseGuards(UserTokenValidation)
+  async deleteFeedComment(@Param('commentUid') commentUid: string, @Req() req: Request & { userEmail?: string }) {
+    const member = await this.resolveMember(req);
+    return this.feedCommentsService.deleteComment(member.uid, commentUid);
+  }
+
+  @Api(server.route.likeFeedForumPost)
+  @UseGuards(UserTokenValidation)
+  async likeFeedForumPost(@Param('uid') uid: string, @Req() req: Request & { userEmail?: string }) {
+    const member = await this.resolveMember(req);
+    return this.feedLikesService.like(member.uid, uid);
+  }
+
+  @Api(server.route.unlikeFeedForumPost)
+  @UseGuards(UserTokenValidation)
+  async unlikeFeedForumPost(@Param('uid') uid: string, @Req() req: Request & { userEmail?: string }) {
+    const member = await this.resolveMember(req);
+    return this.feedLikesService.unlike(member.uid, uid);
+  }
+
+  private async hasForumReadPermission(userEmail?: string): Promise<boolean> {
+    if (!userEmail) return false;
+    try {
+      const { allowed } = await this.accessControl.hasPermissionByEmail(userEmail, FORUM_PERMISSIONS.READ);
+      return allowed;
+    } catch {
+      return false;
+    }
+  }
+
+  private async resolveMember(req: Request & { userEmail?: string }) {
+    if (!req.userEmail) {
+      throw new ForbiddenException('Authenticated member required');
+    }
+    const member = await this.membersService.findMemberByEmail(req.userEmail);
+    if (!member) {
+      this.logger.warn(`Feed request from authenticated email ${req.userEmail} that is not a member`);
+      throw new ForbiddenException('Member not found');
+    }
+    return member;
+  }
+}

--- a/apps/web-api/src/feed/feed.controller.ts
+++ b/apps/web-api/src/feed/feed.controller.ts
@@ -1,6 +1,16 @@
-import { Body, Controller, ForbiddenException, Logger, Param, Req, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  ForbiddenException,
+  Logger,
+  Param,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { Api, initNestServer } from '@ts-rest/nest';
 import { Request } from 'express';
+import { ZodError, ZodType } from 'zod';
 import { apiFeed } from 'libs/contracts/src/lib/contract-feed';
 import {
   CreateFeedCommentRequestSchema,
@@ -36,7 +46,7 @@ export class FeedController {
   @NoCache()
   @UseGuards(UserTokenCheckGuard)
   async getFeedForumPosts(@Req() req: Request & { userEmail?: string }) {
-    const params = FeedForumPostsQueryParams.parse(req.query);
+    const params = this.parse(FeedForumPostsQueryParams, req.query);
 
     const canReadForum = await this.hasForumReadPermission(req.userEmail);
     if (!canReadForum) {
@@ -52,7 +62,7 @@ export class FeedController {
   @Api(server.route.getFeedCommentCounts)
   @NoCache()
   async getFeedCommentCounts(@Body() body: unknown) {
-    const { uids } = FeedCommentCountsRequestSchema.parse(body);
+    const { uids } = this.parse(FeedCommentCountsRequestSchema, body);
     return this.feedCommentsService.getCommentCounts(uids);
   }
 
@@ -60,7 +70,7 @@ export class FeedController {
   @NoCache()
   @UseGuards(UserTokenCheckGuard)
   async getFeedComments(@Req() req: Request & { userEmail?: string }) {
-    const { itemUid } = FeedCommentsQueryParams.parse(req.query);
+    const { itemUid } = this.parse(FeedCommentsQueryParams, req.query);
     const member = req.userEmail ? await this.membersService.findMemberByEmail(req.userEmail) : null;
     return this.feedCommentsService.listComments(itemUid, member?.uid);
   }
@@ -68,7 +78,7 @@ export class FeedController {
   @Api(server.route.createFeedComment)
   @UseGuards(UserTokenValidation)
   async createFeedComment(@Req() req: Request & { userEmail?: string }, @Body() body: unknown) {
-    const validated = CreateFeedCommentRequestSchema.parse(body);
+    const validated = this.parse(CreateFeedCommentRequestSchema, body);
     const member = await this.resolveMember(req);
     return this.feedCommentsService.createComment(member.uid, validated);
   }
@@ -92,6 +102,22 @@ export class FeedController {
   async unlikeFeedForumPost(@Param('uid') uid: string, @Req() req: Request & { userEmail?: string }) {
     const member = await this.resolveMember(req);
     return this.feedLikesService.unlike(member.uid, uid);
+  }
+
+  // Schema.parse() throws a raw ZodError, which the global exception filter
+  // doesn't recognize as an HttpException — it falls through to a generic
+  // 500 instead of a 400. Route every contract-schema parse through here so
+  // invalid input (e.g. empty text, which the app-wide empty-string-to-null
+  // interceptor turns into `null` before this runs) surfaces as a proper 400.
+  private parse<T>(schema: ZodType<T, any, any>, data: unknown): T {
+    try {
+      return schema.parse(data);
+    } catch (err) {
+      if (err instanceof ZodError) {
+        throw new BadRequestException(err.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join('; '));
+      }
+      throw err;
+    }
   }
 
   private async hasForumReadPermission(userEmail?: string): Promise<boolean> {

--- a/apps/web-api/src/feed/feed.module.ts
+++ b/apps/web-api/src/feed/feed.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { SharedModule } from '../shared/shared.module';
+import { MembersModule } from '../members/members.module';
+import { AccessControlV2Module } from '../access-control-v2/access-control-v2.module';
+import { ForumModule } from '../forum/forum.module';
+import { FeedController } from './feed.controller';
+import { FeedForumPostsService } from './feed-forum-posts.service';
+import { FeedCommentsService } from './feed-comments.service';
+import { FeedLikesService } from './feed-likes.service';
+
+@Module({
+  imports: [SharedModule, MembersModule, AccessControlV2Module, ForumModule],
+  controllers: [FeedController],
+  providers: [FeedForumPostsService, FeedCommentsService, FeedLikesService],
+})
+export class FeedModule {}

--- a/apps/web-api/src/forum/protosphere-api.client.ts
+++ b/apps/web-api/src/forum/protosphere-api.client.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 export interface NodeBBTopicAuthor {
   memberUid: string | null;
@@ -22,6 +22,7 @@ export interface NodeBBRecentTopic {
 
 @Injectable()
 export class ProtosphereApiClient {
+  private readonly logger = new Logger(ProtosphereApiClient.name);
   private forumApiUrl: string;
 
   constructor() {
@@ -41,13 +42,22 @@ export class ProtosphereApiClient {
   /**
    * GET /api/recent — public, unauthenticated (NodeBB's own PUBLIC_GET_ALLOWLIST
    * carve-out), so this is a plain guest-level read, no per-caller auth needed.
+   *
+   * NodeBB being unreachable shouldn't 500 the whole newsfeed — degrade to an
+   * empty list and log a warning, same "don't error, just omit" philosophy as
+   * the forum-access gate in feed.controller.ts.
    */
   async getRecentTopics(opts: { page?: number } = {}): Promise<NodeBBRecentTopic[]> {
-    const response = await axios.get(`${this.forumApiUrl}/api/recent`, {
-      params: opts.page ? { page: opts.page } : undefined,
-    });
-    const topics = Array.isArray(response.data?.topics) ? response.data.topics : [];
-    return topics.map((topic: any) => this.mapRecentTopic(topic));
+    try {
+      const response = await axios.get(`${this.forumApiUrl}/api/recent`, {
+        params: opts.page ? { page: opts.page } : undefined,
+      });
+      const topics = Array.isArray(response.data?.topics) ? response.data.topics : [];
+      return topics.map((topic: any) => this.mapRecentTopic(topic));
+    } catch (err) {
+      this.logger.warn(`getRecentTopics: could not reach ${this.forumApiUrl}/api/recent — ${(err as Error).message}`);
+      return [];
+    }
   }
 
   private mapRecentTopic(topic: any): NodeBBRecentTopic {

--- a/apps/web-api/src/forum/protosphere-api.client.ts
+++ b/apps/web-api/src/forum/protosphere-api.client.ts
@@ -1,6 +1,25 @@
 import axios from 'axios';
 import { Injectable } from '@nestjs/common';
 
+export interface NodeBBTopicAuthor {
+  memberUid: string | null;
+  name: string;
+  avatarUrl: string | null;
+  role: string | null;
+}
+
+export interface NodeBBRecentTopic {
+  tid: number;
+  cid: number;
+  categoryName: string;
+  title: string;
+  timestamp: number;
+  postcount: number;
+  bodyHtml: string;
+  author: NodeBBTopicAuthor;
+  forumTopicUrl: string | null;
+}
+
 @Injectable()
 export class ProtosphereApiClient {
   private forumApiUrl: string;
@@ -17,5 +36,41 @@ export class ProtosphereApiClient {
     });
 
     return response.data.some((group) => group?.memberships?.length > 0);
+  }
+
+  /**
+   * GET /api/recent — public, unauthenticated (NodeBB's own PUBLIC_GET_ALLOWLIST
+   * carve-out), so this is a plain guest-level read, no per-caller auth needed.
+   */
+  async getRecentTopics(opts: { page?: number } = {}): Promise<NodeBBRecentTopic[]> {
+    const response = await axios.get(`${this.forumApiUrl}/api/recent`, {
+      params: opts.page ? { page: opts.page } : undefined,
+    });
+    const topics = Array.isArray(response.data?.topics) ? response.data.topics : [];
+    return topics.map((topic: any) => this.mapRecentTopic(topic));
+  }
+
+  private mapRecentTopic(topic: any): NodeBBRecentTopic {
+    // `topic.user` is the topic starter (real author for the feed card);
+    // `topic.teaser.user` can be a later replier's stripped-down user object
+    // and lacks memberUid/teamRole, so only `topic.user` is used for author.
+    const user = topic.user ?? {};
+    const webUiBaseUrl = process.env.WEB_UI_BASE_URL;
+    return {
+      tid: topic.tid,
+      cid: topic.cid,
+      categoryName: topic.category?.name ?? '',
+      title: topic.titleRaw ?? topic.title ?? '',
+      timestamp: Number(topic.timestamp) || Date.now(),
+      postcount: Number(topic.postcount) || 0,
+      bodyHtml: topic.teaser?.content ?? '',
+      author: {
+        memberUid: user.memberUid ?? null,
+        name: user.displayname || user.username || 'Unknown',
+        avatarUrl: user.picture ?? null,
+        role: user.teamRole ?? null,
+      },
+      forumTopicUrl: webUiBaseUrl ? `${webUiBaseUrl}/forum/topics/${topic.cid}/${topic.tid}` : null,
+    };
   }
 }

--- a/apps/web-api/src/scripts/seed-feed.ts
+++ b/apps/web-api/src/scripts/seed-feed.ts
@@ -1,0 +1,137 @@
+/**
+ * Seed test data for the newsfeed forum-posts/comments/likes feature.
+ *
+ * Forum posts themselves are never stored locally (they're a live read-through
+ * of NodeBB), so this only seeds the two directory-native tables:
+ *   - FeedComment  — a couple of comments on the most recent live NodeBB
+ *     topics (fetched from FORUM_API_URL/api/recent, as fp_<tid>) and on the
+ *     most recent TeamNewsItem rows already in this DB.
+ *   - FeedForumPostLike — a few likes on those same forum-post uids.
+ *
+ * Idempotent: skips a comment if the same (itemUid, authorUid, text) already
+ * exists; likes upsert on the (forumPostUid, memberUid) unique constraint.
+ *
+ * Run via `yarn api:seed-feed`. Requires at least 2 seeded Members and,
+ * for the forum-post half, a reachable FORUM_API_URL (falls back to
+ * news-item-only seed data with a warning if NodeBB isn't reachable).
+ */
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+import axios from 'axios';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+interface FeedTarget {
+  uid: string;
+  title: string;
+}
+
+async function fetchRecentForumPosts(count: number): Promise<FeedTarget[]> {
+  const forumApiUrl = process.env.FORUM_API_URL;
+  if (!forumApiUrl) {
+    console.warn('FORUM_API_URL not set — skipping forum-post seed data (comments/likes on fp_* uids).');
+    return [];
+  }
+  try {
+    const response = await axios.get(`${forumApiUrl}/api/recent`);
+    const topics = Array.isArray(response.data?.topics) ? response.data.topics : [];
+    return topics
+      .slice(0, count)
+      .map((t: any) => ({ uid: `fp_${t.tid}`, title: t.titleRaw ?? t.title ?? `topic ${t.tid}` }));
+  } catch (err) {
+    console.warn(`Could not reach ${forumApiUrl}/api/recent — skipping forum-post seed data.`, (err as Error).message);
+    return [];
+  }
+}
+
+async function fetchRecentNewsItems(count: number): Promise<FeedTarget[]> {
+  return prisma.teamNewsItem.findMany({
+    orderBy: { eventDate: 'desc' },
+    take: count,
+    select: { uid: true, title: true },
+  });
+}
+
+async function pickMemberUids(count: number): Promise<string[]> {
+  const members = await prisma.member.findMany({
+    orderBy: { createdAt: 'asc' },
+    take: count,
+    select: { uid: true },
+  });
+  return members.map((m) => m.uid);
+}
+
+async function seedComment(itemType: 'NEWS' | 'FORUM_POST', itemUid: string, authorUid: string, text: string) {
+  const existing = await prisma.feedComment.findFirst({ where: { itemUid, authorUid, text } });
+  if (existing) return { row: existing, created: false };
+  const row = await prisma.feedComment.create({ data: { itemType, itemUid, authorUid, text } });
+  return { row, created: true };
+}
+
+async function seedLike(forumPostUid: string, memberUid: string) {
+  return prisma.feedForumPostLike.upsert({
+    where: { forumPostUid_memberUid: { forumPostUid, memberUid } },
+    create: { forumPostUid, memberUid },
+    update: {},
+  });
+}
+
+async function main() {
+  const members = await pickMemberUids(6);
+  if (members.length < 2) {
+    console.error('Need at least 2 seeded Members to create feed comments/likes — seed members first.');
+    process.exit(1);
+  }
+
+  const forumPosts = await fetchRecentForumPosts(2);
+  const newsItems = await fetchRecentNewsItems(2);
+
+  console.log(`Members available: ${members.length}`);
+  console.log(`Forum posts: ${forumPosts.map((f) => `${f.uid} (${f.title})`).join(', ') || '(none)'}`);
+  console.log(`News items: ${newsItems.map((n) => `${n.uid} (${n.title})`).join(', ') || '(none found)'}`);
+
+  let commentsCreated = 0;
+  let likesUpserted = 0;
+
+  for (const [index, post] of forumPosts.entries()) {
+    const firstAuthor = members[index % members.length];
+    const secondAuthor = members[(index + 1) % members.length];
+
+    const c1 = await seedComment('FORUM_POST', post.uid, firstAuthor, `Great write-up on "${post.title}" — thanks for sharing!`);
+    if (c1.created) commentsCreated++;
+
+    if (secondAuthor !== firstAuthor) {
+      const c2 = await seedComment('FORUM_POST', post.uid, secondAuthor, 'Following this thread, curious how it plays out.');
+      if (c2.created) commentsCreated++;
+    }
+
+    for (const liker of members.slice(0, 3)) {
+      await seedLike(post.uid, liker);
+      likesUpserted++;
+    }
+  }
+
+  for (const [index, item] of newsItems.entries()) {
+    const author = members[(index + 2) % members.length];
+    const { created } = await seedComment('NEWS', item.uid, author, `Congrats on this — "${item.title}" is exciting news!`);
+    if (created) commentsCreated++;
+  }
+
+  const totalComments = await prisma.feedComment.count();
+  const totalLikes = await prisma.feedForumPostLike.count();
+
+  console.log('\n— Feed seed complete —');
+  console.log(`comments created this run: ${commentsCreated} (total in DB: ${totalComments})`);
+  console.log(`likes upserted this run: ${likesUpserted} (total in DB: ${totalLikes})`);
+}
+
+main()
+  .catch((e) => {
+    console.error('Seed failed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/web-api/src/utils/html-to-text.spec.ts
+++ b/apps/web-api/src/utils/html-to-text.spec.ts
@@ -1,0 +1,21 @@
+import { stripHtmlToPlainText } from './html-to-text';
+
+describe('stripHtmlToPlainText', () => {
+  it('returns an empty string for empty input', () => {
+    expect(stripHtmlToPlainText('')).toBe('');
+  });
+
+  it('strips tags and decodes residual entities left by sanitize-html', () => {
+    expect(stripHtmlToPlainText('<p>Fish &amp; Chips</p>')).toBe('Fish & Chips');
+    expect(stripHtmlToPlainText('It&#39;s a test')).toBe("It's a test");
+  });
+
+  it('inserts whitespace at stripped block-tag boundaries instead of running words together', () => {
+    expect(stripHtmlToPlainText('<p>Para1</p><p>Para2</p>')).toBe('Para1 Para2');
+    expect(stripHtmlToPlainText('Line one<br>Line two')).toBe('Line one Line two');
+  });
+
+  it('collapses repeated whitespace and trims', () => {
+    expect(stripHtmlToPlainText('  <div>  Hello   world  </div>  ')).toBe('Hello world');
+  });
+});

--- a/apps/web-api/src/utils/html-to-text.ts
+++ b/apps/web-api/src/utils/html-to-text.ts
@@ -1,0 +1,26 @@
+import sanitizeHtml from 'sanitize-html';
+
+// sanitize-html decodes entities on parse but re-escapes &, <, > in its
+// output (it assumes the output will be re-embedded as HTML), so a second
+// decode pass is needed to get real plain text.
+const RESIDUAL_ENTITIES: Array<[RegExp, string]> = [
+  [/&amp;/g, '&'],
+  [/&lt;/g, '<'],
+  [/&gt;/g, '>'],
+  [/&quot;/g, '"'],
+  [/&#0*39;|&apos;/g, "'"],
+];
+
+// sanitize-html inserts no whitespace when it strips block-level tags
+// (`<p>Para1</p><p>Para2</p>` -> "Para1Para2"), so those boundaries need an
+// explicit space before stripping or adjacent words run together.
+const BLOCK_BOUNDARY_TAGS = /<\/?(p|div|br|li|ul|ol|h[1-6]|blockquote|tr)[^>]*>/gi;
+
+export function stripHtmlToPlainText(html: string): string {
+  if (!html) return '';
+  const withBoundaries = html.replace(BLOCK_BOUNDARY_TAGS, ' ');
+  const stripped = sanitizeHtml(withBoundaries, { allowedTags: [], allowedAttributes: {} });
+  return RESIDUAL_ENTITIES.reduce((acc, [re, repl]) => acc.replace(re, repl), stripped)
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/docs/NEWSFEED_FORUM_POSTS.md
+++ b/docs/NEWSFEED_FORUM_POSTS.md
@@ -1,0 +1,293 @@
+# Newsfeed: Forum Posts, Comments & Likes
+
+> Status: **Shipped.** Forum posts are read-through from NodeBB (never stored locally); comments and likes are directory-native and never synced to NodeBB.
+
+Lets the home newsfeed surface **forum/discussion posts** (NodeBB topics) alongside team news, and lets any signed-in member **comment on** and **like** feed items — both team news items and forum posts — inline, without leaving the feed.
+
+Two things are easy to conflate and aren't the same:
+
+- **Forum posts** (`GET /v1/feed/forum-posts`) are a **read-through view of NodeBB**. Nothing about a forum post is stored in Postgres; every request re-fetches the current topic list from NodeBB's own public API.
+- **Comments and likes** are **100% directory-native**, stored only in this app's DB. A comment on a forum-post feed item is *not* a NodeBB reply, and a like is *not* a NodeBB upvote — NodeBB has no "like" concept at all, only upvote/downvote, and this feature doesn't touch that.
+
+### Confirmed: no state sync with the real Forum page
+
+This is a deliberate product decision, confirmed explicitly after review against the Home mockups (which show a forum-post card and the real Forum thread looking like the same post) — it's easy to look at those side by side and assume liking/commenting on Home should be the same state as `forum/topics/:cid/:tid` on the real Forum page. **It is not, and should not become that without a new, explicit decision:**
+
+- Liking a post on Home writes to `FeedForumPostLike` only. It never calls NodeBB, so it does **not** register as an upvote on the real Forum page, and a real NodeBB upvote/downvote does **not** change what Home shows.
+- Commenting on a forum-post card writes to `FeedComment` only. It never becomes a NodeBB reply, and NodeBB replies are never read back — `GET /v1/feed/forum-posts` only ever reads a topic's *original* post, never its replies.
+- The `category` field is the raw NodeBB category name (`General`/`Launch`/`Talent`/`Intros`), passed straight through. If a mockup shows a fixed badge like "DISCUSSION" instead, that's a frontend display choice (hardcode the badge text for any forum-post card) — not something the backend derives or should change.
+- Author "role" is NodeBB's `teamRole` only (e.g. "Founder"), with no team/company name attached (e.g. no "@ Lattice Compute" suffix) — also confirmed, not an oversight.
+
+If a future task asks to make these numbers/threads match the real Forum page, that is a **materially larger change** — it would mean calling NodeBB's write API (member-authenticated, not the guest read used today) for likes/comments instead of `FeedForumPostLike`/`FeedComment`, and reading NodeBB's live vote/reply data on every fetch. Treat it as a new feature requiring its own product decision, not a bug fix.
+
+## Why forum posts aren't stored locally
+
+Forum content lives in Protocol Labs' NodeBB fork, not in this app's database. There's no indexer anywhere that copies NodeBB topics into Postgres (or into OpenSearch, despite a `forum_thread` index being *queried* elsewhere in this codebase — nothing writes to it). The one already-sanctioned way to read topic data without a NodeBB login is NodeBB's own public, unauthenticated REST surface, carved out specifically for this in NodeBB's `jwt-auth.js` (`PUBLIC_GET_ALLOWLIST`):
+
+- `GET {FORUM_API_URL}/api/recent` — the endpoint this feature calls. Returns recent topics with title, category (`{cid, name, ...}`), and the topic-starter's user object already embedded — no per-topic follow-up request needed.
+- `GET {FORUM_API_URL}/api/topic/:tid` — full topic detail (not currently called; recent-list data is sufficient).
+
+Real, already-synced fields read off each topic (nothing here is invented — see `apps/web-api/src/forum/protosphere-api.client.ts`):
+
+| Feed field | NodeBB source |
+|---|---|
+| `title` | `topic.titleRaw` (fallback `topic.title`) |
+| `body` | `topic.teaser.content` (the topic's latest/main post snippet) |
+| `category` | `topic.category.name` |
+| `author.memberUid` | `topic.user.memberUid` — synced custom field, the join key back to `Member.uid` |
+| `author.name` | `topic.user.displayname` (fallback `username`) |
+| `author.avatarUrl` | `topic.user.picture` |
+| `author.role` | `topic.user.teamRole` |
+| `createdAt` | `topic.timestamp` |
+
+`title`/`body` are run through `stripHtmlToPlainText` (`apps/web-api/src/utils/html-to-text.ts`) before being returned — NodeBB content can contain rendered HTML, and `sanitize-html` alone isn't enough (it re-escapes `&`/`<`/`>` in its output and inserts no whitespace at stripped block-tag boundaries), so this wraps it with an entity-decode pass and a block-boundary-to-space pass.
+
+### `focusAreas` — a deliberate simplification
+
+Team news items derive `focusAreas` from `Team.teamFocusAreas`. Forum posts have no such link — a NodeBB topic isn't tied to a team. The real production NodeBB categories (`Intros`, `Talent`, `Launch`, `General`) are generic forum sections, not domain topics, so there's no meaningful mapping onto the five news focus-area tab titles (`Digital Human Rights`, `Economies & Governance`, etc.). Per product decision, a forum post's `focusAreas` is just `[categoryName]` verbatim — e.g. `["General"]`. It will only ever match a news focus-area tab by coincidence; in practice these posts mostly surface under "All".
+
+## Data model
+
+Only comments and likes are persisted. Both follow the `Follow` model's polymorphic pattern (soft reference to the target, hard FK to the acting member):
+
+```prisma
+enum FeedItemType {
+  NEWS
+  FORUM_POST
+}
+
+model FeedComment {
+  id        Int          @id @default(autoincrement())
+  uid       String       @unique @default(cuid())
+  itemType  FeedItemType
+  itemUid   String
+  text      String
+  authorUid String
+  author    Member       @relation("MemberFeedComments", fields: [authorUid], references: [uid], onDelete: Cascade)
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+
+  @@index([itemType, itemUid, createdAt])
+  @@index([authorUid])
+}
+
+model FeedForumPostLike {
+  id           Int      @id @default(autoincrement())
+  uid          String   @unique @default(cuid())
+  forumPostUid String
+  memberUid    String
+  member       Member   @relation("MemberFeedForumPostLikes", fields: [memberUid], references: [uid], onDelete: Cascade)
+  createdAt    DateTime @default(now())
+
+  @@unique([forumPostUid, memberUid])
+  @@index([forumPostUid])
+  @@index([memberUid])
+}
+```
+
+- **`itemUid` / `forumPostUid`** are **intentionally not hard FKs** — `itemUid` references either a `TeamNewsItem.uid` (real row) or a synthetic `fp_<tid>` uid (no local row at all, since forum posts aren't stored). `itemType` is redundant with the `fp_` prefix but kept explicit for query clarity/indexing, same rationale as `Follow.entityType`.
+- **`authorUid` / `memberUid`** ARE hard FKs — the actor is always a real directory member, so these cascade-delete with the member (same as `ArticleComment.authorUid`).
+- **`fp_` uids are guaranteed collision-free** with `TeamNewsItem` cuids — the prefix is a hard invariant the frontend and backend both rely on to tell the two item types apart from the uid alone.
+- **`@@unique([forumPostUid, memberUid])`** makes like/unlike idempotent, same as `TeamNewsUpvote`.
+
+Migration: `apps/web-api/prisma/migrations/20260727120000_add_feed_comments_and_forum_likes/`.
+
+## Endpoints
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| GET | `/v1/feed/forum-posts` | `UserTokenCheckGuard` (optional) | Live NodeBB topics. Returns `{ items: [] }` — not a 403 — for anonymous callers or signed-in members without `forum.read`. |
+| POST | `/v1/feed/comments/counts` | none | Batch comment counts for a list of feed item uids (news or forum posts). |
+| GET | `/v1/feed/comments` | `UserTokenCheckGuard` (optional) | Comments for one feed item; anonymous callers get `isOwn: false` on every comment. |
+| POST | `/v1/feed/comments` | `UserTokenValidation` (required) | Any signed-in member — no forum-access requirement. |
+| DELETE | `/v1/feed/comments/:commentUid` | `UserTokenValidation` (required) | Author-only; **403** for anyone else. |
+| POST | `/v1/feed/forum-posts/:uid/like` | `UserTokenValidation` (required) | Any signed-in member — likes are our own surface, not forum-gated. Idempotent. |
+| DELETE | `/v1/feed/forum-posts/:uid/like` | `UserTokenValidation` (required) | Idempotent. |
+
+Contracts: `libs/contracts/src/lib/contract-feed.ts` + `libs/contracts/src/schema/feed.ts`. Implementation: `apps/web-api/src/feed/`.
+
+Examples below use a member access token (`-H "Authorization: Bearer $TOKEN"`).
+
+### List forum posts for the feed
+
+`GET /v1/feed/forum-posts?limit=20&page=0`
+
+`limit` defaults to `20` (max `100`); `page` defaults to `0` and is passed straight through to NodeBB's own paging. Requires the caller to hold the `forum.read` permission (`AccessControlV2Service`, same gate `search.controller.ts` uses elsewhere) — checked via the caller's email, catching any error and treating it as "no access" rather than throwing.
+
+```bash
+curl "http://localhost:3000/v1/feed/forum-posts?limit=5" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{
+  "items": [
+    {
+      "uid": "fp_188",
+      "title": "Payy publishes deep-dive on React Native + Rust bridge for wallet math",
+      "body": "Payy publishes deep-dive on React Native + Rust bridge for wallet math",
+      "author": {
+        "memberUid": "cmpxsx1l900r7n54fh7dxyd79",
+        "name": "self registered 1",
+        "avatarUrl": null,
+        "role": "role 1"
+      },
+      "focusAreas": ["General"],
+      "category": "General",
+      "createdAt": "2026-07-07T09:51:35.910Z",
+      "forumTopicUrl": "https://plnetwork.io/forum/topics/7/188",
+      "commentCount": 0,
+      "likeCount": 0,
+      "viewerHasLiked": false
+    }
+  ]
+}
+```
+
+A caller without `forum.read` (or an anonymous request):
+
+```bash
+curl "http://localhost:3000/v1/feed/forum-posts"
+```
+
+```json
+{ "items": [] }
+```
+
+### Batch comment counts
+
+`POST /v1/feed/comments/counts`
+
+Accepts up to 200 uids at once (mix of news-item uids and `fp_`-prefixed forum-post uids). A uid with no comments is simply absent from `counts` — the frontend should default missing keys to `0`.
+
+```bash
+curl -X POST "http://localhost:3000/v1/feed/comments/counts" \
+  -H "Content-Type: application/json" \
+  -d '{"uids": ["fp_188", "cQjK2p0nzTeamNews1"]}'
+```
+
+```json
+{ "counts": { "fp_188": 2 } }
+```
+
+### List comments for a feed item
+
+`GET /v1/feed/comments?itemUid=fp_188`
+
+Ordered oldest-first (thread reading order). `isOwn` is `true` only for the authenticated caller's own comments — always `false` for anonymous requests.
+
+```bash
+curl "http://localhost:3000/v1/feed/comments?itemUid=fp_188" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{
+  "items": [
+    {
+      "uid": "cm1a2b3c4d5e",
+      "itemUid": "fp_188",
+      "text": "Great deep-dive, thanks for sharing!",
+      "author": {
+        "uid": "cmpxsx1l900r7n54fh7dxyd79",
+        "name": "self registered 1",
+        "avatarUrl": null
+      },
+      "createdAt": "2026-07-08T10:15:00.000Z",
+      "isOwn": true
+    }
+  ]
+}
+```
+
+### Add a comment
+
+`POST /v1/feed/comments`
+
+Body: `{ itemUid: string, text: string (1-2000 chars) }`. `itemType` is inferred from the uid: any uid starting with `fp_` is treated as a forum post, everything else as a news item. For a news-item comment, the news item must exist (`404` otherwise); a forum-post uid is accepted as-is with no NodeBB round-trip, since forum posts are a soft reference by design.
+
+```bash
+curl -X POST "http://localhost:3000/v1/feed/comments" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"itemUid": "fp_188", "text": "Great deep-dive, thanks for sharing!"}'
+```
+
+```json
+{
+  "uid": "cm1a2b3c4d5e",
+  "itemUid": "fp_188",
+  "text": "Great deep-dive, thanks for sharing!",
+  "author": {
+    "uid": "cmpxsx1l900r7n54fh7dxyd79",
+    "name": "self registered 1",
+    "avatarUrl": null
+  },
+  "createdAt": "2026-07-08T10:15:00.000Z",
+  "isOwn": true
+}
+```
+
+`401` if unauthenticated; `404` if `itemUid` looks like a news-item uid that doesn't exist.
+
+### Delete a comment
+
+`DELETE /v1/feed/comments/:commentUid`
+
+Author-only — there is no admin-override bypass (unlike NodeBB's own forum-comment permissions, which do allow Directory Admin to edit/delete any comment; this feed-comment surface currently doesn't mirror that).
+
+```bash
+curl -X DELETE "http://localhost:3000/v1/feed/comments/cm1a2b3c4d5e" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{ "uid": "cm1a2b3c4d5e", "deleted": true }
+```
+
+`404` if the comment doesn't exist; `403` if the caller isn't the author.
+
+### Like / unlike a forum post
+
+`POST` / `DELETE /v1/feed/forum-posts/:uid/like`
+
+Idempotent both ways — liking an already-liked post, or unliking a never-liked one, both succeed and just return the current state. Not gated on `forum.read`: any signed-in member can like a post they can otherwise see.
+
+```bash
+curl -X POST "http://localhost:3000/v1/feed/forum-posts/fp_188/like" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{ "likeCount": 1, "viewerHasLiked": true }
+```
+
+```bash
+curl -X DELETE "http://localhost:3000/v1/feed/forum-posts/fp_188/like" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{ "likeCount": 0, "viewerHasLiked": false }
+```
+
+## Batching pattern (no N+1)
+
+`commentCount`/`likeCount`/`viewerHasLiked` are computed for a whole page of forum posts in two queries total, not one per item — the same `groupBy` + viewer-scoped-`findMany` pattern `TeamNewsQueryService.loadUpvotes` already uses for news-item upvotes:
+
+```ts
+const [grouped, viewerRows] = await Promise.all([
+  prisma.feedForumPostLike.groupBy({ by: ['forumPostUid'], where: { forumPostUid: { in: uids } }, _count: { _all: true } }),
+  viewerMemberUid
+    ? prisma.feedForumPostLike.findMany({ where: { forumPostUid: { in: uids }, memberUid: viewerMemberUid }, select: { forumPostUid: true } })
+    : Promise.resolve([]),
+]);
+```
+reduced to a `Map<uid, count>` and a `Set<uid>` and looked up per item while building the response. `FeedCommentsService.loadCommentCounts` is the same shape and is reused directly by `FeedForumPostsService`, so the `groupBy` isn't duplicated between the two services.
+
+## Extending to other feed item types (future)
+
+The comment/like surface already generalizes past `NEWS`/`FORUM_POST`:
+
+1. Add a new `FeedItemType` enum value.
+2. Give the new item type's uid a distinct, collision-free prefix (mirroring `fp_`), or otherwise make `createComment`'s `itemType` inference unambiguous.
+3. Reuse `FeedCommentsService`/`FeedLikesService` as-is — neither has any type-specific branching beyond the `NEWS` existence-check in `createComment`.

--- a/docs/NEWSFEED_FORUM_POSTS.md
+++ b/docs/NEWSFEED_FORUM_POSTS.md
@@ -42,9 +42,7 @@ Real, already-synced fields read off each topic (nothing here is invented — se
 
 `title`/`body` are run through `stripHtmlToPlainText` (`apps/web-api/src/utils/html-to-text.ts`) before being returned — NodeBB content can contain rendered HTML, and `sanitize-html` alone isn't enough (it re-escapes `&`/`<`/`>` in its output and inserts no whitespace at stripped block-tag boundaries), so this wraps it with an entity-decode pass and a block-boundary-to-space pass.
 
-### `focusAreas` — a deliberate simplification
-
-Team news items derive `focusAreas` from `Team.teamFocusAreas`. Forum posts have no such link — a NodeBB topic isn't tied to a team. The real production NodeBB categories (`Intros`, `Talent`, `Launch`, `General`) are generic forum sections, not domain topics, so there's no meaningful mapping onto the five news focus-area tab titles (`Digital Human Rights`, `Economies & Governance`, etc.). Per product decision, a forum post's `focusAreas` is just `[categoryName]` verbatim — e.g. `["General"]`. It will only ever match a news focus-area tab by coincidence; in practice these posts mostly surface under "All".
+Forum posts have no `focusAreas` field — unlike team news items (which derive it from `Team.teamFocusAreas`), a NodeBB topic isn't tied to a team, and the real production NodeBB categories (`Intros`, `Talent`, `Launch`, `General`) are generic forum sections with no meaningful mapping onto the five news focus-area tab titles (`Digital Human Rights`, `Economies & Governance`, etc.). Don't add one back without a concrete, non-coincidental source for it — see the `category` field above for the one real per-topic classification NodeBB actually provides.
 
 ## Data model
 
@@ -132,7 +130,6 @@ curl "http://localhost:3000/v1/feed/forum-posts?limit=5" \
         "avatarUrl": null,
         "role": "role 1"
       },
-      "focusAreas": ["General"],
       "category": "General",
       "createdAt": "2026-07-07T09:51:35.910Z",
       "forumTopicUrl": "https://plnetwork.io/forum/topics/7/188",

--- a/libs/contracts/src/lib/contract-feed.ts
+++ b/libs/contracts/src/lib/contract-feed.ts
@@ -1,0 +1,86 @@
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+import {
+  CreateFeedCommentRequestSchema,
+  DeleteFeedCommentResponseSchema,
+  FeedCommentCountsRequestSchema,
+  FeedCommentCountsResponseSchema,
+  FeedCommentSchema,
+  FeedCommentsQueryParams,
+  FeedCommentsResponseSchema,
+  FeedForumPostLikeStatusSchema,
+  FeedForumPostsQueryParams,
+  FeedForumPostsResponseSchema,
+} from '../schema/feed';
+import { getAPIVersionAsPath } from '../utils/versioned-path';
+
+const contract = initContract();
+
+export const apiFeed = contract.router({
+  getFeedForumPosts: {
+    method: 'GET',
+    path: `${getAPIVersionAsPath('1')}/feed/forum-posts`,
+    query: FeedForumPostsQueryParams,
+    responses: {
+      200: FeedForumPostsResponseSchema,
+    },
+    summary: 'Recent forum topics for the newsfeed (empty items for callers without forum access)',
+  },
+  getFeedCommentCounts: {
+    method: 'POST',
+    path: `${getAPIVersionAsPath('1')}/feed/comments/counts`,
+    body: FeedCommentCountsRequestSchema,
+    responses: {
+      200: FeedCommentCountsResponseSchema,
+    },
+    summary: 'Batch comment counts for a list of feed item uids (news items or forum posts)',
+  },
+  getFeedComments: {
+    method: 'GET',
+    path: `${getAPIVersionAsPath('1')}/feed/comments`,
+    query: FeedCommentsQueryParams,
+    responses: {
+      200: FeedCommentsResponseSchema,
+    },
+    summary: 'List comments for one feed item',
+  },
+  createFeedComment: {
+    method: 'POST',
+    path: `${getAPIVersionAsPath('1')}/feed/comments`,
+    body: CreateFeedCommentRequestSchema,
+    responses: {
+      201: FeedCommentSchema,
+    },
+    summary: 'Add a comment to a feed item (any signed-in member)',
+  },
+  deleteFeedComment: {
+    method: 'DELETE',
+    path: `${getAPIVersionAsPath('1')}/feed/comments/:commentUid`,
+    pathParams: z.object({ commentUid: z.string() }),
+    body: z.object({}).optional(),
+    responses: {
+      200: DeleteFeedCommentResponseSchema,
+    },
+    summary: 'Delete your own feed comment',
+  },
+  likeFeedForumPost: {
+    method: 'POST',
+    path: `${getAPIVersionAsPath('1')}/feed/forum-posts/:uid/like`,
+    pathParams: z.object({ uid: z.string() }),
+    body: z.object({}).optional(),
+    responses: {
+      200: FeedForumPostLikeStatusSchema,
+    },
+    summary: 'Like a forum-post feed item (idempotent)',
+  },
+  unlikeFeedForumPost: {
+    method: 'DELETE',
+    path: `${getAPIVersionAsPath('1')}/feed/forum-posts/:uid/like`,
+    pathParams: z.object({ uid: z.string() }),
+    body: z.object({}).optional(),
+    responses: {
+      200: FeedForumPostLikeStatusSchema,
+    },
+    summary: 'Unlike a forum-post feed item (idempotent)',
+  },
+});

--- a/libs/contracts/src/schema/feed.ts
+++ b/libs/contracts/src/schema/feed.ts
@@ -16,7 +16,6 @@ export const FeedForumPostSchema = z.object({
   title: z.string(),
   body: z.string(),
   author: FeedForumPostAuthorSchema,
-  focusAreas: z.array(z.string()),
   category: z.string(),
   createdAt: z.string(),
   forumTopicUrl: z.string().nullable(),

--- a/libs/contracts/src/schema/feed.ts
+++ b/libs/contracts/src/schema/feed.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+
+// ── Forum posts ──────────────────────────────────────────────────────────
+// Forum topics surfaced in the newsfeed. Sourced live from NodeBB (never
+// stored locally); only forum-access callers receive non-empty items.
+
+export const FeedForumPostAuthorSchema = z.object({
+  memberUid: z.string().nullable(),
+  name: z.string(),
+  avatarUrl: z.string().nullable(),
+  role: z.string().nullable(),
+});
+
+export const FeedForumPostSchema = z.object({
+  uid: z.string(),
+  title: z.string(),
+  body: z.string(),
+  author: FeedForumPostAuthorSchema,
+  focusAreas: z.array(z.string()),
+  category: z.string(),
+  createdAt: z.string(),
+  forumTopicUrl: z.string().nullable(),
+  commentCount: z.number().int().min(0),
+  likeCount: z.number().int().min(0),
+  viewerHasLiked: z.boolean(),
+});
+
+export const FeedForumPostsResponseSchema = z.object({
+  items: z.array(FeedForumPostSchema),
+});
+
+export const FeedForumPostsQueryParams = z.object({
+  limit: z
+    .preprocess((v) => (v === undefined || v === '' ? undefined : Number(v)), z.number().int().min(1).max(100))
+    .optional()
+    .default(20),
+  page: z
+    .preprocess((v) => (v === undefined || v === '' ? undefined : Number(v)), z.number().int().min(0))
+    .optional()
+    .default(0),
+});
+
+// ── Feed comments (span both news items and forum posts) ────────────────
+// Comments are feed-only — never synced to NodeBB, even for forum posts.
+
+export const FeedCommentAuthorSchema = z.object({
+  uid: z.string(),
+  name: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+});
+
+export const FeedCommentSchema = z.object({
+  uid: z.string(),
+  itemUid: z.string(),
+  text: z.string(),
+  author: FeedCommentAuthorSchema,
+  createdAt: z.string(),
+  isOwn: z.boolean(),
+});
+
+export const FeedCommentsQueryParams = z.object({
+  itemUid: z.string().min(1),
+});
+
+export const FeedCommentsResponseSchema = z.object({
+  items: z.array(FeedCommentSchema),
+});
+
+export const CreateFeedCommentRequestSchema = z.object({
+  itemUid: z.string().min(1),
+  text: z.string().trim().min(1).max(2000),
+});
+
+export const FeedCommentCountsRequestSchema = z.object({
+  uids: z.array(z.string()).min(1).max(200),
+});
+
+// Keyed by item uid; a uid absent from `counts` implies 0.
+export const FeedCommentCountsResponseSchema = z.object({
+  counts: z.record(z.string(), z.number().int().min(0)),
+});
+
+export const DeleteFeedCommentResponseSchema = z.object({
+  uid: z.string(),
+  deleted: z.boolean(),
+});
+
+// ── Forum post likes (directory-portal-native, not a NodeBB vote proxy) ──
+
+export const FeedForumPostLikeStatusSchema = z.object({
+  likeCount: z.number().int().min(0),
+  viewerHasLiked: z.boolean(),
+});
+
+export type FeedForumPostAuthor = z.infer<typeof FeedForumPostAuthorSchema>;
+export type FeedForumPost = z.infer<typeof FeedForumPostSchema>;
+export type FeedForumPostsResponse = z.infer<typeof FeedForumPostsResponseSchema>;
+export type FeedForumPostsQuery = z.infer<typeof FeedForumPostsQueryParams>;
+export type FeedCommentAuthor = z.infer<typeof FeedCommentAuthorSchema>;
+export type FeedComment = z.infer<typeof FeedCommentSchema>;
+export type FeedCommentsQuery = z.infer<typeof FeedCommentsQueryParams>;
+export type FeedCommentsResponse = z.infer<typeof FeedCommentsResponseSchema>;
+export type CreateFeedCommentRequest = z.infer<typeof CreateFeedCommentRequestSchema>;
+export type FeedCommentCountsRequest = z.infer<typeof FeedCommentCountsRequestSchema>;
+export type FeedCommentCountsResponse = z.infer<typeof FeedCommentCountsResponseSchema>;
+export type DeleteFeedCommentResponse = z.infer<typeof DeleteFeedCommentResponseSchema>;
+export type FeedForumPostLikeStatus = z.infer<typeof FeedForumPostLikeStatusSchema>;

--- a/libs/contracts/src/schema/index.ts
+++ b/libs/contracts/src/schema/index.ts
@@ -45,3 +45,4 @@ export * from './team-job-enrichment';
 export * from './team-news';
 export * from './roadmap';
 export * from './follow';
+export * from './feed';

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "api:import-job-openings": "ts-node apps/web-api/src/scripts/import-job-openings.ts",
     "api:export-directory-linkedin": "ts-node apps/web-api/src/scripts/export-directory-linkedin.ts",
     "api:seed-team-news": "ts-node apps/web-api/src/scripts/seed-team-news.ts",
+    "api:seed-feed": "ts-node apps/web-api/src/scripts/seed-feed.ts",
     "api:seed-pathfinder-demo": "ts-node apps/web-api/src/scripts/seed-pathfinder-demo.ts",
     "api:seed-investor-lists": "ts-node apps/web-api/src/scripts/seed-investor-lists.ts",
     "api:seed-pathfinder-neuro": "ts-node --transpile-only apps/web-api/src/scripts/seed-pathfinder-neuro.ts",


### PR DESCRIPTION
## Description

Implemented the backend for the newsfeed's forum-post cards and inline feed comments/likes.
Forum posts are pulled live from NodeBB's own public topic-listing API and are only included for callers with forum access; other callers get an empty list, not an error.
Comments and likes on feed items (both team news and forum posts) are entirely native to the directory and are never written back to NodeBB.
Comment counts on a forum post reflect only these feed comments, not NodeBB's own reply count.
Any signed-in member can read and add comments and can delete their own comments; likes require sign-in but not forum access.

## New endpoints

```bash
curl "$WEB_API_BASE_URL/v1/feed/forum-posts?limit=20&page=0" \
  -H "Authorization: Bearer $TOKEN"
```

```bash
curl -X POST "$WEB_API_BASE_URL/v1/feed/comments/counts" \
  -H "Content-Type: application/json" \
  -d '{"uids": ["fp_42", "some-news-item-uid"]}'
```

```bash
curl "$WEB_API_BASE_URL/v1/feed/comments?itemUid=fp_42" \
  -H "Authorization: Bearer $TOKEN"
```

```bash
curl -X POST "$WEB_API_BASE_URL/v1/feed/comments" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"itemUid": "fp_42", "text": "Great update!"}'
```

```bash
curl -X DELETE "$WEB_API_BASE_URL/v1/feed/comments/$COMMENT_UID" \
  -H "Authorization: Bearer $TOKEN"
```

```bash
curl -X POST "$WEB_API_BASE_URL/v1/feed/forum-posts/fp_42/like" \
  -H "Authorization: Bearer $TOKEN"
```

```bash
curl -X DELETE "$WEB_API_BASE_URL/v1/feed/forum-posts/fp_42/like" \
  -H "Authorization: Bearer $TOKEN"
```


## Ticket

[LAB-2175](https://linear.app/plrs-labos/issue/LAB-2175/team-news-support-forum-posts-and-feed-only-comments-in-the-newsfeed)