### PR TITLE
feat(warm-intros-v2): multi-value path filters + PL-backing facets

### DIFF
--- a/apps/web-api/src/warm-intros-v2/dto/ingest-warm-intros-v2.dto.ts
+++ b/apps/web-api/src/warm-intros-v2/dto/ingest-warm-intros-v2.dto.ts
@@ -63,7 +63,7 @@ export interface IngestWarmIntrosV2Response {
 export class ListWarmPathsV2QueryDto {
   /** `neuro-fund-i` | `gold-co-investors` */
   targetSet?: string;
-  /** Paths where bestConnector OR alternates include this uid. */
+  /** Paths where bestConnector OR alternates include this uid. Comma-separated for OR-of-many. */
   connectorProfileUid?: string;
   minScore?: string;
   /** Default `1` (best path only for list view). */
@@ -74,10 +74,12 @@ export class ListWarmPathsV2QueryDto {
   q?: string;
   /** Case-insensitive match on investor name or email (alias of `q`). */
   search?: string;
-  /** Case-insensitive: investor sectors contains this value. */
+  /** Case-insensitive: investor sectors contains this value. Comma-separated for OR-of-many. */
   sector?: string;
-  /** Filter by hopChain.relationKind: `pl_direct` | `founder_bridge` | `coinvestor_bridge`. */
+  /** Filter by hopChain.relationKind: `pl_direct` | `founder_bridge` | `coinvestor_bridge`. Comma-separated for OR-of-many. */
   relationKind?: string;
+  /** Filter by the middle hop of a founder/coinvestor bridge path. Comma-separated for OR-of-many. */
+  bridgeProfileUid?: string;
   /** When `true`, only paths with hopCount=1 (PL direct). */
   directOnly?: string;
   /** When `true`, only investors with MasterProfile.plBacking set. */

--- a/apps/web-api/src/warm-intros-v2/warm-intros-v2-enrich.util.spec.ts
+++ b/apps/web-api/src/warm-intros-v2/warm-intros-v2-enrich.util.spec.ts
@@ -93,6 +93,7 @@ describe('warm-intros-v2-enrich.util', () => {
         imageUrl: null,
         listSlugs: ['neuro-fund-i', 'gold-co-investors'],
         plBacking: null,
+        coInvestmentsCount: 0,
       });
     });
 
@@ -107,6 +108,24 @@ describe('warm-intros-v2-enrich.util', () => {
       expect(summary.imageUrl).toBe('https://cdn.example/jane.png');
       expect(summary.memberUid).toBe('m1');
       expect(summary.listSlugs).toEqual([]);
+    });
+
+    it('counts coInvestments length, treating non-arrays as zero', () => {
+      expect(
+        toInvestorSummary('inv1', {
+          uid: 'inv1',
+          personKey: 'k',
+          canonicalName: 'Jane',
+          coInvestments: [{ teamUid: 't1' }, { teamUid: 't2' }],
+        }).coInvestmentsCount
+      ).toBe(2);
+
+      expect(
+        toInvestorSummary('inv1', { uid: 'inv1', personKey: 'k', canonicalName: 'Jane', coInvestments: null })
+          .coInvestmentsCount
+      ).toBe(0);
+
+      expect(toInvestorSummary('inv1', null).coInvestmentsCount).toBe(0);
     });
   });
 

