### PR TITLE
feat(ai-apps): deployment block with serving state + manager-gated failure details

### DIFF
--- a/apps/web-api/prisma/migrations/20260729120000_ai_apps_deployment_serving/migration.sql
+++ b/apps/web-api/prisma/migrations/20260729120000_ai_apps_deployment_serving/migration.sql
@@ -1,0 +1,23 @@
+-- AI Apps deployment status: distinguish "latest deploy failed but a previous
+-- version still serves" from "nothing ever shipped".
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "lastDeployedAt" TIMESTAMP(3);
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "failureStream" TEXT;
+
+-- Backfill lastDeployedAt from the append-only audit log: the newest
+-- DEPLOY_SUCCEEDED event per app is exactly "when it last shipped". Without
+-- this, every pre-existing ERROR app would read as "never deployed".
+UPDATE "AiApp" a
+SET "lastDeployedAt" = e."lastSuccess"
+FROM (
+  SELECT "appUid", MAX("createdAt") AS "lastSuccess"
+  FROM "AiAppEvent"
+  WHERE "type" = 'DEPLOY_SUCCEEDED' AND "appUid" IS NOT NULL
+  GROUP BY "appUid"
+) e
+WHERE a."uid" = e."appUid" AND a."lastDeployedAt" IS NULL;
+
+-- Belt and braces: a READY app has by definition shipped, even if its
+-- DEPLOY_SUCCEEDED event predates the audit log. Approximate with updatedAt.
+UPDATE "AiApp"
+SET "lastDeployedAt" = "updatedAt"
+WHERE "status" = 'READY' AND "lastDeployedAt" IS NULL;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -3206,6 +3206,16 @@ model AiApp {
   /// Model the agent reported running on for the last upload (optional
   /// self-reported multipart field, kits ≥1.4).
   agentModel      String?
+  /// When the app last deployed SUCCESSFULLY (written only by markReady).
+  /// Null = never shipped — this is what makes `deployment.serving: 'none'`
+  /// a strict "never deployed" claim, and it survives failed deploys (which
+  /// bump `updatedAt` but must not move this).
+  lastDeployedAt  DateTime?
+  /// Which log stream held the LATEST deploy failure: 'build' | 'runtime'.
+  /// Classified at failure time from the deploy control flow (runner logs only
+  /// cover the last successful phase, so it can't be derived after the fact).
+  /// Null when unknown (e.g. stuck-deploy settle); cleared on success.
+  failureStream   String?
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
 

--- a/apps/web-api/src/ai-apps/ai-apps-deployment.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-deployment.spec.ts
@@ -1,0 +1,244 @@
+/// <reference types="multer" />
+
+// axios ships ESM (not in the jest transform allowlist); the deploy paths under
+// test call it, so mock the calls themselves.
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  get: jest.fn(),
+  isAxiosError: jest.fn((error: any) => !!error?.isAxiosError),
+}));
+
+// The constants module reads env vars at import time; pin the bucket, and make
+// the post-timeout liveness verification instant (one failing attempt) so the
+// "timeout, app never came up" classification path runs in milliseconds.
+jest.mock('./ai-apps.constants', () => ({
+  ...jest.requireActual('./ai-apps.constants'),
+  AI_APPS_S3_BUCKET: 'test-bucket',
+  AI_APPS_VERIFY_ATTEMPTS: 1,
+  AI_APPS_VERIFY_INTERVAL_MS: 0,
+}));
+
+import axios from 'axios';
+import { AiAppsService } from './ai-apps.service';
+import { AI_APPS_DEPLOY_STUCK_MS } from './ai-apps.constants';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const LAST_SHIP = new Date('2026-07-01T00:00:00.000Z');
+
+const APP = {
+  uid: 'app-1',
+  memberUid: 'creator-1',
+  appId: 'demo',
+  name: 'Demo',
+  status: 'READY',
+  notes: null as string | null,
+  s3Key: 'apps/demo/d1/app.zip',
+  deploymentId: 'd1',
+  requiredEnvVars: [] as string[],
+  providedEnvVars: [] as string[],
+  lastDeployedAt: LAST_SHIP as Date | null,
+  failureStream: null as string | null,
+  updatedAt: new Date(),
+};
+
+function buildService(app: Record<string, any> | null = APP) {
+  const prisma = {
+    aiApp: {
+      findUnique: jest.fn().mockResolvedValue(app),
+      findMany: jest.fn().mockResolvedValue(app ? [app] : []),
+      update: jest.fn().mockImplementation(({ data }) => Promise.resolve({ ...APP, ...app, ...data })),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    aiAppEvent: { create: jest.fn().mockResolvedValue({}) },
+    member: {
+      findMany: jest.fn().mockResolvedValue([]),
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
+  };
+  const aws = { uploadFileToS3: jest.fn().mockResolvedValue(undefined) };
+  return { service: new AiAppsService(prisma as any, aws as any), prisma, aws };
+}
+
+/** The `data` of the update() call that wrote status ERROR. */
+function errorWrite(prisma: any): Record<string, any> | undefined {
+  return prisma.aiApp.update.mock.calls.map(([{ data }]: any) => data).find((d: any) => d.status === 'ERROR');
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('deployment.serving derivation', () => {
+  it.each([
+    // [status, lastDeployedAt, expected]
+    ['READY', LAST_SHIP, 'latest'],
+    ['ERROR', LAST_SHIP, 'previous'],
+    ['ERROR', null, 'none'],
+    ['DEPLOYING', LAST_SHIP, 'previous'],
+    ['DRAFT', null, 'none'],
+  ] as const)('status=%s lastDeployedAt=%s → %s', async (status, lastDeployedAt, expected) => {
+    const { service } = buildService({ ...APP, status, lastDeployedAt, updatedAt: new Date() });
+
+    const result = await service.getApp('app-1');
+
+    expect(result.deployment.serving).toBe(expected);
+  });
+});
+
+describe('manager gating of failure details', () => {
+  const failedApp = {
+    ...APP,
+    status: 'ERROR',
+    notes: 'Runner error: 500 kaniko blew up',
+    failureStream: 'build',
+    lastDeployedAt: LAST_SHIP,
+  };
+
+  it('creator sees notes + deployment.failureReason/failureStream (and canManage)', async () => {
+    const { service } = buildService(failedApp);
+
+    const result = await service.getApp('app-1', 'creator-1');
+
+    expect(result.canManage).toBe(true);
+    expect(result.notes).toBe(failedApp.notes);
+    expect(result.deployment).toEqual({
+      serving: 'previous',
+      failureReason: failedApp.notes,
+      failureStream: 'build',
+    });
+  });
+
+  it('a non-manager gets serving only — notes nulled, no failure details', async () => {
+    const { service } = buildService(failedApp);
+
+    const result = await service.getApp('app-1', 'someone-else');
+
+    expect(result.canManage).toBe(false);
+    expect(result.notes).toBeNull();
+    expect(result.deployment).toEqual({ serving: 'previous' });
+  });
+
+  it('an anonymous read is gated like a non-manager', async () => {
+    const { service } = buildService(failedApp);
+
+    const result = await service.getApp('app-1');
+
+    expect(result.notes).toBeNull();
+    expect(result.deployment).toEqual({ serving: 'previous' });
+  });
+
+  it('the raw failureStream column never appears on responses', async () => {
+    const { service } = buildService(failedApp);
+
+    const asManager = await service.getApp('app-1', 'creator-1');
+    const asVisitor = await service.getApp('app-1', 'someone-else');
+
+    expect('failureStream' in asManager).toBe(false);
+    expect('failureStream' in asVisitor).toBe(false);
+  });
+
+  it('listApps gates per row: requester sees details on own apps only', async () => {
+    const own = { ...failedApp };
+    const other = { ...failedApp, uid: 'app-2', appId: 'other', memberUid: 'someone-else' };
+    const { service, prisma } = buildService(failedApp);
+    prisma.aiApp.findMany.mockResolvedValueOnce([own, other]);
+
+    const result = await service.listApps('creator-1');
+
+    expect(result[0].notes).toBe(failedApp.notes);
+    expect(result[0].deployment.failureReason).toBe(failedApp.notes);
+    expect(result[1].notes).toBeNull();
+    expect(result[1].deployment).toEqual({ serving: 'previous' });
+    // One admin lookup for the requester — never one per row.
+    expect(prisma.member.findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it('listApps without a requester gates every row', async () => {
+    const { service, prisma } = buildService(failedApp);
+    prisma.aiApp.findMany.mockResolvedValueOnce([failedApp]);
+
+    const result = await service.listApps();
+
+    expect(result[0].notes).toBeNull();
+    expect(result[0].deployment).toEqual({ serving: 'previous' });
+    expect(prisma.member.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe('deploy outcome writes', () => {
+  it('a successful deploy sets lastDeployedAt and clears failureStream (markReady)', async () => {
+    const { service, prisma } = buildService({ ...APP, status: 'ERROR', notes: 'old failure', failureStream: 'build' });
+    mockedAxios.post.mockResolvedValue({ status: 200, data: { port: 31001 } });
+
+    const result = await service.deployDraft('creator-1', 'app-1', undefined);
+
+    const readyWrite = prisma.aiApp.update.mock.calls.map(([{ data }]: any) => data).find((d: any) => d.status === 'READY');
+    expect(readyWrite).toMatchObject({ notes: null, failureStream: null });
+    expect(readyWrite.lastDeployedAt).toBeInstanceOf(Date);
+    expect(result.deployment.serving).toBe('latest');
+  });
+
+  it('a hard runner error is classified as a build failure and never touches lastDeployedAt', async () => {
+    const { service, prisma } = buildService({ ...APP, status: 'ERROR' });
+    mockedAxios.post.mockRejectedValue({ isAxiosError: true, response: { status: 500, data: 'kaniko error' } });
+
+    await expect(service.deployDraft('creator-1', 'app-1', undefined)).rejects.toThrow();
+
+    expect(errorWrite(prisma)).toMatchObject({ failureStream: 'build' });
+    expect(errorWrite(prisma)).not.toHaveProperty('lastDeployedAt');
+  });
+
+  it('a runner 2xx carrying status:"failed" is a failure, not a success', async () => {
+    const { service, prisma } = buildService({ ...APP, status: 'ERROR' });
+    mockedAxios.post.mockResolvedValue({ status: 200, data: { status: 'failed', port: null } });
+
+    await expect(service.deployDraft('creator-1', 'app-1', undefined)).rejects.toThrow();
+
+    expect(errorWrite(prisma)).toMatchObject({ status: 'ERROR', failureStream: 'build' });
+    expect(prisma.aiApp.update.mock.calls.map(([{ data }]: any) => data.status)).not.toContain('READY');
+  });
+
+  it('a timeout where the app never comes up leaves the stream unclassified', async () => {
+    const { service, prisma } = buildService({ ...APP, status: 'ERROR' });
+    mockedAxios.post.mockRejectedValue({ isAxiosError: true, response: undefined, code: 'ECONNABORTED' });
+    mockedAxios.get.mockRejectedValue(new Error('unreachable')); // liveness verify fails
+
+    await expect(service.deployDraft('creator-1', 'app-1', undefined)).rejects.toThrow();
+
+    expect(errorWrite(prisma)).toMatchObject({ status: 'ERROR', failureStream: null });
+  });
+
+  it('a secrets-injection failure is classified as a runtime failure', async () => {
+    const { service, prisma } = buildService({
+      ...APP,
+      status: 'ERROR',
+      requiredEnvVars: ['API_KEY'],
+      providedEnvVars: ['API_KEY'],
+    });
+    // Build succeeds; the runner registry lookup then fails the secrets redeploy.
+    mockedAxios.post.mockResolvedValueOnce({ status: 200, data: { port: 31001 } });
+    mockedAxios.get.mockResolvedValue({ data: { apps: [] } }); // no image for appId
+
+    await expect(service.deployDraft('creator-1', 'app-1', undefined)).rejects.toThrow();
+
+    expect(errorWrite(prisma)).toMatchObject({ failureStream: 'runtime' });
+  });
+
+  it('a stuck-deploy settle writes ERROR with failureStream null (stale values must not leak)', async () => {
+    const stuck = {
+      ...APP,
+      status: 'DEPLOYING',
+      failureStream: 'build',
+      updatedAt: new Date(Date.now() - AI_APPS_DEPLOY_STUCK_MS - 60_000),
+    };
+    const { service, prisma } = buildService(stuck);
+    prisma.aiApp.findUnique.mockResolvedValueOnce(stuck).mockResolvedValueOnce({ ...stuck, status: 'ERROR' });
+
+    await service.getApp('app-1');
+
+    expect(prisma.aiApp.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'ERROR', failureStream: null }) })
+    );
+  });
+});

--- a/apps/web-api/src/ai-apps/ai-apps.controller.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.controller.ts
@@ -98,13 +98,19 @@ export class AiAppsController {
     return this.connectService.approve(uid, memberUid);
   }
 
-  /** Dashboard list of all AI Apps with their deploy status. */
+  /**
+   * Dashboard list of all AI Apps with their deploy status. The requester is
+   * resolved (like the detail route) so failure details (`notes`,
+   * `deployment.failureReason`/`failureStream`) can be included only on apps
+   * the requester manages — everyone else gets `deployment.serving` alone.
+   */
   @NoCache()
   @Get()
   @UseGuards(UserTokenCheckGuard, RbacGuard)
   @RequirePermissions(READ)
-  async listApps() {
-    return this.aiAppsService.listApps();
+  async listApps(@Req() req: any) {
+    const memberUid = await this.resolveMemberUid(req).catch(() => undefined);
+    return this.aiAppsService.listApps(memberUid);
   }
 
   /**

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -73,6 +73,25 @@ type AiAppMember = { uid: string; name: string; image: string | null };
 /** Response shape across all AI Apps endpoints: `memberUid` replaced by `member`. */
 type WithMember<T extends { memberUid: string }> = Omit<T, 'memberUid'> & { member: AiAppMember | null };
 
+/** What is actually serving traffic — independent of whether the LATEST deploy succeeded. */
+type AiAppServing = 'latest' | 'previous' | 'none';
+
+/**
+ * Deploy-outcome block on app responses (contract shared with the frontend).
+ * `failureReason`/`failureStream` are manager-only: the runner's failure text
+ * can carry stack fragments, image names, and internal hostnames.
+ */
+interface AiAppDeploymentInfo {
+  serving: AiAppServing;
+  failureReason?: string;
+  failureStream?: 'build' | 'runtime';
+}
+
+/** App responses: raw failure columns replaced by the requester-gated `deployment` block. */
+type ApiAiApp<T extends { memberUid: string }> = Omit<WithMember<T>, 'failureStream'> & {
+  deployment: AiAppDeploymentInfo;
+};
+
 @Injectable()
 export class AiAppsService {
   private readonly logger = new Logger(AiAppsService.name);
@@ -156,13 +175,45 @@ export class AiAppsService {
     };
   }
 
+  /**
+   * The requester-gated response shape: the raw `failureStream` column never
+   * leaves the API, `notes` is nulled for non-managers (runner failure text is
+   * internal), and both reappear inside `deployment` for managers.
+   * `deployment.serving` goes to everyone — it's derived state, not detail:
+   * 'latest' = the current build serves; 'previous' = it last shipped
+   * successfully at `lastDeployedAt` and the runner keeps the old release
+   * serving through a failed rollout; 'none' = never shipped (strict — the
+   * only writer of `lastDeployedAt` is markReady).
+   */
+  private toApiApp<T extends AiApp>(app: WithMember<T>, isManager: boolean): ApiAiApp<T> {
+    const { failureStream, ...rest } = app;
+    const serving: AiAppServing = app.status === 'READY' ? 'latest' : app.lastDeployedAt ? 'previous' : 'none';
+    const deployment: AiAppDeploymentInfo = { serving };
+    if (isManager) {
+      if (app.notes) {
+        deployment.failureReason = app.notes;
+      }
+      if (failureStream === 'build' || failureStream === 'runtime') {
+        deployment.failureStream = failureStream;
+      }
+    }
+    return { ...rest, notes: isManager ? app.notes : null, deployment };
+  }
+
   /** Dashboard list — all non-deleted apps across PL Infra users, newest first, with owner info. */
-  async listApps(): Promise<Array<WithMember<AiApp>>> {
+  async listApps(requesterUid?: string): Promise<Array<ApiAiApp<AiApp>>> {
     const apps = await this.prisma.aiApp.findMany({
       where: { status: { not: 'DELETED' } },
       orderBy: { updatedAt: 'desc' },
     });
-    return this.withMember(await Promise.all(apps.map((app) => this.settleStuckDeploy(app))));
+    const settled = await Promise.all(apps.map((app) => this.settleStuckDeploy(app)));
+    // One admin lookup for the requester, then a per-row creator compare —
+    // never a per-row query.
+    const isAdmin = !!requesterUid && (await this.isRequesterDirectoryAdmin(requesterUid));
+    const withMembers = await this.withMember(settled);
+    return withMembers.map((app, index) =>
+      this.toApiApp(app, isAdmin || (!!requesterUid && settled[index].memberUid === requesterUid))
+    );
   }
 
   /**
@@ -170,7 +221,7 @@ export class AiAppsService {
    * `canManage` (creator or directory admin) — computed server-side so the UI
    * never has to compare member uids from a possibly stale login cookie.
    */
-  async getApp(uid: string, requesterUid?: string): Promise<WithMember<AiApp> & { canManage?: boolean }> {
+  async getApp(uid: string, requesterUid?: string): Promise<ApiAiApp<AiApp> & { canManage?: boolean }> {
     let app = await this.prisma.aiApp.findUnique({ where: { uid } });
     if (!app) {
       throw new NotFoundException(`AI App not found: ${uid}`);
@@ -178,9 +229,10 @@ export class AiAppsService {
     app = await this.settleStuckDeploy(app);
     const result = (await this.withMember([app]))[0];
     if (!requesterUid) {
-      return result;
+      return this.toApiApp(result, false);
     }
-    return { ...result, canManage: await this.isCreatorOrDirectoryAdmin(requesterUid, app) };
+    const canManage = await this.isCreatorOrDirectoryAdmin(requesterUid, app);
+    return { ...this.toApiApp(result, canManage), canManage };
   }
 
   /** Updates dashboard metadata only; this never invokes the sandbox runner or starts a deploy. */
@@ -189,7 +241,7 @@ export class AiAppsService {
     uid: string,
     dto: UpdateAppMetadataDto,
     ownerOnly = false
-  ): Promise<WithMember<AiApp>> {
+  ): Promise<ApiAiApp<AiApp>> {
     if (dto.name === undefined && dto.description === undefined && dto.prd === undefined) {
       throw new BadRequestException('At least one of name, description, or prd must be provided');
     }
@@ -208,7 +260,7 @@ export class AiAppsService {
     if (dto.prd !== undefined) data.prd = dto.prd?.trim() || null;
 
     const updated = await this.prisma.aiApp.update({ where: { uid }, data });
-    return (await this.withMember([updated]))[0];
+    return this.toApiApp((await this.withMember([updated]))[0], true);
   }
 
   /** Update metadata from JSON or multipart; a PRD file overrides body.prd. */
@@ -217,7 +269,7 @@ export class AiAppsService {
     uid: string,
     dto: UpdateAppMetadataDto,
     file?: Express.Multer.File
-  ): Promise<WithMember<AiApp>> {
+  ): Promise<ApiAiApp<AiApp>> {
     if (!file) {
       return this.updateMetadata(requesterUid, uid, dto);
     }
@@ -228,7 +280,7 @@ export class AiAppsService {
   }
 
   /** File-only PRD upload used by POST /:uid/prd. */
-  async uploadPrd(requesterUid: string, uid: string, file: Express.Multer.File): Promise<WithMember<AiApp>> {
+  async uploadPrd(requesterUid: string, uid: string, file: Express.Multer.File): Promise<ApiAiApp<AiApp>> {
     return this.storePrdFile(requesterUid, uid, file, {} as UpdateAppMetadataDto);
   }
 
@@ -238,7 +290,7 @@ export class AiAppsService {
     uid: string,
     file: Express.Multer.File,
     metadata: UpdateAppMetadataDto
-  ): Promise<WithMember<AiApp>> {
+  ): Promise<ApiAiApp<AiApp>> {
     const extension = this.validatePrdFile(file);
     if (!AI_APPS_PRD_S3_BUCKET) {
       throw new InternalServerErrorException('No PRD bucket configured (AI_APPS_PRD_S3_BUCKET or AI_APPS_S3_BUCKET)');
@@ -688,7 +740,9 @@ export class AiAppsService {
       'or the sandbox runner is unavailable. Retry the deploy once the runner is healthy.';
     const { count } = await this.prisma.aiApp.updateMany({
       where: { uid: app.uid, status: 'DEPLOYING' },
-      data: { status: 'ERROR', notes: message },
+      // failureStream stays null: an interrupted deploy's failing phase is
+      // genuinely unknown (and a stale value from an older failure must not leak).
+      data: { status: 'ERROR', notes: message, failureStream: null },
     });
     if (count > 0) {
       this.logger.warn(
@@ -774,6 +828,11 @@ export class AiAppsService {
     if (app.memberUid === requesterUid) {
       return true;
     }
+    return this.isRequesterDirectoryAdmin(requesterUid);
+  }
+
+  /** Requester-only admin check — computed once and reused per row on list responses. */
+  private async isRequesterDirectoryAdmin(requesterUid: string): Promise<boolean> {
     const requester = await this.prisma.member.findUnique({
       where: { uid: requesterUid },
       select: { memberRoles: { select: { name: true } } },
@@ -791,7 +850,7 @@ export class AiAppsService {
     dto: DeployAppDto,
     file: Express.Multer.File,
     agentClient?: string | null
-  ): Promise<WithMember<AiApp>> {
+  ): Promise<ApiAiApp<AiApp>> {
     if (!file?.buffer?.length) {
       throw new BadGatewayException('Missing app ZIP file');
     }
@@ -861,7 +920,8 @@ export class AiAppsService {
       );
     } catch (error) {
       const message = `Deploy failed: ${(error as Error).message}`;
-      await this.failDeploy(app.uid, memberUid, eventContext, message);
+      // Bundle never reached storage — nothing was built, a build-log story.
+      await this.failDeploy(app.uid, memberUid, eventContext, message, 'build');
       throw new BadGatewayException('Failed to store the app bundle');
     }
 
@@ -881,7 +941,7 @@ export class AiAppsService {
     dto: RegisterDraftDto,
     file: Express.Multer.File,
     agentClient?: string | null
-  ): Promise<WithMember<AiApp> & { appPageUrl: string; missingEnvVars: string[] }> {
+  ): Promise<ApiAiApp<AiApp> & { appPageUrl: string; missingEnvVars: string[] }> {
     if (!file?.buffer?.length) {
       throw new BadRequestException('Missing app ZIP file');
     }
@@ -950,7 +1010,7 @@ export class AiAppsService {
 
     const provided = new Set(app.providedEnvVars);
     return {
-      ...(await this.withMember([app]))[0],
+      ...this.toApiApp((await this.withMember([app]))[0], true),
       appPageUrl: buildAppPageUrl(app.uid),
       missingEnvVars: app.requiredEnvVars.filter((name) => !provided.has(name)),
     };
@@ -962,7 +1022,7 @@ export class AiAppsService {
    * (merge/upsert — values never touch our DB), validates every required env
    * var has a value, then redeploys the stored bundle.
    */
-  async deployDraft(requesterUid: string, uid: string, secrets?: Record<string, string>): Promise<WithMember<AiApp>> {
+  async deployDraft(requesterUid: string, uid: string, secrets?: Record<string, string>): Promise<ApiAiApp<AiApp>> {
     const app = await this.prisma.aiApp.findUnique({ where: { uid } });
     if (!app) {
       throw new NotFoundException(`AI App not found: ${uid}`);
@@ -1043,13 +1103,13 @@ export class AiAppsService {
     deploymentId: string,
     s3Key: string,
     secretNames: string[] = []
-  ): Promise<WithMember<AiApp>> {
+  ): Promise<ApiAiApp<AiApp>> {
     const host = buildAppHost(app.appId);
     const url = buildAppUrl(app.appId);
     const httpUrl = buildAppHttpUrl(app.appId);
     await this.prisma.aiApp.update({
       where: { uid: app.uid },
-      data: { status: 'DEPLOYING', deploymentId, s3Key, url, httpUrl, host, notes: null },
+      data: { status: 'DEPLOYING', deploymentId, s3Key, url, httpUrl, host, notes: null, failureStream: null },
     });
     this.dropLogsTailCache(app.appId);
 
@@ -1058,10 +1118,12 @@ export class AiAppsService {
     const markReady = async (port: number | null) => {
       const updated = await this.prisma.aiApp.update({
         where: { uid: app.uid },
-        data: { status: 'READY', url, httpUrl, host, port, notes: null },
+        // The ONLY writer of lastDeployedAt — it must strictly mean "last
+        // successful ship" (deployment.serving derives 'none' from its absence).
+        data: { status: 'READY', url, httpUrl, host, port, notes: null, failureStream: null, lastDeployedAt: new Date() },
       });
       await this.recordEvent('DEPLOY_SUCCEEDED', memberUid, { ...eventContext, message: url });
-      return (await this.withMember([updated]))[0];
+      return this.toApiApp((await this.withMember([updated]))[0], true);
     };
 
     let port: number | null = null;
@@ -1076,8 +1138,20 @@ export class AiAppsService {
         { headers: { 'Content-Type': 'application/json', 'x-runner-token': AI_APPS_RUNNER_TOKEN } }
       );
       this.logRunnerResponse('deploy', app.appId, response.status, response.data);
+      // The runner sometimes reports failure inside a 2xx body (see
+      // logRunnerResponse) — treating that as success would mark a dead deploy
+      // READY and corrupt lastDeployedAt/serving.
+      if (typeof response.data?.status === 'string' && response.data.status.toLowerCase() === 'failed') {
+        const message = `Runner reported failure: ${this.safeStringify(response.data)}`;
+        this.logger.error(`AI App deploy failed for ${app.appId}: ${message}`);
+        await this.failDeploy(app.uid, memberUid, eventContext, message, 'build');
+        throw new BadGatewayException('Failed to deploy app to the sandbox runner');
+      }
       port = response.data.port ?? null;
     } catch (error) {
+      if (error instanceof BadGatewayException) {
+        throw error;
+      }
       this.logRunnerError('deploy', app.appId, error);
       const message = axios.isAxiosError(error)
         ? `Runner error: ${error.response?.status ?? ''} ${JSON.stringify(error.response?.data ?? error.message)}`
@@ -1086,14 +1160,18 @@ export class AiAppsService {
       // A gateway timeout (Cloudflare 504/524, etc.) or no response doesn't mean the
       // deploy failed — the long-running build often completes on the origin. Verify
       // by checking whether the app is actually reachable before declaring failure.
+      const uncertain = this.isUncertainRunnerError(error);
       let survivedTimeout = false;
-      if (this.isUncertainRunnerError(error)) {
+      if (uncertain) {
         this.logger.warn(`Runner timed out for ${app.appId}; verifying app at ${url}. (${message})`);
         survivedTimeout = await this.verifyAppLive(url);
       }
       if (!survivedTimeout) {
         this.logger.error(`AI App deploy failed for ${app.appId}: ${message}`);
-        await this.failDeploy(app.uid, memberUid, eventContext, message);
+        // A hard runner error is a build-phase failure; a timeout with the app
+        // never becoming reachable is genuinely unknown (build may have hung OR
+        // the pod may have crashed) — leave the stream unclassified.
+        await this.failDeploy(app.uid, memberUid, eventContext, message, uncertain ? null : 'build');
         throw new BadGatewayException('Failed to deploy app to the sandbox runner');
       }
       this.logger.log(`AI App ${app.appId} is live despite runner timeout — continuing`);
@@ -1108,7 +1186,8 @@ export class AiAppsService {
       } catch (error) {
         const message = `Secrets injection failed: ${(error as Error).message}`;
         this.logger.error(`AI App deploy failed for ${app.appId}: ${message}`);
-        await this.failDeploy(app.uid, memberUid, eventContext, message);
+        // The image already built — injecting/starting it is a runtime story.
+        await this.failDeploy(app.uid, memberUid, eventContext, message, 'runtime');
         throw new BadGatewayException('Failed to inject secrets on the sandbox runner');
       }
     }
@@ -1178,16 +1257,24 @@ export class AiAppsService {
     return this.safeStringify(error.response.data).includes('helm_release_locked');
   }
 
-  /** Marks a failed deploy: status ERROR with the trimmed message + DEPLOY_FAILED event. */
+  /**
+   * Marks a failed deploy: status ERROR with the trimmed message + DEPLOY_FAILED
+   * event. `failureStream` says which log stream holds the failure ('build' |
+   * 'runtime'), classified by the caller from where in the deploy flow the
+   * failure was caught — the runner's log endpoints only cover the latest
+   * SUCCESSFUL phase, so this cannot be derived after the fact. Null = unknown.
+   * `lastDeployedAt` is deliberately untouched: a failed deploy never moves it.
+   */
   private async failDeploy(
     appUid: string,
     memberUid: string,
     eventContext: { appUid: string; appId: string; deploymentId: string },
-    message: string
+    message: string,
+    failureStream: 'build' | 'runtime' | null = null
   ): Promise<void> {
     await this.prisma.aiApp.update({
       where: { uid: appUid },
-      data: { status: 'ERROR', notes: message.slice(0, 2000) },
+      data: { status: 'ERROR', notes: message.slice(0, 2000), failureStream },
     });
     await this.recordEvent('DEPLOY_FAILED', memberUid, { ...eventContext, message: message.slice(0, 2000) });
   }
@@ -1266,7 +1353,7 @@ export class AiAppsService {
    * the delete events. The row is kept (status flips to `DELETED`) so the audit
    * trail survives. `memberUid` is the member performing the deletion.
    */
-  async deleteApp(memberUid: string, uid: string): Promise<WithMember<AiApp>> {
+  async deleteApp(memberUid: string, uid: string): Promise<ApiAiApp<AiApp>> {
     const app = await this.prisma.aiApp.findUnique({ where: { uid } });
     if (!app) {
       throw new NotFoundException(`AI App not found: ${uid}`);
@@ -1288,7 +1375,7 @@ export class AiAppsService {
         data: { status: 'DELETED', url: null, httpUrl: null, host: null, port: null, notes: null },
       });
       await this.recordEvent('DELETE_SUCCEEDED', memberUid, eventContext);
-      return (await this.withMember([updated]))[0];
+      return this.toApiApp((await this.withMember([updated]))[0], true);
     } catch (error) {
       this.logRunnerError('delete', app.appId, error);
       const message = axios.isAxiosError(error)

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -357,6 +357,8 @@ model AiApp {
   kitVersion   String?         // starter-kit version behind the last agent upload (null = pre-1.4 kit)
   agentClient  String?         // AI tool from the connect session's clientName (e.g. "Claude Code")
   agentModel   String?         // model the agent reported for the last upload (self-reported)
+  lastDeployedAt DateTime?     // last SUCCESSFUL ship (written only by markReady; null = never shipped)
+  failureStream  String?       // 'build' | 'runtime' — which log stream holds the LATEST deploy failure (null = unknown)
   @@unique([memberUid, appId])
 }
 
@@ -406,6 +408,18 @@ model AiAppEvent {            // append-only audit log — one row per event, ne
 Apps are **lazy-created on first deploy** — there is no registration form. (A draft registration counts: it upserts the same record with status `DRAFT`.)
 
 **Response shape:** every AI Apps endpoint (`list`, detail, `events`, and the `deploy` result) returns the owner as `member: { uid, name, image }` and omits the raw `memberUid` (the uid lives in `member.uid`, so it isn't duplicated). `memberUid` remains a column on the DB models above. The detail endpoint additionally returns `canManage` — whether the requesting member is the creator or a directory admin — computed server-side so the UI never compares member uids from a possibly stale login cookie.
+
+**Deployment block & failure-detail gating:** every app response (list, detail, deploy/metadata/delete results) replaces the raw `failureStream` column with a `deployment` object:
+
+```jsonc
+"deployment": {
+  "serving": "latest" | "previous" | "none",  // everyone: what actually serves traffic
+  "failureReason": "…",                        // managers only — equals `notes` (runner failure text)
+  "failureStream": "build" | "runtime"        // managers only — which log tab holds the failure
+}
+```
+
+`serving` is derived, never stored: `READY` → `latest`; otherwise `lastDeployedAt` set → `previous` (the app shipped before, and the runner keeps the old release serving through a failed rollout), else `none` (never shipped — strict, since `markReady` is `lastDeployedAt`'s only writer, and a failed deploy never touches it). "Manager" = the app's creator or a directory admin; the list endpoint resolves the requester (like detail) and gates per row with a single admin lookup. Non-managers also get `notes: null` — the runner's failure text can carry stack fragments, image names, and internal hostnames, and the dashboard deliberately shows visitors a completely normal card for failed apps. `failureStream` is classified at failure time from the deploy control flow (S3/bundle and hard runner errors → `build`; secrets-injection failures → `runtime`; timeouts where the app never came up and stuck-deploy settles → `null`), because the runner's log endpoints only cover the latest *successful* phase. A runner 2xx whose body carries `status: "failed"` is treated as a deploy failure (it used to be silently treated as success).
 
 `AiApp.status` is the current-state snapshot for the dashboard; `AiAppEvent` is the immutable event flow. A row is appended on kit download (`KIT_DOWNLOADED`), on each connect approval/denial (`CONNECT_APPROVED` / `CONNECT_DENIED` — the `userCode` is recorded in `message`), at the start of every deploy (`DEPLOY_STARTED`) and its outcome (`DEPLOY_SUCCEEDED` / `DEPLOY_FAILED`), and likewise for deletes (`DELETE_STARTED` → `DELETE_SUCCEEDED` / `DELETE_FAILED`). Event logging never throws — a logging failure won't break a download, connect, deploy, or delete.
 


### PR DESCRIPTION
## Summary

Backend half of the AI Apps deploy-failure status feature (frontend: memser-spaceport/pln-directory-portal-v2#2698). Every AI App response now carries:

```jsonc
"deployment": {
  "serving": "latest" | "previous" | "none",   // everyone
  "failureReason": "…",                         // managers only (= notes)
  "failureStream": "build" | "runtime"         // managers only
}
```

### Data model
- **`AiApp.lastDeployedAt`** — written **only** by `markReady` (the success path). A failed deploy never touches it, so `serving: 'none'` strictly means "never successfully shipped", and the FE gets a stable signal to key iframe remounts on (failed deploys still bump `updatedAt` via Prisma's `@updatedAt`; existing sort/stuck-deploy semantics depend on that and are untouched).
- **`AiApp.failureStream`** — classified at failure time from the deploy control flow (the runner's log endpoints only cover the latest *successful* phase, so it cannot be derived later): S3/bundle + hard runner errors → `build`; secrets-injection failures → `runtime`; timeouts where the app never became reachable and stuck-deploy settles → `null`. Cleared on every new attempt and on success.
- **Migration** backfills `lastDeployedAt` from `DEPLOY_SUCCEEDED` audit events (plus `updatedAt` fallback for READY rows), so pre-existing failed apps that once shipped don't read as "Never deployed".

### Serving derivation (never stored)
`READY` → `latest`; otherwise `lastDeployedAt` set → `previous`, else `none`.

> **Infra assumption to confirm:** `previous` relies on the runner (Helm/K8s) keeping the old release serving through a failed rollout — standard rolling-update semantics, but worth a nod from the runner team.

### Security: failure details are now manager-gated
`GET /v1/ai-apps` (list) resolves the requester like the detail route (one directory-admin lookup, per-row creator compare — no N+1) and **nulls `notes` for non-managers on both list and detail**. This closes a pre-existing leak: runner failure text (stack fragments, image names, internal hostnames) previously went to every member in the list payload. The raw `failureStream` column never leaves the API — it only appears inside the gated `deployment` block.

### Bug fix along the way
A runner **2xx response carrying `status: "failed"` in the body** was silently treated as deploy success (only `port` was read). It now fails the deploy properly — previously this could mark a dead deploy `READY`, which would have corrupted `lastDeployedAt`/`serving`.

## Testing

New `ai-apps-deployment.spec.ts` (17 tests, repo's service-unit convention): serving matrix, manager/anonymous/list gating incl. the single-admin-lookup guarantee, `lastDeployedAt` written only on success, per-call-site `failureStream` classification, 2xx-`failed` handling, stale-stream clearing on stuck settles. All 9 ai-apps suites pass (102 tests); the full web-api suite's pass/fail set is byte-identical to `develop` (remaining failures are pre-existing, mostly e2e specs that don't run in this jest setup).

## Integration notes (FE)

- FE PR #2698 ships dark and activates automatically when this lands — its dev mock skips apps that already carry real `deployment` data.
- Follow-up FE change once deployed: key the detail-page iframe remount + probe generation on `lastDeployedAt` instead of `updatedAt`, so a *failed* deploy refetch can't reload a visitor's working previous version mid-use.
- The FE's mock env flag (`NEXT_PUBLIC_AI_APPS_DEPLOYMENT_MOCK`) must be off when validating against this API.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)