### PR TITLE
LAB-2176 [AI Apps] Database provisioning

### DIFF
--- a/apps/web-api/prisma/migrations/20260730120000_ai_apps_database_provisioning/migration.sql
+++ b/apps/web-api/prisma/migrations/20260730120000_ai_apps_database_provisioning/migration.sql
@@ -1,0 +1,12 @@
+-- AI Apps: agent-driven database provisioning. The agent can ask the
+-- Deployment Orchestrator to provision a Postgres database for an app
+-- (opt-in convenience for non-technical builders); these columns track the
+-- request and the non-sensitive connection metadata the orchestrator returns.
+-- The password is never stored — only injected into the app's runtime pod.
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseEnabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseType" TEXT;
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseHost" TEXT;
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databasePort" INTEGER;
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseName" TEXT;
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseUser" TEXT;
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseCredentialsInjected" BOOLEAN;

--- a/apps/web-api/prisma/migrations/20260730120000_ai_apps_database_provisioning/migration.sql
+++ b/apps/web-api/prisma/migrations/20260730120000_ai_apps_database_provisioning/migration.sql
@@ -1,12 +1,8 @@
 -- AI Apps: agent-driven database provisioning. The agent can ask the
 -- Deployment Orchestrator to provision a Postgres database for an app
--- (opt-in convenience for non-technical builders); these columns track the
--- request and the non-sensitive connection metadata the orchestrator returns.
--- The password is never stored — only injected into the app's runtime pod.
-ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseEnabled" BOOLEAN NOT NULL DEFAULT false;
-ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseType" TEXT;
-ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseHost" TEXT;
-ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databasePort" INTEGER;
-ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseName" TEXT;
-ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseUser" TEXT;
-ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "databaseCredentialsInjected" BOOLEAN;
+-- (opt-in convenience for non-technical builders). Stored as a single JSON
+-- blob, mirroring the `database` block returned in the API response, since
+-- these fields are always read/written together and never queried
+-- individually. The password is never stored — only injected into the app's
+-- runtime pod.
+ALTER TABLE "AiApp" ADD COLUMN IF NOT EXISTS "database" JSONB;

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -3248,6 +3248,23 @@ model AiApp {
   /// cover the last successful phase, so it can't be derived after the fact).
   /// Null when unknown (e.g. stuck-deploy settle); cleared on success.
   failureStream   String?
+  /// Whether the LAST deploy/draft upload asked us to provision a database —
+  /// an opt-in convenience for non-technical builders (mirrors kitVersion/
+  /// agentModel: reflects the last upload, false when a call omits it). A
+  /// bring-your-own database is just a regular runtime secret and isn't
+  /// tracked here.
+  databaseEnabled Boolean     @default(false)
+  /// Requested database engine, e.g. "postgres". Null when not enabled.
+  databaseType    String?
+  /// Non-sensitive connection metadata returned by the Deployment
+  /// Orchestrator once it provisions the database. The password is never
+  /// returned to us or stored — only the app's runtime pod receives it via
+  /// injected environment variables.
+  databaseHost    String?
+  databasePort    Int?
+  databaseName    String?
+  databaseUser    String?
+  databaseCredentialsInjected Boolean?
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
 

--- a/apps/web-api/prisma/schema.prisma
+++ b/apps/web-api/prisma/schema.prisma
@@ -3248,23 +3248,16 @@ model AiApp {
   /// cover the last successful phase, so it can't be derived after the fact).
   /// Null when unknown (e.g. stuck-deploy settle); cleared on success.
   failureStream   String?
-  /// Whether the LAST deploy/draft upload asked us to provision a database —
-  /// an opt-in convenience for non-technical builders (mirrors kitVersion/
-  /// agentModel: reflects the last upload, false when a call omits it). A
-  /// bring-your-own database is just a regular runtime secret and isn't
-  /// tracked here.
-  databaseEnabled Boolean     @default(false)
-  /// Requested database engine, e.g. "postgres". Null when not enabled.
-  databaseType    String?
-  /// Non-sensitive connection metadata returned by the Deployment
-  /// Orchestrator once it provisions the database. The password is never
-  /// returned to us or stored — only the app's runtime pod receives it via
-  /// injected environment variables.
-  databaseHost    String?
-  databasePort    Int?
-  databaseName    String?
-  databaseUser    String?
-  databaseCredentialsInjected Boolean?
+  /// Database provisioning requested on the LAST deploy/draft upload, plus
+  /// non-sensitive connection metadata once the Deployment Orchestrator
+  /// provisions it — an opt-in convenience for non-technical builders
+  /// (mirrors kitVersion/agentModel: reflects the last upload, null when a
+  /// call omits it). Shape: `{ enabled, type, host?, port?, name?, user?,
+  /// credentialsInjected? }` — mirrors the API response's `database` block
+  /// exactly. The password is never stored, only injected into the app's
+  /// runtime pod. A bring-your-own database is just a regular runtime secret
+  /// and isn't tracked here.
+  database        Json?
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
 

--- a/apps/web-api/src/ai-apps/ai-apps-database.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-database.spec.ts
@@ -1,0 +1,195 @@
+/// <reference types="multer" />
+
+// axios ships ESM (not in the jest transform allowlist); the deploy paths under
+// test call it, so mock the calls themselves.
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  get: jest.fn(),
+  isAxiosError: jest.fn((error: any) => !!error?.isAxiosError),
+}));
+
+// The constants module reads env vars at import time; pin the bucket so the
+// deploy/draft upload paths are exercised regardless of the test environment.
+jest.mock('./ai-apps.constants', () => ({
+  ...jest.requireActual('./ai-apps.constants'),
+  AI_APPS_S3_BUCKET: 'test-bucket',
+}));
+
+import axios from 'axios';
+import { AiAppsService } from './ai-apps.service';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const FILE = { buffer: Buffer.from('zip'), mimetype: 'application/zip' } as Express.Multer.File;
+
+/**
+ * Stateful prisma mock: unlike the simpler per-call mocks elsewhere, this one
+ * accumulates writes across calls so a single deploy's several `update()`s
+ * (DEPLOYING → READY) and a later, separate `deployDraft()` see the same
+ * persisted row — needed to prove `databaseEnabled`/`databaseType` survive
+ * between calls the way the real DB would.
+ */
+function buildService(initial: Record<string, any> | null = null) {
+  let row: Record<string, any> | null = initial ? { ...initial } : null;
+  const prisma = {
+    aiApp: {
+      findUnique: jest.fn().mockImplementation(() => Promise.resolve(row ? { ...row } : null)),
+      upsert: jest.fn().mockImplementation(({ create, update }) => {
+        row = row ? { ...row, ...update } : { uid: 'app-1', memberUid: 'creator-1', ...create };
+        return Promise.resolve({ ...row });
+      }),
+      update: jest.fn().mockImplementation(({ data }) => {
+        row = { ...(row as Record<string, any>), ...data };
+        return Promise.resolve({ ...row });
+      }),
+    },
+    aiAppEvent: { create: jest.fn().mockResolvedValue({}) },
+    member: {
+      findMany: jest.fn().mockResolvedValue([]),
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
+  };
+  const aws = { uploadFileToS3: jest.fn().mockResolvedValue(undefined) };
+  return { service: new AiAppsService(prisma as any, aws as any), prisma, aws, getRow: () => row };
+}
+
+const DEPLOY_DTO = {
+  appId: 'demo',
+  name: 'Demo',
+  description: 'desc',
+  deploymentId: 'd1',
+  database: { enabled: true, type: 'postgres' },
+} as any;
+
+const DEPLOY_DTO_NO_DATABASE = {
+  appId: 'demo',
+  name: 'Demo',
+  description: 'desc',
+  deploymentId: 'd2',
+} as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('agent-driven database provisioning', () => {
+  it('forwards {enabled, type} to the runner and reflects it in the response', async () => {
+    const { service } = buildService(null);
+    mockedAxios.post.mockResolvedValue({ status: 200, data: { port: 31001 } });
+
+    const result = await service.deploy('creator-1', DEPLOY_DTO, FILE);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/deploy'),
+      expect.objectContaining({ appId: 'demo', database: { enabled: true, type: 'postgres' } }),
+      expect.anything()
+    );
+    expect(result.database).toEqual({ enabled: true, type: 'postgres' });
+  });
+
+  it('omits the database field from the runner request when not requested', async () => {
+    const { service } = buildService(null);
+    mockedAxios.post.mockResolvedValue({ status: 200, data: { port: 31001 } });
+
+    const result = await service.deploy('creator-1', DEPLOY_DTO_NO_DATABASE, FILE);
+
+    const [, body] = mockedAxios.post.mock.calls[0];
+    expect(body).not.toHaveProperty('database');
+    expect(result.database).toEqual({ enabled: false });
+  });
+
+  it('stores non-sensitive connection metadata the runner returns once it provisions the database', async () => {
+    const { service } = buildService(null);
+    mockedAxios.post.mockResolvedValue({
+      status: 200,
+      data: {
+        port: 31001,
+        database: {
+          host: 'ai-rds.internal',
+          port: 5432,
+          name: 'db_demo',
+          user: 'db_demo_user',
+          type: 'postgres',
+          credentialsInjected: true,
+        },
+      },
+    });
+
+    const result = await service.deploy('creator-1', DEPLOY_DTO, FILE);
+
+    expect(result.database).toEqual({
+      enabled: true,
+      type: 'postgres',
+      host: 'ai-rds.internal',
+      port: 5432,
+      name: 'db_demo',
+      user: 'db_demo_user',
+      credentialsInjected: true,
+    });
+    // The password never touches us — it isn't part of the runner's response
+    // contract, so it can never appear on the stored row or the API response.
+    expect(JSON.stringify(result)).not.toMatch(/password/i);
+  });
+
+  it('the application never has to generate credentials — only enabled+type is sent, never generated ourselves', async () => {
+    const { service } = buildService(null);
+    mockedAxios.post.mockResolvedValue({ status: 200, data: { port: 31001 } });
+
+    await service.deploy('creator-1', DEPLOY_DTO, FILE);
+
+    const [, body] = mockedAxios.post.mock.calls[0] as [string, Record<string, any>];
+    expect(body.database).toEqual({ enabled: true, type: 'postgres' });
+  });
+
+  it('a member-triggered redeploy keeps requesting the previously provisioned database without the agent resending it', async () => {
+    const existing = {
+      uid: 'app-1',
+      memberUid: 'creator-1',
+      appId: 'demo',
+      name: 'Demo',
+      status: 'READY',
+      s3Key: 'apps/demo/d1/app.zip',
+      deploymentId: 'd1',
+      requiredEnvVars: [],
+      providedEnvVars: [],
+      databaseEnabled: true,
+      databaseType: 'postgres',
+      updatedAt: new Date(),
+    };
+    const { service } = buildService(existing);
+    mockedAxios.post.mockResolvedValue({ status: 200, data: { port: 31001 } });
+
+    await service.deployDraft('creator-1', 'app-1', undefined);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/deploy'),
+      expect.objectContaining({ database: { enabled: true, type: 'postgres' } }),
+      expect.anything()
+    );
+  });
+
+  it('a later deploy that omits the field turns provisioning off for that deploy (mirrors kitVersion/agentModel semantics)', async () => {
+    const existing = {
+      uid: 'app-1',
+      memberUid: 'creator-1',
+      appId: 'demo',
+      name: 'Demo',
+      status: 'READY',
+      s3Key: 'apps/demo/d1/app.zip',
+      deploymentId: 'd1',
+      requiredEnvVars: [],
+      providedEnvVars: [],
+      databaseEnabled: true,
+      databaseType: 'postgres',
+      updatedAt: new Date(),
+    };
+    const { service } = buildService(existing);
+    mockedAxios.post.mockResolvedValue({ status: 200, data: { port: 31001 } });
+
+    const result = await service.deploy('creator-1', DEPLOY_DTO_NO_DATABASE, FILE);
+
+    const [, body] = mockedAxios.post.mock.calls[0];
+    expect(body).not.toHaveProperty('database');
+    expect(result.database).toEqual({ enabled: false });
+  });
+});