--- a/apps/web-api/src/warm-intros-v2/warm-intros-v2-enrich.util.ts
+++ b/apps/web-api/src/warm-intros-v2/warm-intros-v2-enrich.util.ts
@@ -26,6 +26,8 @@ export type EnrichedInvestorSummary = {
   listSlugs: KnownListSlug[];
   /** PL/FIL prior-backer flags when present on MasterProfile. */
   plBacking: unknown | null;
+  /** Length of MasterProfile.coInvestments, for row-level display without fetching the full detail record. */
+  coInvestmentsCount: number;
 };
 
 export type EnrichedConnectorSummary = {
@@ -56,11 +58,16 @@ export type MasterProfileEnrichRow = {
   memberUid?: string | null;
   listMemberships?: unknown;
   plBacking?: unknown | null;
+  coInvestments?: unknown;
   /** Filled by service when Member.image is resolved. */
   imageUrl?: string | null;
 };
 
-function asRecord(value: unknown): Record<string, unknown> | null {
+function coInvestmentsCount(coInvestments: unknown): number {
+  return Array.isArray(coInvestments) ? coInvestments.length : 0;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   return value as Record<string, unknown>;
 }
@@ -153,6 +160,7 @@ export function toInvestorSummary(
       imageUrl: null,
       listSlugs: [],
       plBacking: null,
+      coInvestmentsCount: 0,
     };
   }
   return {
@@ -168,6 +176,7 @@ export function toInvestorSummary(
     imageUrl: profile.imageUrl ?? null,
     listSlugs: parseKnownListSlugs(profile.listMemberships),
     plBacking: profile.plBacking ?? null,
+    coInvestmentsCount: coInvestmentsCount(profile.coInvestments),
   };
 }
 
@@ -346,4 +355,51 @@ export function matchesSector(investor: EnrichedInvestorSummary, sector: string)
 /** True when MasterProfile.plBacking is a non-null object (PL/FIL prior backer). */
 export function matchesPlBacker(investor: EnrichedInvestorSummary): boolean {
   return investor.plBacking != null && typeof investor.plBacking === 'object';
+}
+
+/** hopChain.relationKind, defaulted to `pl_direct` — every path carries one, not just bridges. */
+export function relationKindFromHopChain(hopChain: unknown): string {
+  const chain = asRecord(hopChain);
+  return typeof chain?.relationKind === 'string' && chain.relationKind ? chain.relationKind : 'pl_direct';
+}
+
+/**
+ * The middle hop of a founder/coinvestor bridge chain. hops is
+ * [connector, ...bridge(s), investor] (enrichHopChainNames keeps the investor as the
+ * trailing node), so the bridge sits at length-2 regardless of what precedes it.
+ * `null` for a direct path — there is no bridge to name.
+ */
+export function bridgeProfileUidFromHopChain(hopChain: unknown): string | null {
+  const chain = asRecord(hopChain);
+  if (!chain) return null;
+  const kind = relationKindFromHopChain(hopChain);
+  if (kind !== 'founder_bridge' && kind !== 'coinvestor_bridge') return null;
+  const hops = Array.isArray(chain.hops) ? chain.hops : [];
+  const bridgeNode = hops.length >= 2 ? asRecord(hops[hops.length - 2]) : null;
+  const uid = typeof bridgeNode?.profileUid === 'string' ? bridgeNode.profileUid.trim() : '';
+  return uid || null;
+}
+
+/** Empty `kinds` matches everything — an absent filter, not a filter matching nothing. */
+export function matchesRelationKind(hopChain: unknown, kinds: string[]): boolean {
+  if (kinds.length === 0) return true;
+  return kinds.includes(relationKindFromHopChain(hopChain));
+}
+
+/** Empty `uids` matches everything — an absent filter, not a filter matching nothing. */
+export function matchesConnectorUid(
+  row: { bestConnectorProfileUid: string | null; alternateConnectorProfileUids: unknown },
+  uids: string[]
+): boolean {
+  if (uids.length === 0) return true;
+  if (row.bestConnectorProfileUid && uids.includes(row.bestConnectorProfileUid)) return true;
+  const alternates = Array.isArray(row.alternateConnectorProfileUids) ? row.alternateConnectorProfileUids : [];
+  return alternates.some((uid) => typeof uid === 'string' && uids.includes(uid));
+}
+
+/** Empty `uids` matches everything — an absent filter, not a filter matching nothing. */
+export function matchesBridgeUid(hopChain: unknown, uids: string[]): boolean {
+  if (uids.length === 0) return true;
+  const bridgeUid = bridgeProfileUidFromHopChain(hopChain);
+  return !!bridgeUid && uids.includes(bridgeUid);
 }

--- a/apps/web-api/src/warm-intros-v2/warm-intros-v2.service.spec.ts
+++ b/apps/web-api/src/warm-intros-v2/warm-intros-v2.service.spec.ts
@@ -562,7 +562,7 @@ describe('WarmIntrosV2Service', () => {
       expect(result.paths[0].targetSet).toBe('neuro-fund-i');
     });
 
-    it('applies directOnly as hopCount=1 in Prisma where', async () => {
+    it('applies directOnly as a relationKind=pl_direct hopChain filter (folded in, single-value fast path)', async () => {
       pathFindMany.mockResolvedValue([pathRow]);
       pathCount.mockResolvedValue(1);
 
@@ -574,11 +574,93 @@ describe('WarmIntrosV2Service', () => {
       });
 
       expect(pathFindMany).toHaveBeenCalledWith({
-        where: { rank: 1, targetSet: 'neuro-fund-i', score: { gte: 0.2 }, hopCount: 1 },
+        where: {
+          rank: 1,
+          targetSet: 'neuro-fund-i',
+          score: { gte: 0.2 },
+          hopChain: { path: ['relationKind'], equals: 'pl_direct' },
+        },
         take: 50,
         skip: 0,
         orderBy: [{ score: 'desc' }, { targetProfileUid: 'asc' }],
       });
+    });
+
+    it('directOnly is ignored once an explicit relationKind is given (relationKind wins)', async () => {
+      pathFindMany.mockResolvedValue([pathRow]);
+      pathCount.mockResolvedValue(1);
+
+      await service.listPaths({
+        targetSet: 'neuro-fund-i',
+        directOnly: 'true',
+        relationKind: 'founder_bridge',
+        limit: '50',
+        offset: '0',
+      });
+
+      expect(pathFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ hopChain: { path: ['relationKind'], equals: 'founder_bridge' } }),
+        })
+      );
+    });
+
+    it('OR-matches multiple relationKind values via post-filter over the full candidate set', async () => {
+      const bridgeRow = {
+        ...pathRow,
+        uid: 'p2',
+        targetProfileUid: 'inv2',
+        hopChain: {
+          relationKind: 'founder_bridge',
+          hops: [
+            { profileUid: 'from1', name: 'Juan Benet', role: 'pl_connector' },
+            { profileUid: 'bridge1', name: 'Bridget Founder', role: 'founder' },
+            { profileUid: 'inv2', name: 'Alice', role: 'investor' },
+          ],
+        },
+      };
+      pathFindMany.mockResolvedValue([pathRow, bridgeRow]);
+      masterProfileFindMany.mockResolvedValue([investorProfile, connectorProfile]);
+
+      const result = await service.listPaths({
+        targetSet: 'neuro-fund-i',
+        relationKind: 'pl_direct,founder_bridge',
+        limit: '50',
+        offset: '0',
+      });
+
+      // 2+ values drop the where-clause fast path — no hopChain key in the query.
+      expect(pathFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.not.objectContaining({ hopChain: expect.anything() }) })
+      );
+      expect(result.paths.map((p) => p.uid)).toEqual(['p1', 'p2']);
+    });
+
+    it('filters by bridgeProfileUid via post-filter (no queryable column exists)', async () => {
+      const bridgeRow = {
+        ...pathRow,
+        uid: 'p2',
+        targetProfileUid: 'inv2',
+        hopChain: {
+          relationKind: 'founder_bridge',
+          hops: [
+            { profileUid: 'from1', name: 'Juan Benet', role: 'pl_connector' },
+            { profileUid: 'bridge1', name: 'Bridget Founder', role: 'founder' },
+            { profileUid: 'inv2', name: 'Alice', role: 'investor' },
+          ],
+        },
+      };
+      pathFindMany.mockResolvedValue([pathRow, bridgeRow]);
+      masterProfileFindMany.mockResolvedValue([investorProfile, connectorProfile]);
+
+      const result = await service.listPaths({
+        targetSet: 'neuro-fund-i',
+        bridgeProfileUid: 'bridge1',
+        limit: '50',
+        offset: '0',
+      });
+
+      expect(result.paths.map((p) => p.uid)).toEqual(['p2']);
     });
 
     it('applies relationKind as hopChain JSON path filter', async () => {
@@ -808,18 +890,34 @@ describe('WarmIntrosV2Service', () => {
   });
 
   describe('listFacets', () => {
-    it('lists all pl_internal connectors (not only best) + sectors', async () => {
+    it('lists all pl_internal connectors (not only best) + sectors + path-kind + bridge-person counts', async () => {
       pathFindMany.mockResolvedValue([
-        { targetProfileUid: 'inv1', bestConnectorProfileUid: 'from1' },
-        { targetProfileUid: 'inv2', bestConnectorProfileUid: 'from1' },
+        {
+          targetProfileUid: 'inv1',
+          bestConnectorProfileUid: 'from1',
+          hopChain: { relationKind: 'pl_direct' },
+        },
+        {
+          targetProfileUid: 'inv2',
+          bestConnectorProfileUid: 'from1',
+          hopChain: {
+            relationKind: 'founder_bridge',
+            hops: [
+              { profileUid: 'from1', role: 'pl_connector' },
+              { profileUid: 'bridge1', role: 'founder' },
+              { profileUid: 'inv2', role: 'investor' },
+            ],
+          },
+        },
       ]);
-      // 1st call: pl_internal roster; 2nd: investor profiles for sectors
+      // 1st call: pl_internal roster; 2nd: bridge-person profiles; 3rd: investor profiles for sectors
       masterProfileFindMany
         .mockResolvedValueOnce([
           { uid: 'from1', canonicalName: 'Juan Benet' },
           { uid: 'from2', canonicalName: 'Lacey Wisdom' },
           { uid: 'from3', canonicalName: 'Marc Johnson' },
         ])
+        .mockResolvedValueOnce([{ uid: 'bridge1', canonicalName: 'Bridget Founder' }])
         .mockResolvedValueOnce([
           investorProfile,
           {
@@ -846,6 +944,13 @@ describe('WarmIntrosV2Service', () => {
         { profileUid: 'from2', name: 'Lacey Wisdom', pathCount: 0 },
         { profileUid: 'from3', name: 'Marc Johnson', pathCount: 0 },
       ]);
+      expect(result.kinds).toEqual(
+        expect.arrayContaining([
+          { value: 'pl_direct', count: 1 },
+          { value: 'founder_bridge', count: 1 },
+        ])
+      );
+      expect(result.bridges).toEqual([{ profileUid: 'bridge1', name: 'Bridget Founder', pathCount: 1 }]);
       expect(result.sectors).toEqual(
         expect.arrayContaining([
           { value: 'crypto', count: 2 },
@@ -856,6 +961,15 @@ describe('WarmIntrosV2Service', () => {
       expect(masterProfileFindMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: { types: { has: 'pl_internal' } } })
       );
+    });
+
+    it('falls back to pl_direct and no bridges when hopChain has no relationKind', async () => {
+      pathFindMany.mockResolvedValue([{ targetProfileUid: 'inv1', bestConnectorProfileUid: 'from1', hopChain: null }]);
+      masterProfileFindMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.listFacets({});
+      expect(result.kinds).toEqual([{ value: 'pl_direct', count: 1 }]);
+      expect(result.bridges).toEqual([]);
     });
   });
 

--- a/apps/web-api/src/warm-intros-v2/warm-intros-v2.service.spec.ts
+++ b/apps/web-api/src/warm-intros-v2/warm-intros-v2.service.spec.ts
@@ -958,6 +958,7 @@ describe('WarmIntrosV2Service', () => {
           { value: 'ai', count: 1 },
         ])
       );
+      expect(result.plBackerCount).toBe(0);
       expect(masterProfileFindMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: { types: { has: 'pl_internal' } } })
       );
@@ -970,6 +971,22 @@ describe('WarmIntrosV2Service', () => {
       const result = await service.listFacets({});
       expect(result.kinds).toEqual([{ value: 'pl_direct', count: 1 }]);
       expect(result.bridges).toEqual([]);
+    });
+
+    it('counts investors with plBacking set', async () => {
+      pathFindMany.mockResolvedValue([
+        { targetProfileUid: 'inv1', bestConnectorProfileUid: 'from1', hopChain: { relationKind: 'pl_direct' } },
+        { targetProfileUid: 'inv2', bestConnectorProfileUid: 'from1', hopChain: { relationKind: 'pl_direct' } },
+      ]);
+      masterProfileFindMany
+        .mockResolvedValueOnce([]) // pl_internal roster
+        .mockResolvedValueOnce([
+          { ...investorProfile, plBacking: { backedProtocolLabs: true, backedFilecoin: false, matchKind: 'person' } },
+          { uid: 'inv2', personKey: 'k2', canonicalName: 'Alice', plBacking: null },
+        ]);
+
+      const result = await service.listFacets({ targetSet: 'neuro-fund-i' });
+      expect(result.plBackerCount).toBe(1);
     });
   });
 

--- a/apps/web-api/src/warm-intros-v2/warm-intros-v2.service.ts
+++ b/apps/web-api/src/warm-intros-v2/warm-intros-v2.service.ts
@@ -687,7 +687,11 @@ export class WarmIntrosV2Service {
 
     const sectors = [...sectorCounts.values()].sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
 
-    return { connectors, sectors, kinds, bridges };
+    const plBackerCount = investorUids.filter((uid) =>
+      matchesPlBacker(toInvestorSummary(uid, profilesByUid.get(uid)))
+    ).length;
+
+    return { connectors, sectors, kinds, bridges, plBackerCount };
   }
 
   async listEdges(query: ListConnectionEdgesQueryDto) {

--- a/apps/web-api/src/warm-intros-v2/warm-intros-v2.service.ts
+++ b/apps/web-api/src/warm-intros-v2/warm-intros-v2.service.ts
@@ -23,13 +23,19 @@ import {
 } from './dto/warm-path-feedback.dto';
 import {
   alternateUidsFromHopChain,
+  asRecord,
+  bridgeProfileUidFromHopChain,
   buildPathSummary,
   enrichHopChainNames,
+  matchesBridgeUid,
+  matchesConnectorUid,
   matchesPlBacker,
+  matchesRelationKind,
   matchesSearch,
   matchesSector,
   MasterProfileEnrichRow,
   parseInvestorSectors,
+  relationKindFromHopChain,
   toConnectorSummary,
   toInvestorSummary,
 } from './warm-intros-v2-enrich.util';
@@ -38,6 +44,15 @@ import { computeWarmPathProximity, WARM_INTROS_V2_MIN_SCORE } from './warm-intro
 const FEEDBACK_NOTE_MAX = 600;
 const FEEDBACK_SUMMARY_RECENT_CAP = 5;
 const PATH_RELATION_KINDS = new Set(['pl_direct', 'founder_bridge', 'coinvestor_bridge']);
+
+/** Comma-separated query param → trimmed, non-empty values. */
+function parseCommaList(raw: string | undefined | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+}
 
 type WarmPathRow = {
   uid: string;
@@ -254,7 +269,7 @@ export class WarmIntrosV2Service {
 
   async listPaths(query: ListWarmPathsV2QueryDto) {
     const targetSet = query.targetSet?.trim() || null;
-    const connectorProfileUid = query.connectorProfileUid?.trim() || null;
+    const connectorProfileUids = parseCommaList(query.connectorProfileUid);
     const minScoreRaw = query.minScore?.trim();
     const minScore = minScoreRaw !== undefined && minScoreRaw !== '' ? Number(minScoreRaw) : WARM_INTROS_V2_MIN_SCORE;
     if (!Number.isFinite(minScore)) {
@@ -270,34 +285,48 @@ export class WarmIntrosV2Service {
     const limit = Math.min(Math.max(parseInt(query.limit ?? '50', 10) || 50, 1), 200);
     const offset = Math.max(parseInt(query.offset ?? '0', 10) || 0, 0);
     const search = (query.search ?? query.q)?.trim() || null;
-    const sector = query.sector?.trim() || null;
-    const relationKindRaw = query.relationKind?.trim() || null;
-    if (relationKindRaw && !PATH_RELATION_KINDS.has(relationKindRaw)) {
-      throw new BadRequestException(
-        `relationKind must be one of: ${[...PATH_RELATION_KINDS].join(', ')}`
-      );
+    const sectors = parseCommaList(query.sector);
+    const relationKinds = parseCommaList(query.relationKind);
+    for (const kind of relationKinds) {
+      if (!PATH_RELATION_KINDS.has(kind)) {
+        throw new BadRequestException(`relationKind must be one of: ${[...PATH_RELATION_KINDS].join(', ')}`);
+      }
     }
+    const bridgeProfileUids = parseCommaList(query.bridgeProfileUid);
     const directOnly = query.directOnly?.trim().toLowerCase() === 'true';
+    // directOnly is a shorthand for relationKind=pl_direct — folded in so callers don't
+    // have to pick one spelling for the same filter.
+    const effectiveRelationKinds = directOnly && relationKinds.length === 0 ? ['pl_direct'] : relationKinds;
     const plBacker = query.plBacker?.trim().toLowerCase() === 'true';
-    const needsPostFilter = Boolean(search || sector || plBacker);
+    const needsPostFilter = Boolean(
+      search ||
+        sectors.length ||
+        plBacker ||
+        bridgeProfileUids.length ||
+        effectiveRelationKinds.length > 1 ||
+        connectorProfileUids.length > 1
+    );
     // "All" returns one path per (investor, list); collapse to one row per investor.
     const collapseByInvestor = !targetSet;
     const loadThenPaginate = needsPostFilter || collapseByInvestor;
 
     const where: Prisma.WarmPathV2WhereInput = { rank, score: { gte: minScore } };
     if (targetSet) where.targetSet = targetSet;
-    if (directOnly) where.hopCount = 1;
-    if (relationKindRaw) {
-      where.hopChain = { path: ['relationKind'], equals: relationKindRaw };
+    // A single value stays an indexed/JSON-path where-clause; 2+ values (or a
+    // bridge-person filter, which has no queryable column at all) fall through to
+    // the post-filter below over the full candidate set.
+    if (effectiveRelationKinds.length === 1) {
+      where.hopChain = { path: ['relationKind'], equals: effectiveRelationKinds[0] };
     }
-    if (connectorProfileUid) {
+    if (connectorProfileUids.length === 1) {
       where.OR = [
-        { bestConnectorProfileUid: connectorProfileUid },
-        { alternateConnectorProfileUids: { array_contains: connectorProfileUid } },
+        { bestConnectorProfileUid: connectorProfileUids[0] },
+        { alternateConnectorProfileUids: { array_contains: connectorProfileUids[0] } },
       ];
     }
 
-    // Search/sector/plBacker/All collapse need full candidate set then slice (v2 scale ~1–2k).
+    // Search/sector/plBacker/bridge/multi-value path-via/All collapse need full candidate
+    // set then slice (v2 scale ~1–2k).
     const paths = (await this.prisma.warmPathV2.findMany({
       where,
       ...(loadThenPaginate ? {} : { take: limit, skip: offset }),
@@ -313,11 +342,21 @@ export class WarmIntrosV2Service {
     if (search) {
       enriched = enriched.filter((row) => matchesSearch(row.investor, search));
     }
-    if (sector) {
-      enriched = enriched.filter((row) => matchesSector(row.investor, sector));
+    if (sectors.length) {
+      enriched = enriched.filter((row) => sectors.some((sec) => matchesSector(row.investor, sec)));
     }
     if (plBacker) {
       enriched = enriched.filter((row) => matchesPlBacker(row.investor));
+    }
+    // Only post-filter what the where-clause above didn't already narrow.
+    if (effectiveRelationKinds.length > 1) {
+      enriched = enriched.filter((row) => matchesRelationKind(row.hopChain, effectiveRelationKinds));
+    }
+    if (connectorProfileUids.length > 1) {
+      enriched = enriched.filter((row) => matchesConnectorUid(row, connectorProfileUids));
+    }
+    if (bridgeProfileUids.length) {
+      enriched = enriched.filter((row) => matchesBridgeUid(row.hopChain, bridgeProfileUids));
     }
     if (collapseByInvestor) {
       enriched = collapsePathsByInvestor(enriched);
@@ -578,14 +617,26 @@ export class WarmIntrosV2Service {
       select: {
         targetProfileUid: true,
         bestConnectorProfileUid: true,
+        hopChain: true,
       },
-    })) as Array<{ targetProfileUid: string; bestConnectorProfileUid: string | null }>;
+    })) as Array<{ targetProfileUid: string; bestConnectorProfileUid: string | null; hopChain: unknown }>;
 
     const connectorCounts = new Map<string, number>();
+    // Path-shape counts: every path always carries a relationKind (pl_direct included, not
+    // just the bridge kinds), so this is a straight tally, not a bridge-only special case.
+    const kindCounts = new Map<string, number>();
+    // Bridge-person counts: the middle hop of a founder/coinvestor bridge chain.
+    const bridgeCounts = new Map<string, number>();
+
     for (const p of paths) {
       const cid = p.bestConnectorProfileUid;
-      if (!cid) continue;
-      connectorCounts.set(cid, (connectorCounts.get(cid) ?? 0) + 1);
+      if (cid) connectorCounts.set(cid, (connectorCounts.get(cid) ?? 0) + 1);
+
+      const relationKind = relationKindFromHopChain(p.hopChain);
+      kindCounts.set(relationKind, (kindCounts.get(relationKind) ?? 0) + 1);
+
+      const bridgeUid = bridgeProfileUidFromHopChain(p.hopChain);
+      if (bridgeUid) bridgeCounts.set(bridgeUid, (bridgeCounts.get(bridgeUid) ?? 0) + 1);
     }
 
     const plConnectors = await this.prisma.masterProfile.findMany({
@@ -599,6 +650,20 @@ export class WarmIntrosV2Service {
         profileUid: c.uid,
         name: c.canonicalName || c.uid,
         pathCount: connectorCounts.get(c.uid) ?? 0,
+      }))
+      .sort((a, b) => b.pathCount - a.pathCount || a.name.localeCompare(b.name));
+
+    const kinds = [...kindCounts.entries()]
+      .filter(([kind]) => PATH_RELATION_KINDS.has(kind))
+      .map(([value, count]) => ({ value: value as 'pl_direct' | 'founder_bridge' | 'coinvestor_bridge', count }));
+
+    const bridgeUids = [...bridgeCounts.keys()];
+    const bridgeProfiles = await this.loadProfilesByUids(bridgeUids);
+    const bridges = bridgeUids
+      .map((uid) => ({
+        profileUid: uid,
+        name: bridgeProfiles.get(uid)?.canonicalName || uid,
+        pathCount: bridgeCounts.get(uid) ?? 0,
       }))
       .sort((a, b) => b.pathCount - a.pathCount || a.name.localeCompare(b.name));
 
@@ -622,7 +687,7 @@ export class WarmIntrosV2Service {
 
     const sectors = [...sectorCounts.values()].sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
 
-    return { connectors, sectors };
+    return { connectors, sectors, kinds, bridges };
   }
 
   async listEdges(query: ListConnectionEdgesQueryDto) {
@@ -896,6 +961,7 @@ export class WarmIntrosV2Service {
         memberUid: true,
         listMemberships: true,
         plBacking: true,
+        coInvestments: true,
       },
     });
 


### PR DESCRIPTION
## Summary
- `listPaths` now accepts comma-separated `relationKind`/`connectorProfileUid`/`sector`/`bridgeProfileUid` values, OR-matched — a single-value Prisma where-clause fast path when exactly one value is given, falling back to the existing full-candidate post-filter (already used for `search`/`sector`/`plBacker`) for 2+ values or any bridge filter.
- `listFacets` gains `kinds` (path-shape counts) and `bridges` (founder/co-investor bridge-person counts), reusing new `relationKindFromHopChain`/`bridgeProfileUidFromHopChain` helpers shared with `listPaths`.
- `listFacets` gains `plBackerCount` — count of investors with `MasterProfile.plBacking` set, within the current target set.
- `EnrichedInvestorSummary` gains `coInvestmentsCount` (derived from `MasterProfile.coInvestments`), so the frontend can show a row-level PL-backing fact-line without an extra profile fetch. `plBacking` itself was already returned but undeclared on the type.

Companion frontend PR: `pln-directory-portal-v2`, branch `feat/warm-intros-v2-prototype-parity` — ports the Warm Intros v2 prototype's filters/table/drawer/modal into production, which needs this backend support (grouped multi-select "Path via" filter with honest per-option counts and real OR-matching, "Backed PL/FIL (N)" filter button).

## Test plan
- [x] `npx jest apps/web-api/src/warm-intros-v2` — 59/59 passing
- [ ] Manual verification against a deployed environment (not done in this session — no auth for the gated `/investors` UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)