### PR TITLE
LAB-2226 [AI Apps] Define and enforce CPU/memory limits for build and runtime

### DIFF
--- a/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps-starter-kit.service.ts
@@ -307,6 +307,34 @@ not the scaffold's shape or language.
 5. **Verify before deploying:** \`cd app && npm install && npm start\` (or the app's
    equivalent), then confirm \`GET /health\` is 200 and \`GET /\` renders.
 
+## Resource limits (design within budget)
+Every deployed app runs under a fixed CPU/memory envelope, and every image
+build runs under its own — these are a fixed platform default, not something
+you request. Design and build with them in mind so a deploy doesn't fail:
+
+- **Runtime** (the running app container): **384Mi memory limit**, 300m CPU
+  limit.
+- **Build** (the Docker image build): **2Gi memory limit**, 1 CPU limit.
+
+CPU limits only throttle — the app/build just runs slower under load.
+**Memory limits are hard**: exceeding one gets the process OOM-killed (the
+running app crash-loops; the build fails). Design choices that fit
+comfortably within this budget:
+- Avoid large in-memory caches or datasets — read from disk/network on
+  demand, or bound any cache to a small max size (LRU).
+- Prefer streaming responses over buffering entire payloads in memory.
+- Don't spawn extra worker threads/processes for background work — a single
+  event loop or a small pool is plenty at this scale.
+- Avoid heavy in-process ML/image/video processing — call an external API
+  instead of bundling a large model or native library.
+- Keep the build lean: trim \`devDependencies\` that end up in the Docker
+  build context, disable production source maps, and don't bundle large
+  static datasets into the image.
+
+If a deploy fails with \`notes\` mentioning "OOM-killed" or "exceeded its
+memory limit", that's this budget — see the deploy skill's step 7 for what
+to do next.
+
 ## Apps that need secrets (API keys, tokens, …)
 The member is usually **not a developer** — they will never say "environment
 variable" or "secret". It is YOUR job to recognize when the app needs one and to
@@ -693,6 +721,11 @@ may have no logs left.
 2. **App is deployed but broken** (blank page, 5xx, feature not working) →
    fetch **runtime** logs for the last 30–60 min, reproduce the issue (reload
    the app), then fetch again and diff for new errors/stack traces.
+3. **\`OOMKilled\` or exit code 137 in either log stream** means the build or
+   the running app exceeded its memory limit (see "Resource limits" in
+   \`AGENTS.md\`) — this isn't a code bug to trace, it's a memory-footprint
+   problem. Reduce memory usage (fewer parallel build workers, disable
+   source maps, avoid large in-memory caches/datasets) and redeploy.
 3. Summarize what you found for the member in plain words ("the build failed
    because a package is missing"), fix it, and redeploy. Don't dump raw logs on
    a non-technical member unless they ask.
@@ -1046,6 +1079,15 @@ connection string into the LabOS secrets page, same as an API key.
    (never the URL) — and when \`notes\` alone doesn't explain the failure, fetch
    the **build logs** via the app-logs skill (\`.claude/skills/app-logs/SKILL.md\`)
    to find the real error before retrying.
+
+   **If \`notes\` mentions "OOM-killed" or "exceeded its memory limit"**, the
+   deploy hit the platform's fixed resource budget (see "Resource limits" in
+   \`AGENTS.md\`) — a build that ran out of memory during \`npm install\`/bundling,
+   or a running app that leaked/allocated past its runtime limit. Don't just
+   retry: reduce the memory footprint first (fewer parallel build workers,
+   disable source maps, avoid bundling large datasets, drop large in-memory
+   caches at runtime) and redeploy. Only ask PL Infra for a higher limit if
+   the app has a genuine, explainable need that can't be designed around.
 
    **After the FIRST successful deploy**, offer the optional one-pager PRD —
    see "Offer the one-pager PRD" in the app-metadata skill. If the member wants

--- a/apps/web-api/src/ai-apps/ai-apps.constants.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.constants.ts
@@ -11,7 +11,7 @@
  */
 
 /** Starter kit version shown in the README, ZIP filename, and LabOS UI. Bump when the kit contents or flow change. */
-export const AI_APPS_STARTER_KIT_VERSION = '1.6';
+export const AI_APPS_STARTER_KIT_VERSION = '1.7';
 
 /** Header the AI agent sends with its short-lived deploy token. */
 export const AI_APP_TOKEN_HEADER = 'x-app-token';
@@ -136,6 +136,15 @@ export type AiAppLogPhase = 'build' | 'runtime';
  */
 export const buildRunnerLogsUrl = (appId: string, phase: AiAppLogPhase): string =>
   `${AI_APPS_RUNNER_URL}/v1/apps/${encodeURIComponent(appId)}/${phase}/logs`;
+
+/**
+ * Runner endpoint serving a live (no history) CPU/memory snapshot for an
+ * app's pod alongside the configured resource limits (`GET
+ * /v1/apps/<appId>/metrics`). Admin-only on our side — see
+ * `AiAppsService.getMetrics`.
+ */
+export const buildRunnerMetricsUrl = (appId: string): string =>
+  `${AI_APPS_RUNNER_URL}/v1/apps/${encodeURIComponent(appId)}/metrics`;
 
 /**
  * `order=desc` member log reads. The runner (and CloudWatch behind it) pages

--- a/apps/web-api/src/ai-apps/ai-apps.controller.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.controller.ts
@@ -360,6 +360,20 @@ export class AiAppsController {
   }
 
   /**
+   * Live CPU/memory snapshot (no history) for one app vs its configured
+   * resource limits — capacity-planning visibility for PL Infra, restricted
+   * to directory admins (checked in the service).
+   */
+  @NoCache()
+  @Get(':uid/metrics')
+  @UseGuards(UserTokenCheckGuard, RbacGuard)
+  @RequirePermissions(READ)
+  async getMetrics(@Param('uid') uid: string, @Req() req: any) {
+    const memberUid = await this.resolveMemberUid(req);
+    return this.aiAppsService.getMetrics(memberUid, uid);
+  }
+
+  /**
    * Delete an app: tears it down on the sandbox runner, marks it `DELETED`, and
    * records the delete events. Requires `ai_apps.write`.
    */

--- a/apps/web-api/src/ai-apps/ai-apps.service.ts
+++ b/apps/web-api/src/ai-apps/ai-apps.service.ts
@@ -50,6 +50,7 @@ import {
   buildPrdS3Key,
   buildRunnerDeploymentsUrl,
   buildRunnerLogsUrl,
+  buildRunnerMetricsUrl,
   buildRunnerSecretsUrl,
 } from './ai-apps.constants';
 
@@ -729,6 +730,35 @@ export class AiAppsService {
   }
 
   /**
+   * Admin-only live metrics snapshot (no history) for one app: current
+   * per-container CPU/memory from the runner (metrics-server) alongside the
+   * configured resource limits, so PL Infra can sanity-check the limits
+   * against real usage. Restricted to directory admins — unlike the log
+   * routes (creator-or-admin), this is capacity planning, not member-facing
+   * debugging.
+   */
+  async getMetrics(requesterUid: string, appUid: string): Promise<unknown> {
+    const app = await this.prisma.aiApp.findUnique({ where: { uid: appUid } });
+    if (!app) {
+      throw new NotFoundException(`AI App not found: ${appUid}`);
+    }
+    if (!(await this.isRequesterDirectoryAdmin(requesterUid))) {
+      throw new ForbiddenException('Only a directory admin can view app metrics');
+    }
+
+    try {
+      const response = await axios.get(buildRunnerMetricsUrl(app.appId), {
+        headers: { 'x-runner-token': AI_APPS_RUNNER_TOKEN },
+        timeout: 15000,
+      });
+      return response.data;
+    } catch (error) {
+      this.logRunnerError('metrics', app.appId, error);
+      throw new BadGatewayException('Failed to fetch metrics from the sandbox runner');
+    }
+  }
+
+  /**
    * Blocks a second concurrent deploy for the same app. A fresh (non-stuck)
    * DEPLOYING app is owned by an in-flight deploy, so any new deploy/registration
    * for it is rejected until that one settles (success or failure). A STUCK
@@ -1219,8 +1249,17 @@ export class AiAppsService {
         throw error;
       }
       this.logRunnerError('deploy', app.appId, error);
+      // Prefer the runner's own classified message (e.g. container_oom_killed's
+      // actionable text) verbatim over the full JSON body, so `notes` reads as
+      // a clear error instead of an escaped JSON blob.
+      const runnerErrorText =
+        axios.isAxiosError(error) && typeof error.response?.data?.error === 'string'
+          ? error.response.data.error
+          : undefined;
       const message = axios.isAxiosError(error)
-        ? `Runner error: ${error.response?.status ?? ''} ${JSON.stringify(error.response?.data ?? error.message)}`
+        ? `Runner error: ${error.response?.status ?? ''} ${
+            runnerErrorText ?? JSON.stringify(error.response?.data ?? error.message)
+          }`
         : `Deploy failed: ${(error as Error).message}`;
 
       // A gateway timeout (Cloudflare 504/524, etc.) or no response doesn't mean the
@@ -1329,7 +1368,13 @@ export class AiAppsService {
           return undefined;
         }
         const status = axios.isAxiosError(error) ? error.response?.status : undefined;
-        throw new Error(`runner deployments call failed (status=${status ?? 'n/a'})`);
+        // Prefer the runner's classified message (e.g. container_oom_killed's
+        // actionable text) over a bare status code, same as the build-phase path.
+        const runnerMessage =
+          axios.isAxiosError(error) && typeof error.response?.data?.message === 'string'
+            ? error.response.data.message
+            : undefined;
+        throw new Error(runnerMessage ?? `runner deployments call failed (status=${status ?? 'n/a'})`);
       }
     }
   }

--- a/docs/AI_APPS.md
+++ b/docs/AI_APPS.md
@@ -318,6 +318,70 @@ The starter kit (≥1.5) ships `buildLogsEndpoint` / `runtimeLogsEndpoint` as
 `{appUid}` templates in `pln-app.config.json` plus the `app-logs` skill; the
 deploy skill points at it from its `ERROR`-status and timeout paths.
 
+## Resource limits (build & runtime)
+
+The `deployment-orchestrator` repo sets a fixed CPU/memory envelope on every
+build and every deployed app — the caller (this backend, the agent, the
+member) never chooses it. Sized from live prod usage across the sandbox
+fleet (21 running app pods, 2026-08-06): median ~87Mi memory / 1m CPU
+(near-idle), max observed 310Mi / 54m. Nodes are EC2 (`m6i.large`, not
+Fargate) with `cluster-autoscaler` active, so **requests drive AWS cost**
+(scheduling/scale-up) and are kept low, while **limits** are a free-standing
+safety ceiling sized above the real max with margin.
+
+**Runtime, per app pod** (`charts/app` in the orchestrator repo):
+
+| Container | CPU request | CPU limit | Mem request | Mem limit |
+|---|---|---|---|---|
+| `app` (member's code) | 30m | 300m | 64Mi | 384Mi |
+| `auth-check` (sidecar) | 10m | 100m | 32Mi | 96Mi |
+| `auth-proxy` (sidecar) | 5m | 50m | 16Mi | 32Mi |
+
+**Build, per Kaniko Job** (estimated — no measured data survives a completed
+Job):
+
+| Container | CPU request | CPU limit | Mem request | Mem limit |
+|---|---|---|---|---|
+| `prepare` | 25m | 150m | 32Mi | 128Mi |
+| `kaniko` | 250m | 1000m | 512Mi | 2Gi |
+
+**CPU limits throttle** (cgroups CFS throttling — the process just runs
+slower). **Memory limits are hard**: exceeding one OOM-kills the container.
+Two error codes make that failure mode explicit instead of a generic
+timeout/crash message, both originating in the orchestrator and surfaced
+verbatim into `AiApp.notes` (see `proxyDeploy`'s error handling in
+`ai-apps.service.ts`, which prefers the runner's classified `message`/`error`
+field over the raw JSON body):
+
+- **Runtime**: `classifyKubernetesDiagnostics` (`src/k8s-diagnostics.ts`)
+  returns `container_oom_killed` when a container's `terminated.reason` is
+  `OOMKilled`, ahead of the generic `container_crash_loop` classification.
+- **Build**: `buildAndPushImage` (`src/sandbox.ts`) inspects the failed
+  build Job's pod for an `OOMKilled` container status and throws a message
+  naming the container + its configured memory limit, ahead of the generic
+  build-log error.
+
+The starter kit (≥1.7) documents this budget in `AGENTS.md`/`CLAUDE.md`
+("Resource limits" section — design guidance: avoid large in-memory
+caches/datasets, stream over buffer, avoid extra worker
+threads/processes, avoid heavy in-process ML/image/video work, keep the
+build lean) and teaches the deploy/app-logs skills to recognize
+`OOMKilled`/exceeded-limit messages and reduce memory footprint instead of
+blindly retrying.
+
+**Live metrics (no history)**: `GET /v1/ai-apps/:uid/metrics` — admin-only
+(`isRequesterDirectoryAdmin`, capacity planning rather than member-facing
+debugging), proxies the orchestrator's `GET /v1/apps/:appId/metrics`
+(`kubectl top pod --containers` via metrics-server) with the server-side
+runner token. Returns current per-container CPU/memory alongside the
+configured limits — a live snapshot only, no polling or storage, so the
+limits above can be sanity-checked against real apps over time.
+
+```bash
+curl -sS "https://api.plnetwork.io/v1/ai-apps/<uid>/metrics" \
+  -H "Authorization: Bearer $ADMIN_JWT"
+```
+
 ## Member context (signed-in user → deployed app)
 
 Deployed apps can personalize for the member using them (greet by name, tag


### PR DESCRIPTION
## Description

Defined and enforced CPU/memory limits for AI Apps builds and deployed apps, across both the backend and the sandbox orchestrator repos.

Every deployed app pod and every image build now runs under a fixed resource envelope instead of an unbounded one.

The numbers were sized from live production usage across the sandbox fleet, not guessed.

A build or a running app that exceeds its memory limit now gets OOM-killed and surfaces a clear, actionable error instead of a generic timeout or crash message.

CPU limits throttle rather than fail — only memory limits are hard.

The AI Apps starter kit (bumped to v1.7) now documents the resource budget in the agent instructions and teaches the deploy/logs skills to recognize and react to an OOM failure.

Added an admin-only live metrics endpoint so PL Infra can compare real app usage against the configured limits going forward.

## New endpoint: live app metrics (admin-only)

```bash
curl -sS "https://api.plnetwork.io/v1/ai-apps/<uid>/metrics" \
  -H "Authorization: Bearer $ADMIN_JWT"
```

## New endpoint: orchestrator live pod metrics (internal, service-to-service)

```bash
curl -sS "https://deployment-orchestrator-runner.dev.plnetwork.io/v1/apps/<appId>/metrics" \
  -H "x-runner-token: $RUNNER_TOKEN"
```


## Ticket

[LAB-2226](https://linear.app/plrs-labos/issue/LAB-2226/ai-apps-define-and-enforce-cpumemory-limits-for-build-and-runtime)