--- a/apps/web-api/src/ai-apps/ai-apps-database.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-database.spec.ts
@@ -26,8 +26,8 @@ const FILE = { buffer: Buffer.from('zip'), mimetype: 'application/zip' } as Expr
  * Stateful prisma mock: unlike the simpler per-call mocks elsewhere, this one
  * accumulates writes across calls so a single deploy's several `update()`s
  * (DEPLOYING → READY) and a later, separate `deployDraft()` see the same
- * persisted row — needed to prove `databaseEnabled`/`databaseType` survive
- * between calls the way the real DB would.
+ * persisted row — needed to prove the `database` column survives between
+ * calls the way the real DB would.
  */
 function buildService(initial: Record<string, any> | null = null) {
   let row: Record<string, any> | null = initial ? { ...initial } : null;
@@ -152,8 +152,7 @@ describe('agent-driven database provisioning', () => {
       deploymentId: 'd1',
       requiredEnvVars: [],
       providedEnvVars: [],
-      databaseEnabled: true,
-      databaseType: 'postgres',
+      database: { enabled: true, type: 'postgres' },
       updatedAt: new Date(),
     };
     const { service } = buildService(existing);
@@ -179,8 +178,7 @@ describe('agent-driven database provisioning', () => {
       deploymentId: 'd1',
       requiredEnvVars: [],
       providedEnvVars: [],
-      databaseEnabled: true,
-      databaseType: 'postgres',
+      database: { enabled: true, type: 'postgres' },
       updatedAt: new Date(),
     };
     const { service } = buildService(existing);

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
@@ -894,6 +894,31 @@ step 6 — you register a draft and the member deploys from LabOS after entering
 values there. Never deploy a secrets app directly and never accept key values in
 the chat.
 
+**Needs a database? Decide this too, BEFORE deploying.** Check whether the app
+talks to a database (an ORM/driver import, a \`DATABASE_URL\`/\`DB_*\` read, or
+code you wrote that needs one):
+
+\`\`\`bash
+grep -rniE "DATABASE_URL|postgres|pg\\.Pool|prisma|mongoose|mysql" app --include='*.js' --include='*.ts' --include='*.py' --include='*.json'
+\`\`\`
+
+If the app needs one, **ask the member which they want — don't assume**:
+
+- *"I can set up a database for you automatically — no accounts or setup on
+  your end. Or, if you already have your own database, you can connect that
+  instead. Which would you like?"*
+
+**They want PLN to provision one** (the easy path for non-technical members):
+follow "**Apps that want a provisioned database**" below — add the \`database\`
+field to your deploy/draft call, and the app gets ready-to-use connection env
+vars automatically. You never create the database or generate credentials
+yourself.
+
+**They want to bring their own**: this is just a runtime secret — add a
+connection env var name (e.g. \`DATABASE_URL\`) to \`requiredEnvVars\` and follow
+"**Apps that need secrets (draft flow)**" below; the member pastes their own
+connection string into the LabOS secrets page, same as an API key.
+
 ## Steps
 1. Read \`pln-app.config.json\` to get \`connectEndpoint\`, \`deployEndpoint\`,
    \`draftEndpoint\`, \`metadataEndpoint\`, the \`kitVersion\` (sent with every upload
@@ -973,8 +998,13 @@ the chat.
      -F "deploymentId=<unique id per deploy, e.g. a timestamp>" \\
      -F "kitVersion=<the kitVersion from pln-app.config.json>" \\
      -F "agentModel=<the model you are running on, e.g. claude-sonnet-4-5; omit the field if unknown>" \\
+     -F 'database={"enabled":true,"type":"postgres"}' \\
      -F "file=@app.zip;type=application/zip"
    \`\`\`
+
+   Omit the \`database\` field entirely if the app doesn't need one, or the
+   member is bringing their own — see "Apps that want a provisioned database"
+   below for when to include it.
 
 7. On success the response contains the app record with its deployment URL and
    status:
@@ -1035,6 +1065,9 @@ curl -X POST "<draftEndpoint>" \\
 # → { "uid": "cl…", "status": "DRAFT", "appPageUrl": "https://…/pl-infra/ai-apps/<uid>", "missingEnvVars": [ … ] }
 \`\`\`
 
+An app can need secrets AND a provisioned database — add \`database\` (see
+"Apps that want a provisioned database" below) to this same draft call.
+
 Save the response's \`uid\` as \`appUid\` in \`pln-app.config.json\`, same as a
 regular deploy.
 
@@ -1062,6 +1095,49 @@ on the AI Apps dashboard.
   on the app's card and choose **Deployment settings**. If they want a direct
   link, hand them \`appSettingsUrl\` from \`pln-app.config.json\` with \`{appUid}\`
   replaced by the saved \`appUid\` — it opens that modal straight away.
+
+## Apps that want a provisioned database
+
+When the member asks PLN to provision a database (see "Needs a database?"
+above), add \`database\` to the SAME deploy or draft call from step 6 — it's
+one extra multipart field, not a separate request:
+
+\`\`\`bash
+-F 'database={"enabled":true,"type":"postgres"}'
+\`\`\`
+
+That's the entire contract. You never create the database, generate a
+username/password, or write any provisioning code — the Deployment
+Orchestrator provisions a dedicated Postgres database and user, and injects
+the connection details into the app's runtime as environment variables. Read
+them with your normal env-var access (\`process.env.DATABASE_URL\`,
+\`os.environ["DATABASE_URL"]\`, …) — never hardcode a connection string or ask
+the member for one:
+
+| Variable | Use it when… |
+|---|---|
+| \`DATABASE_URL\` | your framework/ORM takes a standard Postgres URL (\`postgresql://user:pass@host:5432/db\`) |
+| \`JDBC_DATABASE_URL\` | a Java/JDBC app (\`jdbc:postgresql://host:5432/db\`) |
+| \`DB_TYPE\`, \`DB_HOST\`, \`DB_PORT\`, \`DB_NAME\`, \`DB_USER\`, \`DB_PASSWORD\` | you need the individual parameters |
+
+The database user can only read/write its own database — it can't create
+other databases or roles, so don't write migration code that assumes
+superuser rights. \`CREATE TABLE\`/\`INSERT\`/etc. work normally.
+
+- **Once provisioned, keep sending \`database\` on every future deploy of this
+  app** (redeploys, code updates — every call from step 6), exactly like you
+  resend \`appName\`/\`appDescription\`. Save \`{"enabled":true,"type":"postgres"}\`
+  to \`pln-app.config.json\` (see the \`database\` key) the first time the member
+  opts in, and read it back on every later deploy instead of asking again.
+- Only ask the member once per app. If \`database\` is already set in the
+  config, don't re-run the "Needs a database?" prompt on redeploys.
+- This is entirely optional — if the member already has their own database,
+  don't send this field at all; treat their connection string as a regular
+  runtime secret instead (see "Apps that need secrets" above).
+- The response's \`database\` block (\`enabled\`, \`type\`, \`host\`, \`port\`, \`name\`,
+  \`user\`, \`credentialsInjected\`) is informational only — never the password —
+  and is not something you need to show the member; the app already has what
+  it needs via the injected env vars.
 
 ## Keep the deployment URL private
 This rule covers ONLY the deployed app's own address — the URL/host/port on
@@ -1115,6 +1191,9 @@ errors or misbehaves. Log lines may include the app's URL/host — the
 - Runtime secrets are supported only through the draft flow above — the sandbox
   injects exactly the env vars the member provided in LabOS. Non-secret config
   should ship sensible defaults — see the migration checklist in \`AGENTS.md\`.
+- Database provisioning is entirely optional and only for members who ask for
+  it — never send \`database\` unprompted, and never provision one just because
+  the app happens to touch a database driver without asking first.
 `;
   }
 
@@ -1135,8 +1214,9 @@ errors or misbehaves. Log lines may include the app's URL/host — the
         appUid: '',
         appName: '',
         appDescription: '',
+        database: null,
         notes:
-          'No token is stored here. At deploy time the agent runs the LabOS connect flow (see .claude/skills/deploy-to-labs) to get a short-lived deploy token. Set appId to a stable lowercase slug on first deploy and reuse it. appName/appDescription hold the member-APPROVED display metadata (see .claude/skills/app-metadata) — redeploys resend them verbatim. After the first deploy, save the response uid as appUid; metadataEndpoint, buildLogsEndpoint, runtimeLogsEndpoint, and appSettingsUrl are templates where {appUid} is replaced with it (appSettingsUrl opens the member-facing Deployment settings modal to update secrets & redeploy; the logs endpoints serve the build and runtime logs — see .claude/skills/app-logs). If the app needs runtime secrets, register it via draftEndpoint instead of deploying (see the deploy skill).',
+          'No token is stored here. At deploy time the agent runs the LabOS connect flow (see .claude/skills/deploy-to-labs) to get a short-lived deploy token. Set appId to a stable lowercase slug on first deploy and reuse it. appName/appDescription hold the member-APPROVED display metadata (see .claude/skills/app-metadata) — redeploys resend them verbatim. After the first deploy, save the response uid as appUid; metadataEndpoint, buildLogsEndpoint, runtimeLogsEndpoint, and appSettingsUrl are templates where {appUid} is replaced with it (appSettingsUrl opens the member-facing Deployment settings modal to update secrets & redeploy; the logs endpoints serve the build and runtime logs — see .claude/skills/app-logs). If the app needs runtime secrets, register it via draftEndpoint instead of deploying (see the deploy skill). database is null unless the member has opted into a PLN-provisioned database — once they do, set it to {"enabled":true,"type":"postgres"} and resend it verbatim on every deploy/draft call (see the deploy skill\'s "Apps that want a provisioned database"); a bring-your-own database is a regular runtime secret instead and never goes in this field.',
       },
       null,
       2

--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.spec.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.spec.ts
@@ -161,4 +161,27 @@ describe('AiAppsStarterKitService buildZip', () => {
     expect(skill).toContain('signed-out');
     expect(skill).toContain('"teams"');
   });
+
+  it('teaches the agent to offer database provisioning as an alternative to BYO', () => {
+    const config = JSON.parse(entries.get('pln-app.config.json') as string);
+    // Absent by default; the agent sets it only after the member opts in, and
+    // persists it so redeploys don't have to ask again.
+    expect(config.database).toBeNull();
+
+    const deploySkill = entries.get('.claude/skills/deploy-to-labs/SKILL.md') as string;
+    // The choice belongs to the member, not the agent.
+    expect(deploySkill).toContain("don't assume");
+    expect(deploySkill).toContain('Needs a database?');
+    // The exact opt-in payload the backend expects.
+    expect(deploySkill).toContain('{"enabled":true,"type":"postgres"}');
+    // The app never generates its own credentials or creates the database.
+    expect(deploySkill).toContain('You never create the database');
+    // The ready-to-use env vars a provisioned database injects.
+    expect(deploySkill).toContain('DATABASE_URL');
+    expect(deploySkill).toContain('JDBC_DATABASE_URL');
+    expect(deploySkill).toContain('DB_PASSWORD');
+    // BYO is routed through the existing secrets flow, not a bespoke one.
+    expect(deploySkill).toContain('bring their own');
+    expect(deploySkill).toContain('this is just a runtime secret');
+  });
 });

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -11,7 +11,7 @@
  */
 
 /** Starter kit version shown in the README, ZIP filename, and LabOS UI. Bump when the kit contents or flow change. */
-export const AI_APPS_STARTER_KIT_VERSION = '1.5';
+export const AI_APPS_STARTER_KIT_VERSION = '1.6';
 
 /** Header the AI agent sends with its short-lived deploy token. */
 export const AI_APP_TOKEN_HEADER = 'x-app-token';

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -60,12 +60,23 @@ import {
  */
 const GATEWAY_TIMEOUT_STATUSES = [408, 502, 503, 504, 521, 522, 523, 524, 530];
 
+/** Non-sensitive database metadata the runner returns once it provisions one. Never a password. */
+interface RunnerDeployDatabaseInfo {
+  host?: string;
+  port?: number;
+  name?: string;
+  user?: string;
+  type?: string;
+  credentialsInjected?: boolean;
+}
+
 interface RunnerDeployResponse {
   status?: string;
   host?: string;
   url?: string;
   httpUrl?: string;
   port?: number;
+  database?: RunnerDeployDatabaseInfo;
 }
 
 type AiAppMember = { uid: string; name: string; image: string | null };
@@ -87,9 +98,35 @@ interface AiAppDeploymentInfo {
   failureStream?: 'build' | 'runtime';
 }
 
-/** App responses: raw failure columns replaced by the requester-gated `deployment` block. */
-type ApiAiApp<T extends { memberUid: string }> = Omit<WithMember<T>, 'failureStream'> & {
+/**
+ * Database block on app responses: everyone sees whether a database was
+ * requested; connection metadata (never the password) appears once the
+ * Deployment Orchestrator reports it provisioned.
+ */
+interface AiAppDatabaseInfo {
+  enabled: boolean;
+  type?: string | null;
+  host?: string | null;
+  port?: number | null;
+  name?: string | null;
+  user?: string | null;
+  credentialsInjected?: boolean | null;
+}
+
+/** Raw `AiApp` database columns replaced by the `database` block below. */
+type RawDatabaseColumns =
+  | 'databaseEnabled'
+  | 'databaseType'
+  | 'databaseHost'
+  | 'databasePort'
+  | 'databaseName'
+  | 'databaseUser'
+  | 'databaseCredentialsInjected';
+
+/** App responses: raw failure/database columns replaced by requester-facing `deployment`/`database` blocks. */
+type ApiAiApp<T extends { memberUid: string }> = Omit<WithMember<T>, 'failureStream' | RawDatabaseColumns> & {
   deployment: AiAppDeploymentInfo;
+  database: AiAppDatabaseInfo;
 };
 
 @Injectable()
@@ -186,7 +223,17 @@ export class AiAppsService {
    * only writer of `lastDeployedAt` is markReady).
    */
   private toApiApp<T extends AiApp>(app: WithMember<T>, isManager: boolean): ApiAiApp<T> {
-    const { failureStream, ...rest } = app;
+    const {
+      failureStream,
+      databaseEnabled,
+      databaseType,
+      databaseHost,
+      databasePort,
+      databaseName,
+      databaseUser,
+      databaseCredentialsInjected,
+      ...rest
+    } = app;
     const serving: AiAppServing = app.status === 'READY' ? 'latest' : app.lastDeployedAt ? 'previous' : 'none';
     const deployment: AiAppDeploymentInfo = { serving };
     if (isManager) {
@@ -197,7 +244,16 @@ export class AiAppsService {
         deployment.failureStream = failureStream;
       }
     }
-    return { ...rest, notes: isManager ? app.notes : null, deployment };
+    const database: AiAppDatabaseInfo = { enabled: databaseEnabled };
+    if (databaseEnabled) {
+      database.type = databaseType;
+      database.host = databaseHost;
+      database.port = databasePort;
+      database.name = databaseName;
+      database.user = databaseUser;
+      database.credentialsInjected = databaseCredentialsInjected;
+    }
+    return { ...rest, notes: isManager ? app.notes : null, deployment, database };
   }
 
   /** Dashboard list — all non-deleted apps across PL Infra users, newest first, with owner info. */
@@ -890,6 +946,8 @@ export class AiAppsService {
         kitVersion: dto.kitVersion ?? null,
         agentClient: agentClient ?? null,
         agentModel: dto.agentModel ?? null,
+        databaseEnabled: !!dto.database,
+        databaseType: dto.database?.type ?? null,
       },
       update: {
         name: dto.name,
@@ -905,6 +963,10 @@ export class AiAppsService {
         kitVersion: dto.kitVersion ?? null,
         agentClient: agentClient ?? null,
         agentModel: dto.agentModel ?? null,
+        // Same "reflects the last upload" rule applies to database provisioning
+        // — the kit resends `database` on every deploy once the member opts in.
+        databaseEnabled: !!dto.database,
+        databaseType: dto.database?.type ?? null,
         notes: null,
       },
     });
@@ -986,6 +1048,8 @@ export class AiAppsService {
         kitVersion: dto.kitVersion ?? null,
         agentClient: agentClient ?? null,
         agentModel: dto.agentModel ?? null,
+        databaseEnabled: !!dto.database,
+        databaseType: dto.database?.type ?? null,
       },
       update: {
         name: dto.name,
@@ -997,6 +1061,8 @@ export class AiAppsService {
         kitVersion: dto.kitVersion ?? null,
         agentClient: agentClient ?? null,
         agentModel: dto.agentModel ?? null,
+        databaseEnabled: !!dto.database,
+        databaseType: dto.database?.type ?? null,
         notes: null,
       },
     });
@@ -1099,7 +1165,7 @@ export class AiAppsService {
    */
   private async proxyDeploy(
     memberUid: string,
-    app: Pick<AiApp, 'uid' | 'appId'>,
+    app: Pick<AiApp, 'uid' | 'appId' | 'databaseEnabled' | 'databaseType'>,
     deploymentId: string,
     s3Key: string,
     secretNames: string[] = []
@@ -1115,26 +1181,56 @@ export class AiAppsService {
 
     const eventContext = { appUid: app.uid, appId: app.appId, deploymentId };
 
-    const markReady = async (port: number | null) => {
+    const markReady = async (port: number | null, databaseInfo?: RunnerDeployDatabaseInfo) => {
       const updated = await this.prisma.aiApp.update({
         where: { uid: app.uid },
         // The ONLY writer of lastDeployedAt — it must strictly mean "last
         // successful ship" (deployment.serving derives 'none' from its absence).
-        data: { status: 'READY', url, httpUrl, host, port, notes: null, failureStream: null, lastDeployedAt: new Date() },
+        data: {
+          status: 'READY',
+          url,
+          httpUrl,
+          host,
+          port,
+          notes: null,
+          failureStream: null,
+          lastDeployedAt: new Date(),
+          // Non-sensitive connection metadata the orchestrator reports once it
+          // provisions the database. Never the password — that lives only in
+          // the app's injected runtime env vars.
+          ...(databaseInfo
+            ? {
+                databaseHost: databaseInfo.host ?? null,
+                databasePort: databaseInfo.port ?? null,
+                databaseName: databaseInfo.name ?? null,
+                databaseUser: databaseInfo.user ?? null,
+                databaseCredentialsInjected: databaseInfo.credentialsInjected ?? null,
+              }
+            : {}),
+        },
       });
       await this.recordEvent('DEPLOY_SUCCEEDED', memberUid, { ...eventContext, message: url });
       return this.toApiApp((await this.withMember([updated]))[0], true);
     };
 
     let port: number | null = null;
+    let databaseInfo: RunnerDeployDatabaseInfo | undefined;
     try {
       this.logger.log(
         `Runner deploy request for ${app.appId}: POST ${AI_APPS_RUNNER_URL}/deploy ` +
-          `(deploymentId=${deploymentId}, s3Key=${s3Key})`
+          `(deploymentId=${deploymentId}, s3Key=${s3Key}${app.databaseEnabled ? `, database=${app.databaseType}` : ''})`
       );
       const response = await axios.post<RunnerDeployResponse>(
         `${AI_APPS_RUNNER_URL}/deploy`,
-        { appId: app.appId, deploymentId, s3Key },
+        {
+          appId: app.appId,
+          deploymentId,
+          s3Key,
+          // The app never generates credentials or creates the database
+          // itself — this just asks the Deployment Orchestrator to provision
+          // one and inject connection env vars into the runtime.
+          ...(app.databaseEnabled ? { database: { enabled: true, type: app.databaseType } } : {}),
+        },
         { headers: { 'Content-Type': 'application/json', 'x-runner-token': AI_APPS_RUNNER_TOKEN } }
       );
       this.logRunnerResponse('deploy', app.appId, response.status, response.data);
@@ -1148,6 +1244,7 @@ export class AiAppsService {
         throw new BadGatewayException('Failed to deploy app to the sandbox runner');
       }
       port = response.data.port ?? null;
+      databaseInfo = response.data.database;
     } catch (error) {
       if (error instanceof BadGatewayException) {
         throw error;
@@ -1192,7 +1289,7 @@ export class AiAppsService {
       }
     }
 
-    return markReady(port);
+    return markReady(port, databaseInfo);
   }
 
   /**

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import axios from 'axios';
 import { randomUUID } from 'crypto';
-import { AiApp, AiAppEvent, AiAppEventType, AiAppFeedback } from '@prisma/client';
+import { AiApp, AiAppEvent, AiAppEventType, AiAppFeedback, Prisma } from '@prisma/client';
 import { PrismaService } from '../shared/prisma.service';
 import { isDirectoryAdmin } from '../utils/constants';
 import { AwsService } from '../utils/aws/aws.service';
@@ -101,7 +101,8 @@ interface AiAppDeploymentInfo {
 /**
  * Database block on app responses: everyone sees whether a database was
  * requested; connection metadata (never the password) appears once the
- * Deployment Orchestrator reports it provisioned.
+ * Deployment Orchestrator reports it provisioned. Also the exact shape stored
+ * in the `AiApp.database` JSON column — no separate storage/response shapes.
  */
 interface AiAppDatabaseInfo {
   enabled: boolean;
@@ -113,18 +114,8 @@ interface AiAppDatabaseInfo {
   credentialsInjected?: boolean | null;
 }
 
-/** Raw `AiApp` database columns replaced by the `database` block below. */
-type RawDatabaseColumns =
-  | 'databaseEnabled'
-  | 'databaseType'
-  | 'databaseHost'
-  | 'databasePort'
-  | 'databaseName'
-  | 'databaseUser'
-  | 'databaseCredentialsInjected';
-
-/** App responses: raw failure/database columns replaced by requester-facing `deployment`/`database` blocks. */
-type ApiAiApp<T extends { memberUid: string }> = Omit<WithMember<T>, 'failureStream' | RawDatabaseColumns> & {
+/** App responses: the raw `failureStream`/`database` columns replaced by requester-facing `deployment`/`database` blocks. */
+type ApiAiApp<T extends { memberUid: string }> = Omit<WithMember<T>, 'failureStream' | 'database'> & {
   deployment: AiAppDeploymentInfo;
   database: AiAppDatabaseInfo;
 };
@@ -223,17 +214,7 @@ export class AiAppsService {
    * only writer of `lastDeployedAt` is markReady).
    */
   private toApiApp<T extends AiApp>(app: WithMember<T>, isManager: boolean): ApiAiApp<T> {
-    const {
-      failureStream,
-      databaseEnabled,
-      databaseType,
-      databaseHost,
-      databasePort,
-      databaseName,
-      databaseUser,
-      databaseCredentialsInjected,
-      ...rest
-    } = app;
+    const { failureStream, database: storedDatabase, ...rest } = app;
     const serving: AiAppServing = app.status === 'READY' ? 'latest' : app.lastDeployedAt ? 'previous' : 'none';
     const deployment: AiAppDeploymentInfo = { serving };
     if (isManager) {
@@ -244,15 +225,8 @@ export class AiAppsService {
         deployment.failureStream = failureStream;
       }
     }
-    const database: AiAppDatabaseInfo = { enabled: databaseEnabled };
-    if (databaseEnabled) {
-      database.type = databaseType;
-      database.host = databaseHost;
-      database.port = databasePort;
-      database.name = databaseName;
-      database.user = databaseUser;
-      database.credentialsInjected = databaseCredentialsInjected;
-    }
+    const parsedDatabase = storedDatabase as AiAppDatabaseInfo | null;
+    const database: AiAppDatabaseInfo = parsedDatabase?.enabled ? parsedDatabase : { enabled: false };
     return { ...rest, notes: isManager ? app.notes : null, deployment, database };
   }
 
@@ -946,8 +920,7 @@ export class AiAppsService {
         kitVersion: dto.kitVersion ?? null,
         agentClient: agentClient ?? null,
         agentModel: dto.agentModel ?? null,
-        databaseEnabled: !!dto.database,
-        databaseType: dto.database?.type ?? null,
+        database: dto.database ? { enabled: true, type: dto.database.type } : Prisma.DbNull,
       },
       update: {
         name: dto.name,
@@ -965,8 +938,7 @@ export class AiAppsService {
         agentModel: dto.agentModel ?? null,
         // Same "reflects the last upload" rule applies to database provisioning
         // — the kit resends `database` on every deploy once the member opts in.
-        databaseEnabled: !!dto.database,
-        databaseType: dto.database?.type ?? null,
+        database: dto.database ? { enabled: true, type: dto.database.type } : Prisma.DbNull,
         notes: null,
       },
     });
@@ -1048,8 +1020,7 @@ export class AiAppsService {
         kitVersion: dto.kitVersion ?? null,
         agentClient: agentClient ?? null,
         agentModel: dto.agentModel ?? null,
-        databaseEnabled: !!dto.database,
-        databaseType: dto.database?.type ?? null,
+        database: dto.database ? { enabled: true, type: dto.database.type } : Prisma.DbNull,
       },
       update: {
         name: dto.name,
@@ -1061,8 +1032,7 @@ export class AiAppsService {
         kitVersion: dto.kitVersion ?? null,
         agentClient: agentClient ?? null,
         agentModel: dto.agentModel ?? null,
-        databaseEnabled: !!dto.database,
-        databaseType: dto.database?.type ?? null,
+        database: dto.database ? { enabled: true, type: dto.database.type } : Prisma.DbNull,
         notes: null,
       },
     });
@@ -1165,7 +1135,7 @@ export class AiAppsService {
    */
   private async proxyDeploy(
     memberUid: string,
-    app: Pick<AiApp, 'uid' | 'appId' | 'databaseEnabled' | 'databaseType'>,
+    app: Pick<AiApp, 'uid' | 'appId' | 'database'>,
     deploymentId: string,
     s3Key: string,
     secretNames: string[] = []
@@ -1173,6 +1143,7 @@ export class AiAppsService {
     const host = buildAppHost(app.appId);
     const url = buildAppUrl(app.appId);
     const httpUrl = buildAppHttpUrl(app.appId);
+    const requestedDatabase = app.database as AiAppDatabaseInfo | null;
     await this.prisma.aiApp.update({
       where: { uid: app.uid },
       data: { status: 'DEPLOYING', deploymentId, s3Key, url, httpUrl, host, notes: null, failureStream: null },
@@ -1196,15 +1167,20 @@ export class AiAppsService {
           failureStream: null,
           lastDeployedAt: new Date(),
           // Non-sensitive connection metadata the orchestrator reports once it
-          // provisions the database. Never the password — that lives only in
-          // the app's injected runtime env vars.
-          ...(databaseInfo
+          // provisions the database, merged into the same JSON blob we asked
+          // it to provision from. Never the password — that lives only in the
+          // app's injected runtime env vars.
+          ...(databaseInfo && requestedDatabase?.enabled
             ? {
-                databaseHost: databaseInfo.host ?? null,
-                databasePort: databaseInfo.port ?? null,
-                databaseName: databaseInfo.name ?? null,
-                databaseUser: databaseInfo.user ?? null,
-                databaseCredentialsInjected: databaseInfo.credentialsInjected ?? null,
+                database: {
+                  enabled: true,
+                  type: requestedDatabase.type ?? null,
+                  host: databaseInfo.host ?? null,
+                  port: databaseInfo.port ?? null,
+                  name: databaseInfo.name ?? null,
+                  user: databaseInfo.user ?? null,
+                  credentialsInjected: databaseInfo.credentialsInjected ?? null,
+                },
               }
             : {}),
         },
@@ -1218,7 +1194,9 @@ export class AiAppsService {
     try {
       this.logger.log(
         `Runner deploy request for ${app.appId}: POST ${AI_APPS_RUNNER_URL}/deploy ` +
-          `(deploymentId=${deploymentId}, s3Key=${s3Key}${app.databaseEnabled ? `, database=${app.databaseType}` : ''})`
+          `(deploymentId=${deploymentId}, s3Key=${s3Key}${
+            requestedDatabase?.enabled ? `, database=${requestedDatabase.type}` : ''
+          })`
       );
       const response = await axios.post<RunnerDeployResponse>(
         `${AI_APPS_RUNNER_URL}/deploy`,
@@ -1229,7 +1207,7 @@ export class AiAppsService {
           // The app never generates credentials or creates the database
           // itself — this just asks the Deployment Orchestrator to provision
           // one and inject connection env vars into the runtime.
-          ...(app.databaseEnabled ? { database: { enabled: true, type: app.databaseType } } : {}),
+          ...(requestedDatabase?.enabled ? { database: { enabled: true, type: requestedDatabase.type } } : {}),
         },
         { headers: { 'Content-Type': 'application/json', 'x-runner-token': AI_APPS_RUNNER_TOKEN } }
       );

--- a/apps/web-api/src/ai-apps/dto/deploy-app.dto.ts
+++ b/apps/web-api/src/ai-apps/dto/deploy-app.dto.ts
@@ -1,6 +1,22 @@
 import { createZodDto } from '@abitia/zod-dto';
 import { z } from 'zod';
 
+/** Database engines the Deployment Orchestrator can provision on request. */
+export const AI_APPS_SUPPORTED_DATABASE_TYPES = ['postgres'] as const;
+
+/**
+ * Opt-in database provisioning. The app never generates credentials or
+ * creates the database itself — sending this just asks the Deployment
+ * Orchestrator to provision one and inject the connection env vars into the
+ * runtime. A member who wants their own database instead skips this field
+ * entirely and supplies their connection string as a regular runtime secret
+ * (see the draft flow's `requiredEnvVars`).
+ */
+export const DatabaseConfigSchema = z.object({
+  enabled: z.literal(true),
+  type: z.enum(AI_APPS_SUPPORTED_DATABASE_TYPES),
+});
+
 /**
  * Multipart form fields posted by the member's AI agent to `/v1/ai-apps/deploy`
  * alongside the app ZIP file. App metadata (name/description) is parsed from
@@ -36,6 +52,25 @@ export const DeployAppSchema = z.object({
    * TOOL name isn't sent here; it comes from the connect session's clientName.
    */
   agentModel: z.string().trim().min(1).max(100).optional(),
+  /**
+   * Opt-in database provisioning request, e.g. `{"enabled":true,"type":"postgres"}`.
+   * Multipart delivers it as a JSON string; absent entirely when the member
+   * brought their own database (or hasn't been asked yet).
+   */
+  database: z.preprocess((value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }, DatabaseConfigSchema.optional()),
 });
 
 export class DeployAppDto extends createZodDto(DeployAppSchema) {}

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -123,9 +123,12 @@ curl -X POST "$AI_APPS_DEPLOY_ENDPOINT" \
   -F "name=My Leaderboard" \
   -F "description=A small leaderboard demo" \
   -F "deploymentId=deploy-1718900000" \
-  -F "kitVersion=1.5" \
+  -F "kitVersion=1.6" \
+  -F 'database={"enabled":true,"type":"postgres"}' \
   -F "file=@app.zip;type=application/zip"
 ```
+
+`database` is optional — see "Agent-driven database provisioning" below.
 
 `name`/`description` are member-facing: kits ≥1.5 send values the member explicitly approved (and resend the same values on redeploys — see "Editable metadata & one-pager PRD").
 
@@ -144,6 +147,31 @@ The backend uploads the ZIP to `s3://<AI_APPS_S3_BUCKET>/apps/<appId>/<deploymen
 **Helm-lock retry (secrets apps):** when a build survives such a timeout, its Helm upgrade is often still running when the follow-up secrets-injection deployment fires, and the runner answers `409` with `error: "helm_release_locked"` ("release is already being modified"). The backend treats that specific 409 as transient and retries the injection (`AI_APPS_HELM_LOCK_RETRIES` × `AI_APPS_HELM_LOCK_RETRY_INTERVAL_MS`, default 8 × 15s ≈ 2 min, env-overridable) until the lock clears; only after the budget is exhausted (or on any other injection error) is the app marked `ERROR`.
 
 **Stuck deploys & manual retry:** deploys run synchronously inside the API process, so a legitimate one settles to `READY`/`ERROR` within minutes. An app still `DEPLOYING` after `AI_APPS_DEPLOY_STUCK_MINUTES` (default 15, env-overridable) is **stuck** — the API died mid-deploy or the runner hung — and is settled lazily on read: `GET /v1/ai-apps` and `GET /v1/ai-apps/:uid` flip such rows to `ERROR` with an explanatory `notes` and a `DEPLOY_FAILED` event (the update is conditioned on the row still being `DEPLOYING`, so a concurrently-settling deploy wins). The owner or a directory admin can then **retry** via the member deploy endpoint (`POST /v1/ai-apps/:uid/deploy`, empty body for apps without secrets) — it redeploys the bundle stored at `s3Key`, so it recovers from runner/backend outages without the agent re-uploading; if the app *itself* is broken the retry fails again with the runner error in `notes`, and the fix is to redeploy from the agent. While a **fresh** (non-stuck) deploy is in flight the endpoint returns `409` to prevent concurrent deploys. The LabOS detail page shows a status card for `ERROR` (error notes + Retry button for the creator/admin) and `DEPLOYING` (auto-refreshing progress), and the dashboard cards carry `Deploy failed` / `Deploying` badges.
+
+## Agent-driven database provisioning
+
+Non-technical builders often get stuck the moment their app needs a backend — they don't know what a database is, let alone how to provision one. Kits ≥1.6 let the agent offer a **PLN-provisioned database** as an alternative to bringing their own: the agent asks the member which they want, and if they want ours, it adds one extra field to the same deploy/draft call from "Deploy request" above:
+
+```jsonc
+"database": { "enabled": true, "type": "postgres" }
+```
+
+(As multipart, that's `-F 'database={"enabled":true,"type":"postgres"}'`.) The app never generates credentials or creates the database itself — the field just asks the sandbox runner (Deployment Orchestrator) to provision a dedicated Postgres database and non-admin user, and to inject the connection details into the app's runtime as environment variables: `DATABASE_URL`, `JDBC_DATABASE_URL`, and the individual parameters `DB_TYPE`/`DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD`. The app reads them the same way it would read any other env var — no code changes to *request* a database, just to *use* one.
+
+A member who already has their own database skips this field entirely and supplies their connection string as a regular runtime secret through the **draft flow** below (e.g. a required env var named `DATABASE_URL`) — provisioning is an opt-in convenience, never a requirement.
+
+`postgres` is the only supported `type` today. `databaseEnabled`/`databaseType` reflect the **last** deploy/draft upload, the same "reflects the last upload" rule `kitVersion`/`agentModel` follow — a call that omits `database` turns provisioning off for that call, so kits persist the member's choice in `pln-app.config.json` and resend it on every redeploy (member-triggered redeploys from the LabOS Deployment settings modal reuse whatever was last stored, with no agent involved). Every app response carries the non-sensitive result in a `database` block:
+
+```jsonc
+"database": {
+  "enabled": true,
+  "type": "postgres",
+  "host": "…", "port": 5432, "name": "db_demo", "user": "db_demo_user",
+  "credentialsInjected": true
+}
+```
+
+The password is never part of this contract — it only ever reaches the app's runtime environment, never our database or API responses. `enabled: false` (the default) means the app doesn't have — or hasn't asked for — a PLN-provisioned database; a bring-your-own database never sets this block, since it's just a secret.
 
 ## Draft apps & runtime secrets
 
@@ -359,6 +387,10 @@ model AiApp {
   agentModel   String?         // model the agent reported for the last upload (self-reported)
   lastDeployedAt DateTime?     // last SUCCESSFUL ship (written only by markReady; null = never shipped)
   failureStream  String?       // 'build' | 'runtime' — which log stream holds the LATEST deploy failure (null = unknown)
+  databaseEnabled Boolean @default(false)  // database requested on the LAST deploy/draft upload (kitVersion-style: reflects last upload)
+  databaseType    String?       // e.g. "postgres"; null when not enabled
+  databaseHost / databasePort / databaseName / databaseUser  // non-sensitive connection metadata from the runner — never the password
+  databaseCredentialsInjected Boolean?
   @@unique([memberUid, appId])
 }
 
@@ -442,13 +474,14 @@ Design System is embedded as a curated folder (see below):
 ```
 README.md                                      human quick-start
 CLAUDE.md / AGENTS.md                          agent build + deploy instructions
-.claude/skills/deploy-to-labs/SKILL.md         deploy skill (incl. connect flow)
+.claude/skills/deploy-to-labs/SKILL.md         deploy skill (incl. connect flow, secrets, database provisioning ≥1.6)
 .claude/skills/app-metadata/SKILL.md           propose → approve name/description + optional one-pager PRD (kits ≥1.5)
 .claude/skills/app-logs/SKILL.md               fetch build/runtime logs to debug failed deploys + runtime errors (kits ≥1.5)
 .claude/skills/pl-design-system/SKILL.md       single UI skill (components + tokens)
 .claude/skills/pln-member-context/SKILL.md     how the app gets the signed-in member's identity
 pln-app.config.json                            connect/deploy/draft/metadata/logs/member-context endpoints
-                                               (+ appId, appUid, approved appName/appDescription) — NO token
+                                               (+ appId, appUid, approved appName/appDescription,
+                                                database provisioning choice ≥1.6) — NO token
 pl-design-system/                              curated PL Design System (files, not a nested zip)
 styles/pln-theme.css                           minimal CSS-variable fallback (plain-HTML apps)
 styles/FONTS.md                                Inter font guidance
@@ -518,6 +551,7 @@ S3 uploads reuse the shared `AwsService`, so the standard `AWS_REGION` / `AWS_AC
 - `apps/web-api/prisma/migrations/20260707120000_ai_apps_draft_secrets/` — `DRAFT` status, `s3Key`/`requiredEnvVars`/`providedEnvVars`, draft/secrets event values.
 - `apps/web-api/prisma/migrations/20260714120000_ai_apps_upload_meta/` — `kitVersion`/`agentClient`/`agentModel` columns (self-reported metadata about the last agent upload).
 - `apps/web-api/prisma/migrations/20260715120000_ai_apps_editable_metadata/` — `prd` column (one-pager PRD).
+- `apps/web-api/prisma/migrations/20260730120000_ai_apps_database_provisioning/` — `databaseEnabled`/`databaseType` + non-sensitive connection metadata columns (agent-driven database provisioning).
 - LabOS UI (`pln-directory-portal-v2`): `app/pl-infra/ai-apps/connect/page.tsx` + `components/page/ai-apps/AiAppsConnectPage/` — the approval page; connect calls in `services/ai-apps/ai-apps.service.ts`.
 - `.claude/skills/ai-apps/SKILL.md` — agent guidance for working on this feature.
 

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -160,7 +160,7 @@ Non-technical builders often get stuck the moment their app needs a backend — 
 
 A member who already has their own database skips this field entirely and supplies their connection string as a regular runtime secret through the **draft flow** below (e.g. a required env var named `DATABASE_URL`) — provisioning is an opt-in convenience, never a requirement.
 
-`postgres` is the only supported `type` today. `databaseEnabled`/`databaseType` reflect the **last** deploy/draft upload, the same "reflects the last upload" rule `kitVersion`/`agentModel` follow — a call that omits `database` turns provisioning off for that call, so kits persist the member's choice in `pln-app.config.json` and resend it on every redeploy (member-triggered redeploys from the LabOS Deployment settings modal reuse whatever was last stored, with no agent involved). Every app response carries the non-sensitive result in a `database` block:
+`postgres` is the only supported `type` today. The `AiApp.database` column — a single JSON blob shaped exactly like the response block below — reflects the **last** deploy/draft upload, the same "reflects the last upload" rule `kitVersion`/`agentModel` follow: a call that omits `database` sets the column to `NULL` (provisioning off) for that call, so kits persist the member's choice in `pln-app.config.json` and resend it on every redeploy (member-triggered redeploys from the LabOS Deployment settings modal reuse whatever was last stored, with no agent involved). Every app response carries the non-sensitive result in a `database` block:
 
 ```jsonc
 "database": {
@@ -387,10 +387,9 @@ model AiApp {
   agentModel   String?         // model the agent reported for the last upload (self-reported)
   lastDeployedAt DateTime?     // last SUCCESSFUL ship (written only by markReady; null = never shipped)
   failureStream  String?       // 'build' | 'runtime' — which log stream holds the LATEST deploy failure (null = unknown)
-  databaseEnabled Boolean @default(false)  // database requested on the LAST deploy/draft upload (kitVersion-style: reflects last upload)
-  databaseType    String?       // e.g. "postgres"; null when not enabled
-  databaseHost / databasePort / databaseName / databaseUser  // non-sensitive connection metadata from the runner — never the password
-  databaseCredentialsInjected Boolean?
+  database        Json?         // { enabled, type, host?, port?, name?, user?, credentialsInjected? } — one JSON blob,
+                                 // reflects the LAST deploy/draft upload (kitVersion-style); null = not requested.
+                                 // Non-sensitive connection metadata only — the password is never stored.
   @@unique([memberUid, appId])
 }
 
@@ -551,7 +550,7 @@ S3 uploads reuse the shared `AwsService`, so the standard `AWS_REGION` / `AWS_AC
 - `apps/web-api/prisma/migrations/20260707120000_ai_apps_draft_secrets/` — `DRAFT` status, `s3Key`/`requiredEnvVars`/`providedEnvVars`, draft/secrets event values.
 - `apps/web-api/prisma/migrations/20260714120000_ai_apps_upload_meta/` — `kitVersion`/`agentClient`/`agentModel` columns (self-reported metadata about the last agent upload).
 - `apps/web-api/prisma/migrations/20260715120000_ai_apps_editable_metadata/` — `prd` column (one-pager PRD).
-- `apps/web-api/prisma/migrations/20260730120000_ai_apps_database_provisioning/` — `databaseEnabled`/`databaseType` + non-sensitive connection metadata columns (agent-driven database provisioning).
+- `apps/web-api/prisma/migrations/20260730120000_ai_apps_database_provisioning/` — single `database` JSON column: provisioning request + non-sensitive connection metadata (agent-driven database provisioning).
 - LabOS UI (`pln-directory-portal-v2`): `app/pl-infra/ai-apps/connect/page.tsx` + `components/page/ai-apps/AiAppsConnectPage/` — the approval page; connect calls in `services/ai-apps/ai-apps.service.ts`.
 - `.claude/skills/ai-apps/SKILL.md` — agent guidance for working on this feature.
 


### PR DESCRIPTION
## Description

Non-technical AI Apps builders can now ask their AI agent to provision a database for them instead of setting one up themselves.
The agent's deploy skill now checks whether an app needs a database and asks the member to choose between a PLN-provisioned database or their own.
When the member opts in, the agent adds a `database` field to the same deploy or draft upload it already sends.
The application never generates credentials or creates the database itself — the Deployment Orchestrator provisions it and injects the connection details as environment variables.
Members bringing their own database continue to use the existing runtime-secrets flow, unchanged.
Every AI App response now reports whether a database was requested and, once provisioned, its non-sensitive connection details — never the password.

Example of the new deploy request field:

```bash
curl -X POST "$AI_APPS_DEPLOY_ENDPOINT" \
  -H "x-app-token: $DEPLOY_TOKEN" \
  -F "appId=my-app" \
  -F "name=My App" \
  -F "deploymentId=deploy-1" \
  -F 'database={"enabled":true,"type":"postgres"}' \
  -F "file=@app.zip;type=application/zip"
```


## Ticket

[LAB-2176](https://linear.app/plrs-labos/issue/LAB-2176/ai-apps-database-provisioning-for-be-apps)